### PR TITLE
#69 Infra: participants DynamoDB table

### DIFF
--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -134,7 +134,7 @@ resource "aws_cloudfront_distribution" "spa" {
   }
 
   ordered_cache_behavior {
-    path_pattern     = "/participants"
+    path_pattern     = "/participants*"
     target_origin_id = "api-gateway-backend"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods   = ["GET", "HEAD"]
@@ -147,6 +147,8 @@ resource "aws_cloudfront_distribution" "spa" {
       }
       headers      = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]
     }
+
+    compress = true
   }
 
   default_cache_behavior {

--- a/projects/yogaswap/dynamodb.tf
+++ b/projects/yogaswap/dynamodb.tf
@@ -82,12 +82,26 @@ module "memberships_table" {
   ]
 }
 
+# Participants: PK = tenantId, SK = userId (Nickname)
+# Speichert Teilnehmerprofil-Daten (optional E-Mail, Einladungsstatus, Settings)
+module "participants_table" {
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-participants-table"
+  hash_key  = "tenantId"
+  range_key = "userId"
+  attributes = [
+    { name = "tenantId", type = "S" },
+    { name = "userId", type = "S" }
+  ]
+}
+
 output "table_names" {
   value = [
     module.swaps_table.table_name,
     module.course_overrides_table.table_name,
     module.courses_table.table_name,
     module.tenants_table.table_name,
-    module.memberships_table.table_name
+    module.memberships_table.table_name,
+    module.participants_table.table_name
   ]
 }

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -140,10 +140,11 @@ locals {
     "create_participants" = {
       name             = "create-participants"
       file_name        = "createParticipants.zip"
-      table_arns       = [module.memberships_table.table_arn]
+      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem"]
       tables = {
-        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -174,12 +175,14 @@ locals {
       file_name = "getTenantContext.zip"
       table_arns = [
         module.tenants_table.table_arn,
-        module.memberships_table.table_arn
+        module.memberships_table.table_arn,
+        module.participants_table.table_arn
       ]
       dynamodb_actions = ["dynamodb:GetItem"]
       tables = {
-        "TENANTS_TABLE"     = module.tenants_table.table_name
-        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+        "TENANTS_TABLE"      = module.tenants_table.table_name
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
       }
       s3_actions   = []
       s3_resources = []


### PR DESCRIPTION
## Summary
- Fügt eine neue DynamoDB-Tabelle `participants` hinzu (PK `tenantId`, SK `userId`) für Teilnehmerprofile.
- Wired die Tabelle in IaC an die relevanten Lambdas (`create_participants`, `get_tenant_context`) via `PARTICIPANTS_TABLE` + IAM table_arns.

## Test plan
- [x] `projects/yogaswap`: `tofu validate`
- [x] `projects/yogaswap`: `tofu plan` zeigt 1 neue Tabelle + Lambda env/policy updates

Made with [Cursor](https://cursor.com)