### PR TITLE
Feat: ParticipantProfile CRUD

### DIFF
--- a/app/src/api/participants.test.ts
+++ b/app/src/api/participants.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { inviteUser } from "./participants";
+import { getParticipants, inviteUser, updateParticipant } from "./participants";
 import axios from "axios";
 
 vi.mock("axios");
@@ -52,5 +52,55 @@ describe("inviteUser", () => {
     });
 
     expect(result).toEqual({ error: "Request failed" });
+  });
+});
+
+describe("participants API (getParticipants/updateParticipant)", () => {
+  beforeEach(() => {
+    vi.mocked(axios.get).mockReset();
+    vi.mocked(axios.put).mockReset();
+  });
+
+  it("getParticipants lädt Teilnehmer inkl. status", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [
+        { tenantId: "default-tenant", userId: "alice", status: "no_login" },
+      ],
+    });
+
+    const result = await getParticipants();
+    expect(result).toEqual([
+      { tenantId: "default-tenant", userId: "alice", status: "no_login" },
+    ]);
+
+    expect(axios.get).toHaveBeenCalledWith("/participants", undefined);
+  });
+
+  it("getParticipants mit search nutzt Query-Param", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [],
+    });
+
+    await getParticipants("ali");
+    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { search: "ali" } });
+  });
+
+  it("updateParticipant PUT aktualisiert Profil und liefert status", async () => {
+    vi.mocked(axios.put).mockResolvedValueOnce({
+      data: {
+        tenantId: "default-tenant",
+        userId: "alice",
+        email: "alice@example.com",
+        status: "invited",
+      },
+    });
+
+    const result = await updateParticipant("alice", { email: "alice@example.com" });
+
+    expect(result.status).toBe("invited");
+    expect(axios.put).toHaveBeenCalledWith(
+      "/participants/alice",
+      { email: "alice@example.com" },
+    );
   });
 });

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -1,5 +1,6 @@
 // app/api/participants.ts
 import axios from 'axios';
+import type { ParticipantProfile, ParticipantStatus, ParticipantSettings } from 'shared/types';
 
 export interface InviteUserRequest {
   email?: string;
@@ -17,6 +18,15 @@ export interface InviteUserResponse {
   link?: string;
 }
 
+export type ParticipantWithStatus = ParticipantProfile & { status: ParticipantStatus };
+
+export interface UpdateParticipantRequest {
+  email?: string | null;
+  settings?: ParticipantSettings;
+  inviteSentAt?: string | null;
+  authUserId?: string | null;
+}
+
 export async function inviteUser(data: InviteUserRequest): Promise<InviteUserResponse> {
   try {
     const response = await axios.post<InviteUserResponse>('/participants', data);
@@ -29,4 +39,18 @@ export async function inviteUser(data: InviteUserRequest): Promise<InviteUserRes
     }
     return { error: "Request failed" };
   }
+}
+
+export async function getParticipants(search?: string): Promise<ParticipantWithStatus[]> {
+  const config = search ? { params: { search } } : undefined;
+  const response = await axios.get<ParticipantWithStatus[]>('/participants', config);
+  return response.data;
+}
+
+export async function updateParticipant(
+  userId: string,
+  data: UpdateParticipantRequest,
+): Promise<ParticipantWithStatus> {
+  const response = await axios.put<ParticipantWithStatus>(`/participants/${encodeURIComponent(userId)}`, data);
+  return response.data;
 }

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -1,11 +1,11 @@
 // app/api/participants.ts
 import axios from 'axios';
