### PR TITLE
Issue #50 + IaC: Teilnehmer ohne E-Mail & CloudFront Invalidation

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,46 @@
+const tseslint = require("typescript-eslint");
+
+module.exports = [
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "zips/**",
+      // generated build artifacts (some older builds live here)
+      "src/dist/**",
+      "src/lambdas/shared/dynamoClient.js",
+      // plain JS utility scripts (not worth linting right now)
+      "scripts/**",
+      "**/*.d.ts",
+    ],
+  },
+  ...tseslint.config(
+    tseslint.configs.recommended,
+    {
+      languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: "commonjs",
+      },
+      rules: {
+        // Keep this lightweight; we already typecheck via `tsc --noEmit`.
+        "no-console": "off",
+        // Keep unused vars strict in TS sources.
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+        ],
+        "@typescript-eslint/no-require-imports": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "prefer-const": "off",
+      },
+    },
+  ),
+  // This file is a one-off script; keep lint strict elsewhere.
+  {
+    files: ["src/scripts/migrate_users.ts"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "off",
+    },
+  },
+];
+

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,11 +25,13 @@
         "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-jest": "^4.1.0",
         "esbuild": "^0.24.0",
+        "eslint": "^9.35.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.4",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.43.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -8831,6 +8833,235 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -10387,6 +10618,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -10501,6 +10739,301 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -10850,6 +11383,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -10861,6 +11404,23 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -11772,6 +12332,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -11987,6 +12554,189 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -11998,6 +12748,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/events": {
@@ -12061,10 +12857,24 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12096,6 +12906,19 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -12122,6 +12945,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -12324,6 +13168,19 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12463,6 +13320,16 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immer": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
@@ -12471,6 +13338,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -13610,10 +14504,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13636,6 +14551,16 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -13687,6 +14612,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -13743,6 +14682,13 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13849,9 +14795,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14020,6 +14966,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14081,6 +15045,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -14222,6 +15199,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -14816,6 +15803,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
@@ -14854,6 +15889,19 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -15033,6 +16081,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -15068,6 +16129,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "@typescript-eslint/parser": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/uglify-js": {
@@ -15164,6 +16249,26 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/url": {
@@ -15299,6 +16404,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "seed:build": "npm run build && node dist/seed/index.js",
     "seed:tenants": "ts-node src/scripts/seed_tenants.ts",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.890.0",
@@ -30,10 +31,12 @@
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",
     "esbuild": "^0.24.0",
+    "eslint": "^9.35.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.4",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "typescript-eslint": "^8.43.0",
     "typescript": "^5.9.2",
     "@aws-sdk/client-cognito-identity-provider": "^3.0.0",
     "@aws-sdk/client-ses": "^3.0.0"

--- a/backend/src/lambdas/createOverride/index.ts
+++ b/backend/src/lambdas/createOverride/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { PutItemCommand } from '@aws-sdk/client-dynamodb';
-import { getTenantContext, TenantContext } from '../shared/tenantContext';
+import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 
 const client = dynamoClient;

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -81,6 +81,41 @@ describe('createParticipants Lambda', () => {
     expect(cognitoMockSend).not.toHaveBeenCalled();
   });
 
