### PR TITLE
#64 ParticipantProfile: Types + Status-Ableitung + Settings

### DIFF
--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -136,10 +136,36 @@ export interface ParticipantProfile {
   inviteSentAt?: string;
 
   /** Optional: flexible, tenant-spezifische Teilnehmer-Einstellungen. */
-  settings?: Record<string, unknown>;
+  settings?: ParticipantSettings;
 }
 
 export type ParticipantStatus = "no_login" | "invited" | "active";
+
+/**
+ * Teilnehmer-spezifische Einstellungen.
+ *
+ * Design-Ziel: offen für Erweiterungen, aber mit typsicheren "bekannten" Feldern,
+ * sobald ihr konkrete Use-Cases (Waitlist/Notifications) implementiert.
+ */
+export type ParticipantSettings = {
+  /**
+   * Wenn gesetzt: Teilnehmer möchte nicht mehr nachrücken, wenn der Kurs weniger
+   * als X Minuten in der Zukunft liegt.
+   */
+  waitlistNoPromoteWithinMinutes?: number;
+
+  /** Benachrichtigungspräferenzen (MVP-freundlich, später erweiterbar). */
+  notifications?: {
+    enabled?: boolean;
+    /** z.B. "swap_active", "swap_pending", "waitlist_promoted" */
+    events?: string[];
+    /** z.B. ["email"] */
+    channels?: Array<"email">;
+  };
+
+  /** Erweiterungspunkt für zukünftige Einstellungen. */
+  [key: string]: unknown;
+};
 
 /**
  * Ableitung des Teilnehmer-Status aus Profilfeldern (ohne eigenes Status-Feld).

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -116,3 +116,38 @@ export interface UserTenantMembership {
    */
   instructorCanSeeAllCoursesOverride?: boolean;
 }
+
+/**
+ * Teilnehmerprofil innerhalb eines Tenants.
+ * Dient als stabile, erweiterbare Entität für Teilnehmerverwaltung (E-Mail optional, Settings, Einladungsstatus).
+ */
+export interface ParticipantProfile {
+  tenantId: string;
+  /** Aktuell: Nickname. Kann später auf eine stabile ID migriert werden. */
+  userId: string;
+
+  /** Optional: Kontakt-E-Mail (kann nachgetragen/aktualisiert werden). */
+  email?: string;
+
+  /** Optional: Verknüpfung zur Auth-Identität (z.B. Cognito sub). */
+  authUserId?: string | null;
+
+  /** Optional: Zeitpunkt der letzten Einladung (ISO timestamp). */
+  inviteSentAt?: string;
+
+  /** Optional: flexible, tenant-spezifische Teilnehmer-Einstellungen. */
+  settings?: Record<string, unknown>;
+}
+
+export type ParticipantStatus = "no_login" | "invited" | "active";
+
+/**
+ * Ableitung des Teilnehmer-Status aus Profilfeldern (ohne eigenes Status-Feld).
+ */
+export function getParticipantStatus(
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+): ParticipantStatus {
+  if (profile.authUserId) return "active";
+  if (profile.inviteSentAt) return "invited";
+  return "no_login";
+}


### PR DESCRIPTION
## Summary
- Führt `ParticipantProfile` als zentrale, erweiterbare Tenant-Entität ein (E-Mail optional, Invite-Felder, Settings).
- Status wird ableitbar gemacht via `getParticipantStatus` (no_login / invited / active) – ohne eigenes Statusfeld.
- Ergänzt ein typsicheres, aber offenes `ParticipantSettings`-Gerüst (Waitlist/Notifications + Extension-Punkt).

## Test plan
- [x] `shared`: `npm run build`

Made with [Cursor](https://cursor.com)