-import type { ParticipantProfile, ParticipantStatus, ParticipantSettings } from 'shared/types';
+import type { ParticipantProfile, ParticipantStatus, ParticipantSettings, UserRole } from 'shared/types';
 
 export interface InviteUserRequest {
   email?: string;
   nickname: string;
-  role: "participant" | "instructor" | "admin";
+  role: UserRole;
 }
 
 export interface InviteUserResponse {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -2,17 +2,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import AdminPanel from "./AdminPanel";
-import { inviteUser } from "../api/participants";
+import { getParticipants, inviteUser } from "../api/participants";
 
 vi.mock("../api/participants", () => ({
   inviteUser: vi.fn(),
+  getParticipants: vi.fn(),
+  updateParticipant: vi.fn(),
 }));
 
 const mockedInviteUser = inviteUser as unknown as ReturnType<typeof vi.fn>;
+const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
 
 describe("AdminPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedGetParticipants.mockResolvedValue([]);
   });
 
   it("deaktiviert den Einladen-Button, wenn Email oder Nickname fehlen", () => {
@@ -169,6 +173,26 @@ describe("AdminPanel", () => {
 
     await waitFor(() => {
       expect(within(panel).getByText(/Fehler beim Senden/i)).toBeInTheDocument();
+    });
+  });
+
+  it("lädt Teilnehmerliste für die Verwaltung", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+      expect(within(panel).getByText("no_login")).toBeInTheDocument();
     });
   });
 });

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -1,5 +1,10 @@
-import { useState } from "react";
-import { inviteUser } from "../api/participants";
+import { useEffect, useState } from "react";
+import {
+  getParticipants,
+  inviteUser,
+  updateParticipant,
+  type ParticipantWithStatus,
+} from "../api/participants";
 
 export default function AdminPanel() {
   const [email, setEmail] = useState("");
@@ -9,6 +14,42 @@ export default function AdminPanel() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+
+  const [participants, setParticipants] = useState<ParticipantWithStatus[]>([]);
+  const [participantsLoading, setParticipantsLoading] = useState(false);
+  const [participantsMessage, setParticipantsMessage] = useState("");
+  const [participantsError, setParticipantsError] = useState("");
+  const [emailDraftByUserId, setEmailDraftByUserId] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadParticipants() {
+      setParticipantsLoading(true);
+      setParticipantsError("");
+      try {
+        const list = await getParticipants();
+        if (cancelled) return;
+        setParticipants(list);
+        setEmailDraftByUserId(
+          Object.fromEntries(list.map((p) => [p.userId, p.email ?? ""])),
+        );
+      } catch {
+        if (!cancelled) {
+        setParticipantsError("Konnte Teilnehmer nicht laden.");
+        }
+      }
+
+      if (!cancelled) {
+        setParticipantsLoading(false);
+      }
+    }
+
+    loadParticipants();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleInvite = async () => {
     if (!nickname) return;
@@ -56,6 +97,25 @@ export default function AdminPanel() {
       setError("Fehler beim Senden");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleUpdateEmail = async (userId: string) => {
+    setParticipantsMessage("");
+    setParticipantsError("");
+
+    const draft = emailDraftByUserId[userId] ?? "";
+    const normalized = draft.trim();
+    try {
+      const updated = await updateParticipant(userId, {
+        email: normalized ? normalized : null,
+      });
+
+      setParticipants((prev) => prev.map((p) => (p.userId === userId ? updated : p)));
+      setEmailDraftByUserId((prev) => ({ ...prev, [userId]: updated.email ?? "" }));
+      setParticipantsMessage(`✅ "${userId}" aktualisiert (Status: ${updated.status}).`);
+    } catch {
+      setParticipantsError("Fehler beim Speichern.");
     }
   };
   
@@ -127,6 +187,60 @@ export default function AdminPanel() {
         )}
         {error && <p style={{ margin: "0.5rem 0", color: "red" }}>{error}</p>}
  
+      </div>
+
+      <div style={{ marginTop: "1rem", paddingTop: "1rem", borderTop: "1px solid #eee" }}>
+        <h3>Teilnehmer verwalten</h3>
+
+        {participantsMessage && (
+          <p style={{ margin: "0.5rem 0", color: "green", whiteSpace: "pre-line" }}>
+            {participantsMessage}
+          </p>
+        )}
+        {participantsError && (
+          <p style={{ margin: "0.5rem 0", color: "red", whiteSpace: "pre-line" }}>
+            {participantsError}
+          </p>
+        )}
+
+        {participantsLoading ? (
+          <p>Teilnehmer werden geladen...</p>
+        ) : participants.length === 0 ? (
+          <p>Keine Teilnehmer gefunden.</p>
+        ) : (
+          <div style={{ display: "grid", gap: "0.5rem", maxWidth: 720 }}>
+            {participants.map((p) => (
+              <div
+                key={p.userId}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "110px 110px 1fr auto",
+                  gap: "0.5rem",
+                  alignItems: "center",
+                }}
+              >
+                <span style={{ fontWeight: 600 }}>{p.userId}</span>
+                <span style={{ color: "#374151" }}>{p.status}</span>
+                <input
+                  type="email"
+                  value={emailDraftByUserId[p.userId] ?? ""}
+                  onChange={(e) =>
+                    setEmailDraftByUserId((prev) => ({
+                      ...prev,
+                      [p.userId]: e.target.value,
+                    }))
+                  }
+                />
+                <button
+                  onClick={() => handleUpdateEmail(p.userId)}
+                  disabled={participantsLoading}
+                >
+                  Speichern
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "seed": "ts-node src/seed/index.ts",
     "seed:build": "npm run build && node dist/seed/index.js",
     "seed:tenants": "ts-node src/scripts/seed_tenants.ts",
+    "backfill:participants": "ts-node src/scripts/backfill_participant_profiles.ts",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "jest",
     "lint": "eslint ."

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -48,6 +48,7 @@ describe('createParticipants Lambda', () => {
       BASE_URL: 'https://yogaswap.example.com',
       SES_SOURCE_EMAIL: 'yogaswap@example.com',
       MEMBERSHIPS_TABLE: 'test-memberships-table',
+      PARTICIPANTS_TABLE: 'test-participants-table',
     };
     cognitoMockSend.mockReset();
     sesMockSend.mockReset();
@@ -102,8 +103,8 @@ describe('createParticipants Lambda', () => {
     expect(cognitoMockSend).not.toHaveBeenCalled();
     expect(sesMockSend).not.toHaveBeenCalled();
 
-    // DynamoDB should be called to store membership
-    expect(dynamoMockSend).toHaveBeenCalledTimes(1);
+    // DynamoDB should be called to store membership + participant profile
+    expect(dynamoMockSend).toHaveBeenCalledTimes(2);
     expect(dynamoMockSend).toHaveBeenCalledWith(
       expect.objectContaining({
         TableName: 'test-memberships-table',
@@ -111,6 +112,15 @@ describe('createParticipants Lambda', () => {
           tenantId: { S: 'test-tenant' },
           userId: { S: 'noligin' },
           role: { S: 'participant' },
+        }),
+      })
+    );
+    expect(dynamoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: 'test-participants-table',
+        Item: expect.objectContaining({
+          tenantId: { S: 'test-tenant' },
+          userId: { S: 'noligin' },
         }),
       })
     );
@@ -170,8 +180,8 @@ describe('createParticipants Lambda', () => {
       })
     );
 
-    // Verify DynamoDB call
-    expect(dynamoMockSend).toHaveBeenCalledTimes(1);
+    // Verify DynamoDB call (membership + participant profile)
+    expect(dynamoMockSend).toHaveBeenCalledTimes(2);
     expect(dynamoMockSend).toHaveBeenCalledWith(
       expect.objectContaining({
         TableName: 'test-memberships-table',
@@ -179,6 +189,16 @@ describe('createParticipants Lambda', () => {
           tenantId: { S: 'test-tenant' },
           userId: { S: 'testuser' },
           role: { S: 'participant' },
+        }),
+      })
+    );
+    expect(dynamoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: 'test-participants-table',
+        Item: expect.objectContaining({
+          tenantId: { S: 'test-tenant' },
+          userId: { S: 'testuser' },
+          email: { S: 'test@example.com' },
         }),
       })
     );

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -24,6 +24,37 @@ function generateSafeTempPassword(length = 10) {
   return pw;
 }
 
+async function saveParticipantProfile(params: {
+  tenantId: string;
+  userId: string;
+  email?: string;
+  inviteSentAt?: string;
+}) {
+  if (!process.env.PARTICIPANTS_TABLE) {
+    console.warn("PARTICIPANTS_TABLE environment variable not set, skipping participant profile write.");
+    return;
+  }
+
+  const item: Record<string, { S: string }> = {
+    tenantId: { S: params.tenantId },
+    userId: { S: params.userId },
+  };
+
+  if (params.email && params.email.trim()) {
+    item.email = { S: params.email.trim() };
+  }
+  if (params.inviteSentAt && params.inviteSentAt.trim()) {
+    item.inviteSentAt = { S: params.inviteSentAt };
+  }
+
+  await dynamodb.send(
+    new PutItemCommand({
+      TableName: process.env.PARTICIPANTS_TABLE,
+      Item: item,
+    }),
+  );
+}
+
 export const handler = async (event: any) => {
   console.log('EVENT:', JSON.stringify(event));
   // Debug: Environment Variables ausgeben
@@ -69,6 +100,11 @@ export const handler = async (event: any) => {
           "MEMBERSHIPS_TABLE environment variable not set, skipping DynamoDB write.",
         );
       }
+
+      await saveParticipantProfile({
+        tenantId,
+        userId: nickname,
+      });
     } catch (err: any) {
       console.error("Failed to save membership in DynamoDB:", err);
       return {
@@ -208,6 +244,17 @@ export const handler = async (event: any) => {
   // Do NOT log passwords in production normally, but log if email failed
   if (!emailSent) {
     console.warn(`⚠️ WICHTIG: E-Mail nicht versendet. User '${username}' benötigt temporäres Passwort: ${rawPassword}`);
+  }
+
+  try {
+    await saveParticipantProfile({
+      tenantId,
+      userId: username,
+      email: emailNormalized,
+      inviteSentAt: emailSent ? new Date().toISOString() : undefined,
+    });
+  } catch (err: any) {
+    console.warn("Failed to save participant profile (ignored):", err?.message || err);
   }
 
   return { 

--- a/backend/src/lambdas/getParticipants/index.test.ts
+++ b/backend/src/lambdas/getParticipants/index.test.ts
@@ -1,0 +1,99 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    QueryCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+describe("getParticipants Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, PARTICIPANTS_TABLE: "test-participants" };
+    mockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  const makeEvent = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent =>
+    ({
+      headers: {},
+      queryStringParameters: null,
+      requestContext: {} as any,
+      ...overrides,
+    } as any);
+
+  test("returns participant list with derived status", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [
+        {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+        },
+        {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "bob" },
+          authUserId: { S: "cognito-sub-123" },
+        },
+      ],
+    });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body).toEqual([
+      expect.objectContaining({ userId: "alice", status: "invited" }),
+      expect.objectContaining({ userId: "bob", status: "active" }),
+    ]);
+
+    expect(QueryCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-participants",
+        KeyConditionExpression: "tenantId = :tid",
+        ExpressionAttributeValues: { ":tid": { S: "default-tenant" } },
+      }),
+    );
+  });
+
+  test("filters by search over userId and email", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: "default-tenant" }, userId: { S: "alice" }, email: { S: "alice@example.com" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "bob" }, email: { S: "bob@example.com" } },
+      ],
+    });
+
+    const result = await handler(
+      makeEvent({
+        queryStringParameters: { search: "ali" },
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].userId).toBe("alice");
+  });
+
+  test("returns 500 when table env var is missing", async () => {
+    process.env.PARTICIPANTS_TABLE = "";
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body).error).toMatch(/PARTICIPANTS_TABLE/);
+  });
+});
+