+  test('creates a foreign-managed participant if email is empty (skips Cognito/SES)', async () => {
+    const event = baseEvent({
+      email: '',
+      nickname: 'noligin',
+      role: 'participant',
+    });
+    event.headers = { 'x-tenant-id': 'test-tenant' };
+
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.username).toBe('noligin');
+    expect(body.emailSent).toBe(false);
+    expect(body.warning).toMatch(/Cognito\/SES übersprungen/i);
+
+    // Cognito + SES should not be called
+    expect(cognitoMockSend).not.toHaveBeenCalled();
+    expect(sesMockSend).not.toHaveBeenCalled();
+
+    // DynamoDB should be called to store membership
+    expect(dynamoMockSend).toHaveBeenCalledTimes(1);
+    expect(dynamoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: 'test-memberships-table',
+        Item: expect.objectContaining({
+          tenantId: { S: 'test-tenant' },
+          userId: { S: 'noligin' },
+          role: { S: 'participant' },
+        }),
+      })
+    );
+  });
+
   test('successfully creates a new user', async () => {
     cognitoMockSend
       .mockResolvedValueOnce({}) // AdminCreateUserCommand

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -39,8 +39,54 @@ export const handler = async (event: any) => {
   const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
   const { email, nickname, role } = body ?? {};
 
-  if (!email || !nickname || !role) {
+  const emailNormalized = typeof email === "string" ? email.trim() : "";
+  const hasEmail = emailNormalized.length > 0;
+
+  if (!nickname || !role) {
     return { statusCode: 400, body: JSON.stringify({ error: "Missing required fields" }) };
+  }
+
+  // Email optional: if missing/empty, skip Cognito and SES and only write membership to DynamoDB.
+  if (!hasEmail) {
+    const tenantId = getTenantId(event);
+    try {
+      if (process.env.MEMBERSHIPS_TABLE) {
+        await dynamodb.send(
+          new PutItemCommand({
+            TableName: process.env.MEMBERSHIPS_TABLE,
+            Item: {
+              tenantId: { S: tenantId },
+              userId: { S: nickname },
+              role: { S: role },
+            },
+          }),
+        );
+        console.log(
+          `Membership saved in DynamoDB (no email): user=${nickname}, tenant=${tenantId}, role=${role}`,
+        );
+      } else {
+        console.warn(
+          "MEMBERSHIPS_TABLE environment variable not set, skipping DynamoDB write.",
+        );
+      }
+    } catch (err: any) {
+      console.error("Failed to save membership in DynamoDB:", err);
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: "Failed to create participant" }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        success: true,
+        username: nickname,
+        emailSent: false,
+        warning:
+          "E-Mail fehlt – Cognito/SES übersprungen. Teilnehmer wurde nur in DynamoDB angelegt.",
+      }),
+    };
   }
 
   // raw temporary password (safe characters)
@@ -58,7 +104,7 @@ export const handler = async (event: any) => {
       Username: nickname, // Nickname muss einzigartig sein
       TemporaryPassword: rawPassword ,
       UserAttributes: [
-        { Name: "email", Value: email },
+        { Name: "email", Value: emailNormalized },
         { Name: "email_verified", Value: "true" },
         { Name: "nickname", Value: username },
         { Name: "custom:role", Value: role }
@@ -122,7 +168,7 @@ export const handler = async (event: any) => {
   // Build link (only nickname in the URL)
   const baseUrlEnv = process.env.BASE_URL || "";
   const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
-  const link = `${baseUrl}/invite?nickname=${encodeURIComponent(username)}&email=${encodeURIComponent(email)}`;
+  const link = `${baseUrl}/invite?nickname=${encodeURIComponent(username)}&email=${encodeURIComponent(emailNormalized)}`;
 
   // Send invitation email (temp password shown in email body)
   const emailHtml = `
@@ -143,14 +189,14 @@ export const handler = async (event: any) => {
     console.log(`📧 process.env.SES_SOURCE_EMAIL = "${process.env.SES_SOURCE_EMAIL}"`);
     await ses.send(new SendEmailCommand({
       Source: sesSourceEmail,
-      Destination: { ToAddresses: [email] },
+      Destination: { ToAddresses: [emailNormalized] },
       Message: {
         Subject: { Data: "YogaSwap Einladung" },
         Body: { Html: { Data: emailHtml } }
       }
     }));
     emailSent = true;
-    console.log("SES email sent successfully to", email);
+    console.log("SES email sent successfully to", emailNormalized);
   } catch (err: any) {
     console.warn("SES send warning:", err?.message || err);
     // do not fail user creation if SES can't send (depending on your policy)

--- a/backend/src/lambdas/createSwap/index.ts
+++ b/backend/src/lambdas/createSwap/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { PutItemCommand } from '@aws-sdk/client-dynamodb';
-import { getTenantContext, TenantContext } from '../shared/tenantContext';
+import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 
 const client = dynamoClient;

--- a/backend/src/lambdas/deleteOverride/index.ts
+++ b/backend/src/lambdas/deleteOverride/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { DeleteItemCommand } from '@aws-sdk/client-dynamodb';
-import { getTenantContext, TenantContext } from '../shared/tenantContext';
+import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 
 const client = dynamoClient;

--- a/backend/src/lambdas/deleteSwap/index.ts
+++ b/backend/src/lambdas/deleteSwap/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { DeleteItemCommand } from "@aws-sdk/client-dynamodb";
-import { getTenantContext, TenantContext } from "../shared/tenantContext";
+import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const client = dynamoClient;

--- a/backend/src/lambdas/getOverrides/index.ts
+++ b/backend/src/lambdas/getOverrides/index.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import type { CourseDateOverride } from "@yogaswap/shared";
-import { getTenantContext, TenantContext } from "../shared/tenantContext";
+import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const client = dynamoClient;

--- a/backend/src/lambdas/processPromotions/index.ts
+++ b/backend/src/lambdas/processPromotions/index.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { QueryCommand, UpdateItemCommand, PutItemCommand, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 import { Swap, CourseDateOverride, Course } from "@yogaswap/shared";
-import { getTenantContext, TenantContext } from "../shared/tenantContext";
+import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const client = dynamoClient;

--- a/backend/src/lambdas/updateOverride/index.ts
+++ b/backend/src/lambdas/updateOverride/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { UpdateItemCommand } from '@aws-sdk/client-dynamodb';
-import { getTenantContext, TenantContext } from '../shared/tenantContext';
+import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 
 const client = dynamoClient;

--- a/backend/src/lambdas/updateSwap/index.ts
+++ b/backend/src/lambdas/updateSwap/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { UpdateItemCommand } from "@aws-sdk/client-dynamodb";
-import { getTenantContext, TenantContext } from "../shared/tenantContext";
+import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const client = dynamoClient;
@@ -27,7 +27,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   let body;
   try {
     body = JSON.parse(event.body);
-  } catch (err) {
+  } catch {
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "Invalid JSON body" }),

--- a/backend/src/scripts/migrate_users.ts
+++ b/backend/src/scripts/migrate_users.ts
@@ -32,7 +32,7 @@ async function run() {
       if (groupResponse.Groups && groupResponse.Groups.length > 0) {
         role = groupResponse.Groups[0].GroupName || "participant";
       }
-    } catch (e) {
+    } catch (_e) {
       console.warn(`Could not fetch groups for ${username}, defaulting to participant`);
     }
 

--- a/backend/src/seed/index.ts
+++ b/backend/src/seed/index.ts
@@ -87,7 +87,7 @@ async function tableExists(tableName: string): Promise<boolean> {
 }
 
 // Liste alle Tabellen auf, die zum Projekt passen könnten
-async function listSimilarTables(prefix: string): Promise<string[]> {
+async function listSimilarTables(_prefix: string): Promise<string[]> {
   try {
     const result = await client.send(new ListTablesCommand({}));
     const allTables = result.TableNames || [];
@@ -222,23 +222,6 @@ async function checkTablesExist(): Promise<void> {
     
     console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     process.exit(1);
-  }
-}
-
-async function seedTable(tableName: string, items: any[]) {
-  for (const item of items) {
-    await client.send(
-      new PutItemCommand({
-        TableName: tableName,
-        Item: Object.fromEntries(
-          Object.entries(item).map(([k, v]) => [
-            k,
-            { S: typeof v === "string" ? v : JSON.stringify(v) },
-          ])
-        ),
-      })
-    );
-    console.log(`✅ Inserted into ${tableName}:`, item);
   }
 }
 

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -12,6 +12,18 @@ variable "api_gateway_domain_name" {
   type = string
 }
 
+variable "aliases" {
+  type        = list(string)
+  description = "Alternate domain names (CNAMEs) for the CloudFront distribution (e.g. app.yogaswap.de)"
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN (must be in us-east-1) to use for aliases. Leave empty to use CloudFront default cert."
+  default     = ""
+}
+
 resource "aws_cloudfront_origin_access_control" "spa" {
   name                              = "${var.bucket_name}-oac"
   description                       = "OAC for S3 static site"
@@ -24,6 +36,8 @@ resource "aws_cloudfront_distribution" "spa" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
+
+  aliases = var.aliases
 
   # Origin API Gateway
   origin {
@@ -168,8 +182,21 @@ resource "aws_cloudfront_distribution" "spa" {
     error_caching_min_ttl = 0
   }
 
-  viewer_certificate {
-    cloudfront_default_certificate = true
+  dynamic "viewer_certificate" {
+    for_each = var.acm_certificate_arn != "" ? [1] : []
+    content {
+      acm_certificate_arn            = var.acm_certificate_arn
+      ssl_support_method             = "sni-only"
+      minimum_protocol_version       = "TLSv1.2_2021"
+      cloudfront_default_certificate = false
+    }
+  }
+
+  dynamic "viewer_certificate" {
+    for_each = var.acm_certificate_arn == "" ? [1] : []
+    content {
+      cloudfront_default_certificate = true
+    }
   }
 
   restrictions {

--- a/projects/yogaswap/cognito.tf
+++ b/projects/yogaswap/cognito.tf
@@ -23,10 +23,10 @@ resource "aws_cognito_user_pool" "yogaswap" {
   }
 
   schema {
-    attribute_data_type      = "String"
-    mutable                  = true
-    name                     = "email"
-    required                 = true
+    attribute_data_type = "String"
+    mutable             = true
+    name                = "email"
+    required            = true
 
     string_attribute_constraints {
       min_length = 1
@@ -35,10 +35,10 @@ resource "aws_cognito_user_pool" "yogaswap" {
   }
 
   schema {
-    attribute_data_type      = "String"
-    mutable                  = true
-    name                     = "role"
-    required                 = false
+    attribute_data_type = "String"
+    mutable             = true
+    name                = "role"
+    required            = false
 
     string_attribute_constraints {
       min_length = 1
@@ -47,10 +47,10 @@ resource "aws_cognito_user_pool" "yogaswap" {
   }
 
   schema {
-    attribute_data_type      = "String"
-    mutable                  = true
-    name                     = "nickname"
-    required                 = true
+    attribute_data_type = "String"
+    mutable             = true
+    name                = "nickname"
+    required            = true
 
     string_attribute_constraints {
       min_length = 1
@@ -73,8 +73,8 @@ resource "aws_cognito_user_pool_client" "yogaswap_app" {
   generate_secret = false
 
   callback_urls = [
-    "https://${module.cloudfront_spa.distribution_url}", 
-    "http://localhost:5173"]
+    "https://${module.cloudfront_spa.distribution_url}",
+  "http://localhost:5173"]
 
   logout_urls = [
     "https://${module.cloudfront_spa.distribution_url}",
@@ -86,7 +86,7 @@ resource "aws_cognito_user_group" "admin" {
   name         = "admin"
   user_pool_id = aws_cognito_user_pool.yogaswap.id
   description  = "Administratoren"
-  precedence   = 0    # niedrigere Zahl = höhere Priorität falls mehrere Rollen relevant sind
+  precedence   = 0 # niedrigere Zahl = höhere Priorität falls mehrere Rollen relevant sind
   # optional: role_arn = aws_iam_role.some_role.arn
 }
 

--- a/projects/yogaswap/dynamodb.tf
+++ b/projects/yogaswap/dynamodb.tf
@@ -1,10 +1,10 @@
 # Tenant-scoped: PK = tenantId, SK = user_swapId (user#swapId)
 # GSI_From/GSI_To: PK = tenantId_user, SK = fromDate_... / toDate_...
 module "swaps_table" {
-  source     = "../modules/dynamodb"
-  name       = "${var.project}-swaps-table"
-  hash_key   = "tenantId"
-  range_key  = "user_swapId"
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-swaps-table"
+  hash_key  = "tenantId"
+  range_key = "user_swapId"
 
   attributes = [
     { name = "tenantId", type = "S" },
@@ -32,10 +32,10 @@ module "swaps_table" {
 
 # Tenant-scoped: PK = tenantId, SK = courseId_date (courseId_date)
 module "course_overrides_table" {
-  source     = "../modules/dynamodb"
-  name       = "${var.project}-courseOverrides-table"
-  hash_key   = "tenantId"
-  range_key  = "courseId_date"
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-courseOverrides-table"
+  hash_key  = "tenantId"
+  range_key = "courseId_date"
   attributes = [
     { name = "tenantId", type = "S" },
     { name = "courseId_date", type = "S" }
@@ -44,10 +44,10 @@ module "course_overrides_table" {
 
 # Tenant-scoped: PK = tenantId, SK = courseId (string, z. B. "1", "2")
 module "courses_table" {
-  source     = "../modules/dynamodb"
-  name       = "${var.project}-courses-table"
-  hash_key   = "tenantId"
-  range_key  = "courseId"
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-courses-table"
+  hash_key  = "tenantId"
+  range_key = "courseId"
   attributes = [
     { name = "tenantId", type = "S" },
     { name = "courseId", type = "S" }
@@ -61,9 +61,9 @@ module "courses_table" {
 # Tenants: PK = tenantId
 # Speichert z. B. Settings, Name, Impressum des Studios
 module "tenants_table" {
-  source     = "../modules/dynamodb"
-  name       = "${var.project}-tenants-table"
-  hash_key   = "tenantId"
+  source   = "../modules/dynamodb"
+  name     = "${var.project}-tenants-table"
+  hash_key = "tenantId"
   attributes = [
     { name = "tenantId", type = "S" }
   ]
@@ -72,10 +72,10 @@ module "tenants_table" {
 # Memberships: PK = tenantId, SK = userId (Nickname)
 # Speichert die Rolle (admin, instructor, participant) des Users in diesem Tenant
 module "memberships_table" {
-  source     = "../modules/dynamodb"
-  name       = "${var.project}-memberships-table"
-  hash_key   = "tenantId"
-  range_key  = "userId"
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-memberships-table"
+  hash_key  = "tenantId"
+  range_key = "userId"
   attributes = [
     { name = "tenantId", type = "S" },
     { name = "userId", type = "S" }

--- a/projects/yogaswap/lambda.tf
+++ b/projects/yogaswap/lambda.tf
@@ -7,8 +7,8 @@ resource "aws_iam_role" "lambda_role" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
-      Action    = "sts:AssumeRole",
-      Effect    = "Allow",
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
       Principal = {
         Service = "lambda.amazonaws.com"
       }
@@ -56,13 +56,13 @@ resource "aws_iam_role_policy" "lambda_policy" {
 resource "aws_lambda_function" "lambda" {
   for_each = local.lambda_configs
 
-  function_name     = "${var.project}-${each.value.name}"
-  handler           = "index.handler"
-  runtime           = "nodejs18.x"
-  role              = aws_iam_role.lambda_role[each.key].arn
-  filename          = "${path.module}/../../backend/zips/${each.value.file_name}"
+  function_name = "${var.project}-${each.value.name}"
+  handler       = "index.handler"
+  runtime       = "nodejs18.x"
+  role          = aws_iam_role.lambda_role[each.key].arn
+  filename      = "${path.module}/../../backend/zips/${each.value.file_name}"
   # Kombiniere Source Code Hash mit Environment Variables Hash, damit Lambda bei Environment-Änderungen neu deployed wird
-  source_code_hash  = sha256(join(",", [
+  source_code_hash = sha256(join(",", [
     filebase64sha256("${path.module}/../../backend/zips/${each.value.file_name}"),
     jsonencode(merge(
       each.value.tables,

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -70,9 +70,9 @@ locals {
       s3_resources = []
     },
     "get_coursedateoverrides" = {
-      name             = var.lambdas["get_coursedateoverrides"].name
-      file_name        = var.lambdas["get_coursedateoverrides"].file_name
-      table_arns       = [module.course_overrides_table.table_arn]
+      name           = var.lambdas["get_coursedateoverrides"].name
+      file_name      = var.lambdas["get_coursedateoverrides"].file_name
+      table_arns     = [module.course_overrides_table.table_arn]
       dynamodb_actions = var.lambdas["get_coursedateoverrides"].dynamodb_actions
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -2,155 +2,155 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0" 
+      version = ">= 5.0.0"
     }
   }
   backend "local" {}
 }
 
-provider "aws" { 
-    region = var.region
+provider "aws" {
+  region = var.region
 }
 
 locals {
   lambda_configs = {
     "get_swaps" = {
-      name           = var.lambdas["get_swaps"].name
-      file_name      = var.lambdas["get_swaps"].file_name
-      table_arns     = [module.swaps_table.table_arn]
+      name             = var.lambdas["get_swaps"].name
+      file_name        = var.lambdas["get_swaps"].file_name
+      table_arns       = [module.swaps_table.table_arn]
       dynamodb_actions = var.lambdas["get_swaps"].dynamodb_actions
       tables = {
         "SWAPS_TABLE" = module.swaps_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "get_swaps_by_status" = {
-      name           = "get-swaps-by-status"
-      file_name      = "getSwapsByStatus.zip"
-      table_arns     = [module.swaps_table.table_arn]
+      name             = "get-swaps-by-status"
+      file_name        = "getSwapsByStatus.zip"
+      table_arns       = [module.swaps_table.table_arn]
       dynamodb_actions = ["dynamodb:Scan", "dynamodb:Query"]
       tables = {
         "SWAPS_TABLE" = module.swaps_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "create_swap" = {
-      name           = "create-swap"
-      file_name      = "createSwap.zip"
-      table_arns     = [module.swaps_table.table_arn]
+      name             = "create-swap"
+      file_name        = "createSwap.zip"
+      table_arns       = [module.swaps_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem"]
       tables = {
         "SWAPS_TABLE" = module.swaps_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "update_swap" = {
-      name           = "update-swap"
-      file_name      = "updateSwap.zip"
-      table_arns     = [module.swaps_table.table_arn]
+      name             = "update-swap"
+      file_name        = "updateSwap.zip"
+      table_arns       = [module.swaps_table.table_arn]
       dynamodb_actions = ["dynamodb:UpdateItem"]
       tables = {
         "SWAPS_TABLE" = module.swaps_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "delete_swap" = {
-      name           = "delete-swap"
-      file_name      = "deleteSwap.zip"
-      dynamodb_actions = ["dynamodb:DeleteItem"]      
-      table_arns     = [module.swaps_table.table_arn]
+      name             = "delete-swap"
+      file_name        = "deleteSwap.zip"
+      dynamodb_actions = ["dynamodb:DeleteItem"]
+      table_arns       = [module.swaps_table.table_arn]
       tables = {
         "SWAPS_TABLE" = module.swaps_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "get_coursedateoverrides" = {
-      name           = var.lambdas["get_coursedateoverrides"].name
-      file_name      = var.lambdas["get_coursedateoverrides"].file_name
-      table_arns     = [module.course_overrides_table.table_arn]
+      name             = var.lambdas["get_coursedateoverrides"].name
+      file_name        = var.lambdas["get_coursedateoverrides"].file_name
+      table_arns       = [module.course_overrides_table.table_arn]
       dynamodb_actions = var.lambdas["get_coursedateoverrides"].dynamodb_actions
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "create_override" = {
-      name           = "create-override"
-      file_name      = "createOverride.zip"
-      table_arns     = [module.course_overrides_table.table_arn]
+      name             = "create-override"
+      file_name        = "createOverride.zip"
+      table_arns       = [module.course_overrides_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem"]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "update_override" = {
-      name           = "update-override"
-      file_name      = "updateOverride.zip"
-      table_arns     = [module.course_overrides_table.table_arn]
+      name             = "update-override"
+      file_name        = "updateOverride.zip"
+      table_arns       = [module.course_overrides_table.table_arn]
       dynamodb_actions = ["dynamodb:UpdateItem"]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "delete_override" = {
-      name           = "delete-override"
-      file_name      = "deleteOverride.zip"
-      dynamodb_actions = ["dynamodb:DeleteItem"]      
-      table_arns     = [module.course_overrides_table.table_arn]
+      name             = "delete-override"
+      file_name        = "deleteOverride.zip"
+      dynamodb_actions = ["dynamodb:DeleteItem"]
+      table_arns       = [module.course_overrides_table.table_arn]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "process_promotions" = {
-      name           = "process-promotions"
-      file_name      = "processPromotions.zip"
-      table_arns     = [module.swaps_table.table_arn, module.course_overrides_table.table_arn, module.courses_table.table_arn]
+      name             = "process-promotions"
+      file_name        = "processPromotions.zip"
+      table_arns       = [module.swaps_table.table_arn, module.course_overrides_table.table_arn, module.courses_table.table_arn]
       dynamodb_actions = ["dynamodb:Scan", "dynamodb:Query", "dynamodb:UpdateItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
       tables = {
-        "SWAPS_TABLE" = module.swaps_table.table_name
+        "SWAPS_TABLE"     = module.swaps_table.table_name
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
-        "COURSES_TABLE" = module.courses_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "get_courses" = {
-      name           = "get-courses"
-      file_name      = "getCourses.zip"
-      table_arns     = [module.courses_table.table_arn]
+      name             = "get-courses"
+      file_name        = "getCourses.zip"
+      table_arns       = [module.courses_table.table_arn]
       dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem"]
       tables = {
         "COURSES_TABLE" = module.courses_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     },
     "create_participants" = {
-      name           = "create-participants"
-      file_name      = "createParticipants.zip"
-      table_arns     = [module.memberships_table.table_arn]
+      name             = "create-participants"
+      file_name        = "createParticipants.zip"
+      table_arns       = [module.memberships_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem"]
       tables = {
         "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
       additional_policies = [
         {
-          Effect   = "Allow"
-          Action   = [
+          Effect = "Allow"
+          Action = [
             "cognito-idp:AdminCreateUser",
             "cognito-idp:AdminAddUserToGroup",
             "cognito-idp:AdminSetUserPassword"
@@ -164,15 +164,15 @@ locals {
         }
       ]
       environment = {
-        USER_POOL_ID = aws_cognito_user_pool.yogaswap.id
-        BASE_URL     = module.cloudfront_spa.distribution_url
-        SES_SOURCE_EMAIL = var.ses_source_email  # E-Mail-Adresse für SES-Absender (muss verifiziert sein)
+        USER_POOL_ID     = aws_cognito_user_pool.yogaswap.id
+        BASE_URL         = module.cloudfront_spa.distribution_url
+        SES_SOURCE_EMAIL = var.ses_source_email # E-Mail-Adresse für SES-Absender (muss verifiziert sein)
       }
     },
     "get_tenant_context" = {
-      name           = "get-tenant-context"
-      file_name      = "getTenantContext.zip"
-      table_arns     = [
+      name      = "get-tenant-context"
+      file_name = "getTenantContext.zip"
+      table_arns = [
         module.tenants_table.table_arn,
         module.memberships_table.table_arn
       ]
@@ -181,28 +181,28 @@ locals {
         "TENANTS_TABLE"     = module.tenants_table.table_name
         "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
       }
-      s3_actions     = []
-      s3_resources   = []
+      s3_actions   = []
+      s3_resources = []
     }
   }
-   # Map für Lambda-ARNs
+  # Map für Lambda-ARNs
   lambda_arns = { for k, v in aws_lambda_function.lambda : k => v.arn }
 
   # API Gateway Routen
   api_routes = {
-    "GET /swaps" = "get_swaps"
-    "GET /swaps/status" = "get_swaps_by_status"
-    "GET /course-overrides" = "get_coursedateoverrides"
-    "POST /swaps" = "create_swap"
-    "PUT /swaps/{swapId}" = "update_swap"
-    "DELETE /swaps/{swapId}" = "delete_swap"
-    "POST /course-overrides" = "create_override"
-    "PUT /course-overrides/{courseId}/{date}" = "update_override"
+    "GET /swaps"                                 = "get_swaps"
+    "GET /swaps/status"                          = "get_swaps_by_status"
+    "GET /course-overrides"                      = "get_coursedateoverrides"
+    "POST /swaps"                                = "create_swap"
+    "PUT /swaps/{swapId}"                        = "update_swap"
+    "DELETE /swaps/{swapId}"                     = "delete_swap"
+    "POST /course-overrides"                     = "create_override"
+    "PUT /course-overrides/{courseId}/{date}"    = "update_override"
     "DELETE /course-overrides/{courseId}/{date}" = "delete_override"
-    "POST /process-promotions" = "process_promotions"
-    "GET /courses" = "get_courses"
-    "POST /participants" = "create_participants"
-    "GET /tenant-context" = "get_tenant_context"
+    "POST /process-promotions"                   = "process_promotions"
+    "GET /courses"                               = "get_courses"
+    "POST /participants"                         = "create_participants"
+    "GET /tenant-context"                        = "get_tenant_context"
   }
 
   build_files = fileset("../../app/build", "**")
@@ -211,18 +211,20 @@ locals {
 
 #--------------apigateway--------------------
 module "yogaswap_api" {
-  source       = "../modules/apigatewayv2"
-  name         = "${var.project}-api"
-  lambda_arns  = local.lambda_arns
-  routes       = local.api_routes
+  source      = "../modules/apigatewayv2"
+  name        = "${var.project}-api"
+  lambda_arns = local.lambda_arns
+  routes      = local.api_routes
 }
 #---------------cloudfront------------------
 
 module "cloudfront_spa" {
-  source      = "../modules/cloudfront"
-  bucket_name = module.spa_site.bucket_name
-  bucket_domain_name = module.spa_site.bucket_regional_domain
+  source                  = "../modules/cloudfront"
+  bucket_name             = module.spa_site.bucket_name
+  bucket_domain_name      = module.spa_site.bucket_regional_domain
   api_gateway_domain_name = replace(module.yogaswap_api.api_endpoint, "https://", "")
+  aliases                 = var.cloudfront_aliases
+  acm_certificate_arn     = var.cloudfront_acm_certificate_arn
 }
 
 resource "random_id" "invalidation" {

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -70,9 +70,9 @@ locals {
       s3_resources = []
     },
     "get_coursedateoverrides" = {
-      name           = var.lambdas["get_coursedateoverrides"].name
-      file_name      = var.lambdas["get_coursedateoverrides"].file_name
-      table_arns     = [module.course_overrides_table.table_arn]
+      name             = var.lambdas["get_coursedateoverrides"].name
+      file_name        = var.lambdas["get_coursedateoverrides"].file_name
+      table_arns       = [module.course_overrides_table.table_arn]
       dynamodb_actions = var.lambdas["get_coursedateoverrides"].dynamodb_actions
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
@@ -227,12 +227,20 @@ module "cloudfront_spa" {
   acm_certificate_arn     = var.cloudfront_acm_certificate_arn
 }
 
-resource "random_id" "invalidation" {
-  byte_length = 4
-  keepers = {
-    # Erzeuge neue ID bei jedem Plan/Apply, um Invalidierung zu triggern
-    always_run = timestamp()
+resource "null_resource" "cloudfront_invalidation" {
+  triggers = {
+    build_hash      = local.build_hash
+    distribution_id = module.cloudfront_spa.distribution_id
   }
+
+  provisioner "local-exec" {
+    command = "aws cloudfront create-invalidation --distribution-id ${self.triggers.distribution_id} --paths '/*'"
+  }
+
+  depends_on = [
+    aws_s3_object.spa_files,
+    null_resource.upload_frontend,
+  ]
 }
 
 output "api_url" {

--- a/projects/yogaswap/s3.tf
+++ b/projects/yogaswap/s3.tf
@@ -1,11 +1,11 @@
 
 module "spa_site" {
-  source      = "../modules/s3_static_site"
-  bucket_name = "${var.project}-site"
+  source                      = "../modules/s3_static_site"
+  bucket_name                 = "${var.project}-site"
   cloudfront_distribution_arn = module.cloudfront_spa.distribution_arn
-  index_file  = "index.html"
-  error_file  = "index.html"
-  enable_website_hosting = true
+  index_file                  = "index.html"
+  error_file                  = "index.html"
+  enable_website_hosting      = true
 }
 
 resource "null_resource" "upload_frontend" {
@@ -20,13 +20,13 @@ resource "null_resource" "upload_frontend" {
 
 # Kopieren der Inhalte für die webpage ins bucket
 resource "aws_s3_object" "spa_files" {
-  for_each = fileset("../../app/build", "**/*") 
+  for_each = fileset("../../app/build", "**/*")
 
   bucket = module.spa_site.bucket_name
-  key = each.value 
-    source = "../../app/build/${each.value}" 
-    etag         = filemd5("../../app/build/${each.value}")
-    content_type = lookup({
+  key    = each.value
+  source = "../../app/build/${each.value}"
+  etag   = filemd5("../../app/build/${each.value}")
+  content_type = lookup({
     html = "text/html",
     js   = "application/javascript",
     css  = "text/css",

--- a/projects/yogaswap/terraform.tfvars.example
+++ b/projects/yogaswap/terraform.tfvars.example
@@ -24,3 +24,12 @@ region = "eu-central-1"
 # Wichtig: Diese E-Mail-Adresse muss in AWS SES Console verifiziert werden!
 ses_source_email = "yogaswap@example.com"
 
+# Optional: Custom Domain für CloudFront (SPA)
+# Wenn du `app.yogaswap.de` über CloudFront nutzen willst, setze:
+# - cloudfront_aliases
+# - cloudfront_acm_certificate_arn (ACM Zertifikat in us-east-1!)
+#
+# Beispiel:
+# cloudfront_aliases = ["app.yogaswap.de"]
+# cloudfront_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+

--- a/projects/yogaswap/variables.tf
+++ b/projects/yogaswap/variables.tf
@@ -2,13 +2,13 @@
 variable "project" {
   description = "Projektname für Ressourcen-Namen"
   type        = string
-  default = "yogaswap-backend-demo"
+  default     = "yogaswap-backend-demo"
 }
 
 variable "region" {
   description = "AWS-Region"
   type        = string
-  default = "eu-central-1" 
+  default     = "eu-central-1"
 }
 
 variable "ses_source_email" {
@@ -17,29 +17,41 @@ variable "ses_source_email" {
   default     = "yogaswap@example.com"
 }
 
+variable "cloudfront_aliases" {
+  description = "CloudFront Alternate Domain Names (CNAMEs), z.B. [\"app.yogaswap.de\"]"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM Zertifikat-ARN (MUSS in us-east-1 liegen) für CloudFront. Leer lassen, um Default-Zertifikat zu nutzen."
+  type        = string
+  default     = ""
+}
+
 variable "lambdas" {
   description = "Map von Lambda-Funktionen und deren Eigenschaften"
   type = map(object({
-    name           = string
-    file_name       = string
-    table_arns     = list(string) # Liste von DynamoDB-Tabellen-ARNs
+    name             = string
+    file_name        = string
+    table_arns       = list(string) # Liste von DynamoDB-Tabellen-ARNs
     dynamodb_actions = list(string) # Aktionen, die die Lambda ausführen darf
-    s3_actions     = list(string)
+    s3_actions       = list(string)
   }))
   default = {
     "get_swaps" = {
-      name           = "get-swaps"
-      file_name         = "getSwaps.zip"
-      table_arns     = [] # Wird später gefüllt
+      name             = "get-swaps"
+      file_name        = "getSwaps.zip"
+      table_arns       = [] # Wird später gefüllt
       dynamodb_actions = ["dynamodb:GetItem", "dynamodb:Scan", "dynamodb:Query"]
-      s3_actions     = []
+      s3_actions       = []
     },
     "get_coursedateoverrides" = {
-      name           = "get-coursedateoverrides"
-      file_name         = "getOverrides.zip"
-      table_arns     = [] # Wird später gefüllt
+      name             = "get-coursedateoverrides"
+      file_name        = "getOverrides.zip"
+      table_arns       = [] # Wird später gefüllt
       dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem"]
-      s3_actions     = []
+      s3_actions       = []
     }
   }
 }


### PR DESCRIPTION
## Summary
- Issue #50: `createParticipants` akzeptiert Teilnehmer ohne E-Mail (Cognito/SES werden dann übersprungen; nur DynamoDB).
- Backend: ESLint hinzugefügt und ungenutzte Imports/Variablen bereinigt.
- IaC: CloudFront Custom Domain (Aliases + ACM ARN) in Terraform nachgezogen und eine zuverlässige Cache-Invalidierung via `aws cloudfront create-invalidation` (getriggert durch `local.build_hash`) ergänzt.

## Warum
- Teilnehmer sollen auch **fremdverwaltet** ohne Login/Email angelegt werden können.
- Linting verhindert schleichende Qualitätsprobleme im Backend.
- Nach `tofu apply` soll die SPA zuverlässig aktualisieren (kein „altes Frontend“ aus CloudFront-Cache).

## Test plan
- [ ] `backend`: `npm test` und `npm run lint`
- [ ] `projects/yogaswap`: `tofu validate` (ggf. mit Netzwerk) und `tofu plan`
- [ ] Optional nach Deploy: Seite laden und prüfen, dass neue Assets/`index.html` sofort sichtbar sind

Made with [Cursor](https://cursor.com)