--- a/backend/src/lambdas/getParticipants/index.ts
+++ b/backend/src/lambdas/getParticipants/index.ts
@@ -1,0 +1,80 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import {
+  type ParticipantProfile,
+  type ParticipantStatus,
+} from "@yogaswap/shared";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+
+function deriveParticipantStatus(
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+): ParticipantStatus {
+  if (profile.authUserId) return "active";
+  if (profile.inviteSentAt) return "invited";
+  return "no_login";
+}
+
+type ParticipantListItem = ParticipantProfile & {
+  status: ParticipantStatus;
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+  const tableName = process.env.PARTICIPANTS_TABLE;
+  if (!tableName) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "PARTICIPANTS_TABLE env var is not set" }),
+    };
+  }
+
+  const { tenantId } = getTenantContext(event);
+  const search = (event.queryStringParameters?.search || "").trim().toLowerCase();
+
+  try {
+    const result = await client.send(
+      new QueryCommand({
+        TableName: tableName,
+        KeyConditionExpression: "tenantId = :tid",
+        ExpressionAttributeValues: { ":tid": { S: tenantId } },
+        ConsistentRead: true,
+      }),
+    );
+
+    const profiles: ParticipantProfile[] = (result.Items || []).map((item) =>
+      unmarshall(item) as ParticipantProfile,
+    );
+
+    const filtered = search
+      ? profiles.filter((p) => {
+          const userId = (p.userId || "").toLowerCase();
+          const email = (p.email || "").toLowerCase();
+          return userId.includes(search) || email.includes(search);
+        })
+      : profiles;
+
+    const participants: ParticipantListItem[] = filtered
+      .map((profile) => ({
+        ...profile,
+        status: deriveParticipantStatus(profile),
+      }))
+      .sort((a, b) => a.userId.localeCompare(b.userId));
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(participants),
+    };
+  } catch (error) {
+    console.error("Failed to list participants:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to list participants" }),
+    };
+  }
+};
+

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -52,6 +52,7 @@ describe("updateParticipant Lambda", () => {
     const body = JSON.parse(result.body);
     expect(body.email).toBe("alice+new@example.com");
     expect(body.userId).toBe("alice");
+    expect(body.status).toBe("no_login");
     expect(mockSend).toHaveBeenCalledTimes(2);
   });
 
@@ -78,6 +79,46 @@ describe("updateParticipant Lambda", () => {
 
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).error).toMatch(/settings must be an object/);
+  });
+
+  test("derives invited/active status when inviteSentAt/authUserId are set", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const resultInvited = await handler(
+      makeEvent({
+        body: JSON.stringify({ inviteSentAt: "2026-01-01T12:00:00.000Z" }),
+      }),
+    );
+
+    expect(resultInvited.statusCode).toBe(200);
+    expect(JSON.parse(resultInvited.body).status).toBe("invited");
+
+    mockSend.mockReset();
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const resultActive = await handler(
+      makeEvent({
+        body: JSON.stringify({ authUserId: "cognito-sub-123" }),
+      }),
+    );
+
+    expect(resultActive.statusCode).toBe(200);
+    expect(JSON.parse(resultActive.body).status).toBe("active");
   });
 });
 

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -1,0 +1,83 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+describe("updateParticipant Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, PARTICIPANTS_TABLE: "test-participants" };
+    mockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  const makeEvent = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent =>
+    ({
+      headers: {},
+      pathParameters: { userId: "alice" },
+      body: JSON.stringify({ email: "alice+new@example.com" }),
+      requestContext: {} as any,
+      ...overrides,
+    } as any);
+
+  test("updates participant profile successfully", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.email).toBe("alice+new@example.com");
+    expect(body.userId).toBe("alice");
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns 404 if participant does not exist", async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body).error).toBe("Participant not found");
+  });
+
+  test("returns 400 for invalid settings payload", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "alice" },
+      },
+    });
+
+    const result = await handler(
+      makeEvent({
+        body: JSON.stringify({ settings: "not-an-object" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/settings must be an object/);
+  });
+});
+

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -1,0 +1,138 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import type { ParticipantProfile, ParticipantSettings } from "@yogaswap/shared";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+
+type UpdateParticipantBody = {
+  email?: string | null;
+  settings?: ParticipantSettings;
+  inviteSentAt?: string | null;
+  authUserId?: string | null;
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+  const tableName = process.env.PARTICIPANTS_TABLE;
+  if (!tableName) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "PARTICIPANTS_TABLE env var is not set" }),
+    };
+  }
+
+  const userId = event.pathParameters?.userId?.trim();
+  if (!userId) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Missing userId in path" }),
+    };
+  }
+
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Missing request body" }),
+    };
+  }
+
+  let body: UpdateParticipantBody;
+  try {
+    body = JSON.parse(event.body);
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Invalid JSON body" }),
+    };
+  }
+
+  const { tenantId } = getTenantContext(event);
+
+  try {
+    const existingResp = await client.send(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: userId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+
+    if (!existingResp.Item) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: "Participant not found" }),
+      };
+    }
+
+    const existing = unmarshall(existingResp.Item) as ParticipantProfile;
+    const updated: ParticipantProfile = {
+      ...existing,
+      tenantId,
+      userId,
+    };
+
+    if (Object.prototype.hasOwnProperty.call(body, "email")) {
+      const email = typeof body.email === "string" ? body.email.trim() : body.email;
+      if (email) updated.email = email;
+      else delete updated.email;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "settings")) {
+      if (body.settings && typeof body.settings === "object" && !Array.isArray(body.settings)) {
+        updated.settings = body.settings;
+      } else if (body.settings == null) {
+        delete updated.settings;
+      } else {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: "settings must be an object" }),
+        };
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "inviteSentAt")) {
+      if (typeof body.inviteSentAt === "string" && body.inviteSentAt.trim()) {
+        updated.inviteSentAt = body.inviteSentAt;
+      } else {
+        delete updated.inviteSentAt;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "authUserId")) {
+      if (typeof body.authUserId === "string" && body.authUserId.trim()) {
+        updated.authUserId = body.authUserId;
+      } else {
+        delete updated.authUserId;
+      }
+    }
+
+    await client.send(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: marshall(updated, { removeUndefinedValues: true }),
+      }),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(updated),
+    };
+  } catch (error) {
+    console.error("Failed to update participant:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to update participant" }),
+    };
+  }
+};
+

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -4,7 +4,11 @@ import {
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
-import type { ParticipantProfile, ParticipantSettings } from "@yogaswap/shared";
+import type {
+  ParticipantProfile,
+  ParticipantSettings,
+  ParticipantStatus,
+} from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
 
@@ -16,6 +20,14 @@ type UpdateParticipantBody = {
   inviteSentAt?: string | null;
   authUserId?: string | null;
 };
+
+function deriveParticipantStatus(
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+): ParticipantStatus {
+  if (profile.authUserId) return "active";
+  if (profile.inviteSentAt) return "invited";
+  return "no_login";
+}
 
 export const handler = async (
   event: APIGatewayProxyEvent,
@@ -125,7 +137,10 @@ export const handler = async (
 
     return {
       statusCode: 200,
-      body: JSON.stringify(updated),
+      body: JSON.stringify({
+        ...updated,
+        status: deriveParticipantStatus(updated),
+      }),
     };
   } catch (error) {
     console.error("Failed to update participant:", error);

--- a/backend/src/scripts/backfill_participant_profiles.ts
+++ b/backend/src/scripts/backfill_participant_profiles.ts
@@ -1,0 +1,81 @@
+import {
+  ScanCommand,
+  PutItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../lambdas/shared/dynamoClient";
+
+const client = dynamoClient;
+
+const MEMBERSHIPS_TABLE =
+  process.env.MEMBERSHIPS_TABLE || "yogaswap-demo-memberships-table";
+const PARTICIPANTS_TABLE =
+  process.env.PARTICIPANTS_TABLE || "yogaswap-demo-participants-table";
+
+async function run(): Promise<void> {
+  console.log(
+    `Backfill start: memberships=${MEMBERSHIPS_TABLE}, participants=${PARTICIPANTS_TABLE}`,
+  );
+
+  let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
+  let scanned = 0;
+  let created = 0;
+
+  do {
+    const scanResp = await client.send(
+      new ScanCommand({
+        TableName: MEMBERSHIPS_TABLE,
+        ExclusiveStartKey: lastEvaluatedKey,
+      }),
+    );
+
+    const items = scanResp.Items || [];
+    scanned += items.length;
+
+    for (const item of items) {
+      const tenantId = item.tenantId?.S;
+      const userId = item.userId?.S;
+      if (!tenantId || !userId) continue;
+
+      let inserted = false;
+      try {
+        await client.send(
+          new PutItemCommand({
+            TableName: PARTICIPANTS_TABLE,
+            Item: {
+              tenantId: { S: tenantId },
+              userId: { S: userId },
+            },
+            // Create only if missing; keeps existing profile fields untouched.
+            ConditionExpression:
+              "attribute_not_exists(tenantId) AND attribute_not_exists(userId)",
+          }),
+        );
+        inserted = true;
+      } catch (error: unknown) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "name" in error &&
+          (error as { name?: string }).name === "ConditionalCheckFailedException"
+        ) {
+          inserted = false;
+        } else {
+          throw error;
+        }
+      }
+
+      if (inserted) created += 1;
+    }
+
+    lastEvaluatedKey = scanResp.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  console.log(`Backfill done: scanned=${scanned}, attemptedCreates=${created}`);
+}
+
+run().catch((error) => {
+  console.error("Backfill failed:", error);
+  process.exit(1);
+});
+

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -137,6 +137,28 @@ locals {
       s3_actions   = []
       s3_resources = []
     },
+    "get_participants" = {
+      name             = "get-participants"
+      file_name        = "getParticipants.zip"
+      table_arns       = [module.participants_table.table_arn]
+      dynamodb_actions = ["dynamodb:Query"]
+      tables = {
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+    },
+    "update_participant" = {
+      name             = "update-participant"
+      file_name        = "updateParticipant.zip"
+      table_arns       = [module.participants_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
+      tables = {
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+    },
     "create_participants" = {
       name             = "create-participants"
       file_name        = "createParticipants.zip"
@@ -204,7 +226,9 @@ locals {
     "DELETE /course-overrides/{courseId}/{date}" = "delete_override"
     "POST /process-promotions"                   = "process_promotions"
     "GET /courses"                               = "get_courses"
+    "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
+    "PUT /participants/{userId}"                 = "update_participant"
     "GET /tenant-context"                        = "get_tenant_context"
   }
 


### PR DESCRIPTION
## Summary
Umsetzung von #65 (Backend: ParticipantProfile CRUD – list/create/update) inkl. API-Endpunkte und einem einmaligen Backfill, damit bestehende Teilnehmer sofort sichtbar sind.

## Backend changes
- `GET /participants` (List) inkl. abgeleitetem `status` (`no_login`/`invited`/`active`)
- `POST /participants` (Create) schreibt zusätzlich `ParticipantProfile` in `PARTICIPANTS_TABLE`
- `PUT /participants/{userId}` (Update) aktualisiert Profilfelder und liefert ebenfalls `status`
- Terraform-Routing: `get_participants`, `update_participant`
- Script: `npm run backfill:participants` (Memberships -> ParticipantProfiles)

## Frontend (Smoke/Test Integration)
- `AdminPanel` erweitert um eine kleine Teilnehmerliste (GET/PUT) als Test, dass Daten/Status korrekt ankommen.

## Test plan
- `npm test --prefix backend`
- `npm run lint --prefix backend`
- `npm test --prefix app`
- `npm run lint --prefix app`
- Live checks (CloudFront/API Gateway): `GET /participants` und `PUT /participants/{userId}` lieferten `status`.

Made with [Cursor](https://cursor.com)