### PR TITLE
#73 Backend: Authorization/Validierung für /participants

### DIFF
--- a/app/src/api/participants.test.ts
+++ b/app/src/api/participants.test.ts
@@ -59,6 +59,14 @@ describe("participants API (getParticipants/updateParticipant)", () => {
   beforeEach(() => {
     vi.mocked(axios.get).mockReset();
     vi.mocked(axios.put).mockReset();
+    localStorage.setItem(
+      "currentUser",
+      JSON.stringify({
+        nickname: "admin",
+        email: "admin@example.com",
+        role: "admin",
+      }),
+    );
   });
 
   it("getParticipants lädt Teilnehmer inkl. status", async () => {
@@ -73,7 +81,7 @@ describe("participants API (getParticipants/updateParticipant)", () => {
       { tenantId: "default-tenant", userId: "alice", status: "no_login" },
     ]);
 
-    expect(axios.get).toHaveBeenCalledWith("/participants", undefined);
+    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { user: "admin" } });
   });
 
   it("getParticipants mit search nutzt Query-Param", async () => {
@@ -82,7 +90,17 @@ describe("participants API (getParticipants/updateParticipant)", () => {
     });
 
     await getParticipants("ali");
-    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { search: "ali" } });
+    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { user: "admin", search: "ali" } });
+  });
+
+  it("getParticipants wirft bei unerwartetem Response-Format", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: { error: "Forbidden" },
+    });
+
+    await expect(getParticipants()).rejects.toThrow(
+      "Unexpected /participants response format",
+    );
   });
 
   it("getParticipants mit Filter/Sort-Optionen sendet alle Query-Params", async () => {
@@ -100,6 +118,7 @@ describe("participants API (getParticipants/updateParticipant)", () => {
 
     expect(axios.get).toHaveBeenCalledWith("/participants", {
       params: {
+        user: "admin",
         search: "ali",
         status: "invited",
         hasEmail: "true",
@@ -125,6 +144,7 @@ describe("participants API (getParticipants/updateParticipant)", () => {
     expect(axios.put).toHaveBeenCalledWith(
       "/participants/alice",
       { email: "alice@example.com" },
+      { params: { user: "admin" } },
     );
   });
 });

--- a/app/src/api/participants.test.ts
+++ b/app/src/api/participants.test.ts
@@ -59,14 +59,6 @@ describe("participants API (getParticipants/updateParticipant)", () => {
   beforeEach(() => {
     vi.mocked(axios.get).mockReset();
     vi.mocked(axios.put).mockReset();
-    localStorage.setItem(
-      "currentUser",
-      JSON.stringify({
-        nickname: "admin",
-        email: "admin@example.com",
-        role: "admin",
-      }),
-    );
   });
 
   it("getParticipants lädt Teilnehmer inkl. status", async () => {
@@ -81,7 +73,7 @@ describe("participants API (getParticipants/updateParticipant)", () => {
       { tenantId: "default-tenant", userId: "alice", status: "no_login" },
     ]);
 
-    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { user: "admin" } });
+    expect(axios.get).toHaveBeenCalledWith("/participants", undefined);
   });
 
   it("getParticipants mit search nutzt Query-Param", async () => {
@@ -90,7 +82,7 @@ describe("participants API (getParticipants/updateParticipant)", () => {
     });
 
     await getParticipants("ali");
-    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { user: "admin", search: "ali" } });
+    expect(axios.get).toHaveBeenCalledWith("/participants", { params: { search: "ali" } });
   });
 
   it("getParticipants wirft bei unerwartetem Response-Format", async () => {
@@ -118,7 +110,6 @@ describe("participants API (getParticipants/updateParticipant)", () => {
 
     expect(axios.get).toHaveBeenCalledWith("/participants", {
       params: {
-        user: "admin",
         search: "ali",
         status: "invited",
         hasEmail: "true",
@@ -144,7 +135,6 @@ describe("participants API (getParticipants/updateParticipant)", () => {
     expect(axios.put).toHaveBeenCalledWith(
       "/participants/alice",
       { email: "alice@example.com" },
-      { params: { user: "admin" } },
     );
   });
 });

--- a/app/src/api/participants.test.ts
+++ b/app/src/api/participants.test.ts
@@ -85,6 +85,30 @@ describe("participants API (getParticipants/updateParticipant)", () => {
     expect(axios.get).toHaveBeenCalledWith("/participants", { params: { search: "ali" } });
   });
 
+  it("getParticipants mit Filter/Sort-Optionen sendet alle Query-Params", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [],
+    });
+
+    await getParticipants({
+      search: "ali",
+      status: "invited",
+      hasEmail: true,
+      sortBy: "nickname",
+      sortOrder: "desc",
+    });
+
+    expect(axios.get).toHaveBeenCalledWith("/participants", {
+      params: {
+        search: "ali",
+        status: "invited",
+        hasEmail: "true",
+        sortBy: "nickname",
+        sortOrder: "desc",
+      },
+    });
+  });
+
   it("updateParticipant PUT aktualisiert Profil und liefert status", async () => {
     vi.mocked(axios.put).mockResolvedValueOnce({
       data: {

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -27,6 +27,17 @@ export interface UpdateParticipantRequest {
   authUserId?: string | null;
 }
 
+export type ParticipantSortBy = "nickname" | "userId" | "email" | "status";
+export type ParticipantSortOrder = "asc" | "desc";
+
+export interface GetParticipantsRequest {
+  search?: string;
+  status?: ParticipantStatus;
+  hasEmail?: boolean;
+  sortBy?: ParticipantSortBy;
+  sortOrder?: ParticipantSortOrder;
+}
+
 export async function inviteUser(data: InviteUserRequest): Promise<InviteUserResponse> {
   try {
     const response = await axios.post<InviteUserResponse>('/participants', data);
@@ -41,8 +52,21 @@ export async function inviteUser(data: InviteUserRequest): Promise<InviteUserRes
   }
 }
 
-export async function getParticipants(search?: string): Promise<ParticipantWithStatus[]> {
-  const config = search ? { params: { search } } : undefined;
+export async function getParticipants(
+  request?: string | GetParticipantsRequest,
+): Promise<ParticipantWithStatus[]> {
+  const params: Record<string, string> = {};
+  if (typeof request === "string") {
+    if (request.trim()) params.search = request;
+  } else if (request) {
+    if (request.search?.trim()) params.search = request.search;
+    if (request.status) params.status = request.status;
+    if (typeof request.hasEmail === "boolean") params.hasEmail = String(request.hasEmail);
+    if (request.sortBy) params.sortBy = request.sortBy;
+    if (request.sortOrder) params.sortOrder = request.sortOrder;
+  }
+
+  const config = Object.keys(params).length > 0 ? { params } : undefined;
   const response = await axios.get<ParticipantWithStatus[]>('/participants', config);
   return response.data;
 }

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -1,7 +1,6 @@
 // app/api/participants.ts
 import axios from 'axios';
 import type { ParticipantProfile, ParticipantStatus, ParticipantSettings, UserRole } from 'shared/types';
-import { loadCurrentUser } from "shared/lib/storage";
 
 export interface InviteUserRequest {
   email?: string;
@@ -56,9 +55,7 @@ export async function inviteUser(data: InviteUserRequest): Promise<InviteUserRes
 export async function getParticipants(
   request?: string | GetParticipantsRequest,
 ): Promise<ParticipantWithStatus[]> {
-  const currentUser = loadCurrentUser();
   const params: Record<string, string> = {};
-  if (currentUser?.nickname) params.user = currentUser.nickname;
   if (typeof request === "string") {
     if (request.trim()) params.search = request;
   } else if (request) {
@@ -82,13 +79,9 @@ export async function updateParticipant(
   userId: string,
   data: UpdateParticipantRequest,
 ): Promise<ParticipantWithStatus> {
-  const currentUser = loadCurrentUser();
-  const params = currentUser?.nickname ? { user: currentUser.nickname } : undefined;
-  const config = params ? { params } : undefined;
   const response = await axios.put<ParticipantWithStatus>(
     `/participants/${encodeURIComponent(userId)}`,
     data,
-    config,
   );
   return response.data;
 }

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -1,6 +1,7 @@
 // app/api/participants.ts
 import axios from 'axios';
 import type { ParticipantProfile, ParticipantStatus, ParticipantSettings, UserRole } from 'shared/types';
+import { loadCurrentUser } from "shared/lib/storage";
 
 export interface InviteUserRequest {
   email?: string;
@@ -55,7 +56,9 @@ export async function inviteUser(data: InviteUserRequest): Promise<InviteUserRes
 export async function getParticipants(
   request?: string | GetParticipantsRequest,
 ): Promise<ParticipantWithStatus[]> {
+  const currentUser = loadCurrentUser();
   const params: Record<string, string> = {};
+  if (currentUser?.nickname) params.user = currentUser.nickname;
   if (typeof request === "string") {
     if (request.trim()) params.search = request;
   } else if (request) {
@@ -68,13 +71,24 @@ export async function getParticipants(
 
   const config = Object.keys(params).length > 0 ? { params } : undefined;
   const response = await axios.get<ParticipantWithStatus[]>('/participants', config);
-  return response.data;
+  if (Array.isArray(response.data)) {
+    return response.data;
+  }
+
+  throw new Error("Unexpected /participants response format");
 }
 
 export async function updateParticipant(
   userId: string,
   data: UpdateParticipantRequest,
 ): Promise<ParticipantWithStatus> {
-  const response = await axios.put<ParticipantWithStatus>(`/participants/${encodeURIComponent(userId)}`, data);
+  const currentUser = loadCurrentUser();
+  const params = currentUser?.nickname ? { user: currentUser.nickname } : undefined;
+  const config = params ? { params } : undefined;
+  const response = await axios.put<ParticipantWithStatus>(
+    `/participants/${encodeURIComponent(userId)}`,
+    data,
+    config,
+  );
   return response.data;
 }

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -30,13 +30,15 @@ export default function AdminPanel() {
       try {
         const list = await getParticipants();
         if (cancelled) return;
-        setParticipants(list);
+        const safeList = Array.isArray(list) ? list : [];
+        setParticipants(safeList);
         setEmailDraftByUserId(
-          Object.fromEntries(list.map((p) => [p.userId, p.email ?? ""])),
+          Object.fromEntries(safeList.map((p) => [p.userId, p.email ?? ""])),
         );
-      } catch {
+      } catch (err) {
+        console.error("Failed to load participants", err);
         if (!cancelled) {
-        setParticipantsError("Konnte Teilnehmer nicht laden.");
+          setParticipantsError("Konnte Teilnehmer nicht laden.");
         }
       }
 
@@ -118,6 +120,7 @@ export default function AdminPanel() {
       setParticipantsError("Fehler beim Speichern.");
     }
   };
+  const safeParticipants = Array.isArray(participants) ? participants : [];
   
   return (
     <div style={{ padding: "1rem", border: "1px solid #ccc", margin: "1rem 0", borderRadius: 8 }}>
@@ -205,11 +208,11 @@ export default function AdminPanel() {
 
         {participantsLoading ? (
           <p>Teilnehmer werden geladen...</p>
-        ) : participants.length === 0 ? (
+        ) : safeParticipants.length === 0 ? (
           <p>Keine Teilnehmer gefunden.</p>
         ) : (
           <div style={{ display: "grid", gap: "0.5rem", maxWidth: 720 }}>
-            {participants.map((p) => (
+            {safeParticipants.map((p) => (
               <div
                 key={p.userId}
                 style={{

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -6,9 +6,25 @@ import './index.css';
 import App from './App';
 import { Amplify } from 'aws-amplify';
 import axios from 'axios';
+import { fetchAuthSession } from 'aws-amplify/auth';
 
 // Konfiguriere Axios für Tenant-Header
 axios.defaults.headers.common['x-tenant-id'] = 'default-tenant';
+
+// Fuegt fuer alle API-Requests den aktuellen Cognito-Token hinzu.
+axios.interceptors.request.use(async (config) => {
+  try {
+    const session = await fetchAuthSession();
+    const idToken = session.tokens?.idToken?.toString();
+    if (idToken) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${idToken}`;
+    }
+  } catch {
+    // Ohne Session bleibt der Request ohne Authorization-Header.
+  }
+  return config;
+});
 
 // Checkmark DEBUG: Prüfe Config
 const userPoolId = import.meta.env.VITE_COGNITO_USER_POOL_ID;

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   canInviteParticipants,
+  canManageParticipants,
   canSeeAllCourses,
   canSeeCourse,
 } from "shared/permissions";
@@ -81,6 +82,36 @@ describe("permissions", () => {
     it("erlaubt Participant nie Einladungen", () => {
       expect(canInviteParticipants(participantMembership, defaultSettings)).toBe(false);
       expect(canInviteParticipants(participantMembership, undefined)).toBe(false);
+    });
+  });
+
+  describe("canManageParticipants", () => {
+    it("erlaubt Admins immer Teilnehmerverwaltung", () => {
+      expect(canManageParticipants(adminMembership, undefined)).toBe(true);
+      expect(canManageParticipants(adminMembership, restrictiveSettings)).toBe(true);
+    });
+
+    it("erlaubt Instructor standardmäßig (undefined => true)", () => {
+      expect(canManageParticipants(instructorMembership, undefined)).toBe(true);
+    });
+
+    it("respektiert instructorCanManageParticipants im Tenant-Setting", () => {
+      expect(
+        canManageParticipants(instructorMembership, {
+          ...defaultSettings,
+          instructorCanManageParticipants: true,
+        }),
+      ).toBe(true);
+      expect(
+        canManageParticipants(instructorMembership, {
+          ...defaultSettings,
+          instructorCanManageParticipants: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("verbietet Participant die Teilnehmerverwaltung", () => {
+      expect(canManageParticipants(participantMembership, defaultSettings)).toBe(false);
     });
   });
 

--- a/backend/src/lambdas/getParticipants/index.test.ts
+++ b/backend/src/lambdas/getParticipants/index.test.ts
@@ -6,6 +6,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
   const mockSend = jest.fn();
   return {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
     QueryCommand: jest.fn((input) => input),
     mockSend,
   };
@@ -18,7 +19,12 @@ describe("getParticipants Lambda", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...OLD_ENV, PARTICIPANTS_TABLE: "test-participants" };
+    process.env = {
+      ...OLD_ENV,
+      PARTICIPANTS_TABLE: "test-participants",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      TENANTS_TABLE: "test-tenants",
+    };
     mockSend.mockReset();
   });
 
@@ -36,6 +42,19 @@ describe("getParticipants Lambda", () => {
 
   test("returns participant list with derived status", async () => {
     mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "admin" },
+        role: { S: "admin" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        name: { S: "Demo" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
       Items: [
         {
           tenantId: { S: "default-tenant" },
@@ -51,7 +70,11 @@ describe("getParticipants Lambda", () => {
       ],
     });
 
-    const result = await handler(makeEvent());
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "admin" } } as any,
+      }),
+    );
     expect(result.statusCode).toBe(200);
 
     const body = JSON.parse(result.body);
@@ -71,6 +94,19 @@ describe("getParticipants Lambda", () => {
 
   test("filters by search over userId and email", async () => {
     mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "admin" },
+        role: { S: "admin" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        name: { S: "Demo" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
       Items: [
         { tenantId: { S: "default-tenant" }, userId: { S: "alice" }, email: { S: "alice@example.com" } },
         { tenantId: { S: "default-tenant" }, userId: { S: "bob" }, email: { S: "bob@example.com" } },
@@ -80,6 +116,7 @@ describe("getParticipants Lambda", () => {
     const result = await handler(
       makeEvent({
         queryStringParameters: { search: "ali" },
+        requestContext: { authorizer: { principalId: "admin" } } as any,
       }),
     );
 
@@ -94,6 +131,35 @@ describe("getParticipants Lambda", () => {
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body).error).toMatch(/PARTICIPANTS_TABLE/);
+  });
+
+  test("returns 403 when membership is missing", async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined });
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "intruder" } } as any,
+      }),
+    );
+    expect(result.statusCode).toBe(403);
+  });
+
+  test("returns 403 for participant role", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "p1" },
+        role: { S: "participant" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+    });
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "p1" } } as any,
+      }),
+    );
+    expect(result.statusCode).toBe(403);
   });
 });
 

--- a/backend/src/lambdas/getParticipants/index.test.ts
+++ b/backend/src/lambdas/getParticipants/index.test.ts
@@ -126,6 +126,99 @@ describe("getParticipants Lambda", () => {
     expect(body[0].userId).toBe("alice");
   });
 
+  test("filters by status", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, userId: { S: "admin" }, role: { S: "admin" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: "default-tenant" }, userId: { S: "no-login" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "invited" }, inviteSentAt: { S: "2026-01-01T12:00:00.000Z" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "active" }, authUserId: { S: "sub-1" } },
+      ],
+    });
+
+    const result = await handler(
+      makeEvent({
+        queryStringParameters: { status: "invited" },
+        requestContext: { authorizer: { principalId: "admin" } } as any,
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toEqual(expect.objectContaining({ userId: "invited", status: "invited" }));
+  });
+
+  test("filters by hasEmail=true", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, userId: { S: "admin" }, role: { S: "admin" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: "default-tenant" }, userId: { S: "alice" }, email: { S: "alice@example.com" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "bob" } },
+      ],
+    });
+
+    const result = await handler(
+      makeEvent({
+        queryStringParameters: { hasEmail: "true" },
+        requestContext: { authorizer: { principalId: "admin" } } as any,
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].userId).toBe("alice");
+  });
+
+  test("sorts by nickname descending", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, userId: { S: "admin" }, role: { S: "admin" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+    });
+    mockSend.mockResolvedValueOnce({
+      Items: [
+        { tenantId: { S: "default-tenant" }, userId: { S: "alice" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "charlie" } },
+        { tenantId: { S: "default-tenant" }, userId: { S: "bob" } },
+      ],
+    });
+
+    const result = await handler(
+      makeEvent({
+        queryStringParameters: { sortBy: "nickname", sortOrder: "desc" },
+        requestContext: { authorizer: { principalId: "admin" } } as any,
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.map((p: { userId: string }) => p.userId)).toEqual(["charlie", "bob", "alice"]);
+  });
+
+  test("returns 400 for invalid status filter", async () => {
+    const result = await handler(
+      makeEvent({
+        queryStringParameters: { status: "unknown" },
+        requestContext: { authorizer: { principalId: "admin" } } as any,
+      }),
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Invalid status filter/);
+  });
+
   test("returns 500 when table env var is missing", async () => {
     process.env.PARTICIPANTS_TABLE = "";
     const result = await handler(makeEvent());

--- a/backend/src/lambdas/getParticipants/index.ts
+++ b/backend/src/lambdas/getParticipants/index.ts
@@ -66,10 +66,21 @@ export const handler = async (
   }
 
   if (!userId) {
+    console.warn("getParticipants forbidden: missing actor userId", { tenantId });
     return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
   }
 
   try {
+    console.log("getParticipants request", {
+      tenantId,
+      actorUserId: userId,
+      search,
+      statusFilter,
+      hasEmailFilter,
+      sortBy,
+      sortOrder,
+    });
+
     const canManage = await canActorManageParticipants({
       client,
       membershipsTable,
@@ -78,6 +89,10 @@ export const handler = async (
       actorUserId: userId,
     });
     if (!canManage) {
+      console.warn("getParticipants forbidden: actor cannot manage participants", {
+        tenantId,
+        actorUserId: userId,
+      });
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
     }
 
@@ -93,6 +108,10 @@ export const handler = async (
     const profiles: ParticipantProfile[] = (result.Items || []).map((item) =>
       unmarshall(item) as ParticipantProfile,
     );
+    console.log("getParticipants query result", {
+      tenantId,
+      rawCount: profiles.length,
+    });
 
     const participants: ParticipantListItem[] = profiles
       .map((profile) => ({
@@ -125,6 +144,12 @@ export const handler = async (
         const cmp = left.localeCompare(right);
         return sortOrder === "desc" ? -cmp : cmp;
       });
+
+    console.log("getParticipants response", {
+      tenantId,
+      rawCount: profiles.length,
+      filteredCount: participants.length,
+    });
 
     return {
       statusCode: 200,

--- a/backend/src/lambdas/getParticipants/index.ts
+++ b/backend/src/lambdas/getParticipants/index.ts
@@ -16,6 +16,9 @@ type ParticipantListItem = ParticipantProfile & {
   status: ParticipantStatus;
 };
 
+type SortBy = "nickname" | "userId" | "email" | "status";
+type SortOrder = "asc" | "desc";
+
 export const handler = async (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
@@ -37,6 +40,31 @@ export const handler = async (
 
   const { tenantId, userId } = getTenantContext(event);
   const search = (event.queryStringParameters?.search || "").trim().toLowerCase();
+  const statusFilter = (event.queryStringParameters?.status || "").trim().toLowerCase();
+  const hasEmailFilter = (event.queryStringParameters?.hasEmail || "").trim().toLowerCase();
+  const sortByRaw = (event.queryStringParameters?.sortBy || "nickname").trim();
+  const sortOrderRaw = (event.queryStringParameters?.sortOrder || "asc").trim().toLowerCase();
+
+  const sortBy: SortBy =
+    sortByRaw === "nickname" || sortByRaw === "userId" || sortByRaw === "email" || sortByRaw === "status"
+      ? sortByRaw
+      : "nickname";
+  const sortOrder: SortOrder = sortOrderRaw === "desc" ? "desc" : "asc";
+
+  const allowedStatuses: ParticipantStatus[] = ["no_login", "invited", "active"];
+  if (statusFilter && !allowedStatuses.includes(statusFilter as ParticipantStatus)) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Invalid status filter" }),
+    };
+  }
+  if (hasEmailFilter && hasEmailFilter !== "true" && hasEmailFilter !== "false") {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Invalid hasEmail filter" }),
+    };
+  }
+
   if (!userId) {
     return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
   }
@@ -66,20 +94,37 @@ export const handler = async (
       unmarshall(item) as ParticipantProfile,
     );
 
-    const filtered = search
-      ? profiles.filter((p) => {
-          const userId = (p.userId || "").toLowerCase();
-          const email = (p.email || "").toLowerCase();
-          return userId.includes(search) || email.includes(search);
-        })
-      : profiles;
-
-    const participants: ParticipantListItem[] = filtered
+    const participants: ParticipantListItem[] = profiles
       .map((profile) => ({
         ...profile,
         status: deriveParticipantStatus(profile),
       }))
-      .sort((a, b) => a.userId.localeCompare(b.userId));
+      .filter((p) => {
+        if (search) {
+          const participantUserId = (p.userId || "").toLowerCase();
+          const participantEmail = (p.email || "").toLowerCase();
+          if (!participantUserId.includes(search) && !participantEmail.includes(search)) return false;
+        }
+
+        if (statusFilter && p.status !== statusFilter) return false;
+
+        if (hasEmailFilter === "true" && !(p.email && p.email.trim())) return false;
+        if (hasEmailFilter === "false" && !!(p.email && p.email.trim())) return false;
+
+        return true;
+      })
+      .sort((a, b) => {
+        const getSortValue = (item: ParticipantListItem): string => {
+          if (sortBy === "nickname" || sortBy === "userId") return item.userId || "";
+          if (sortBy === "email") return item.email || "";
+          return item.status;
+        };
+
+        const left = getSortValue(a).toLowerCase();
+        const right = getSortValue(b).toLowerCase();
+        const cmp = left.localeCompare(right);
+        return sortOrder === "desc" ? -cmp : cmp;
+      });
 
     return {
       statusCode: 200,

--- a/backend/src/lambdas/getParticipants/index.ts
+++ b/backend/src/lambdas/getParticipants/index.ts
@@ -1,14 +1,12 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { GetItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import {
-  type Tenant,
   type ParticipantProfile,
   type ParticipantStatus,
-  type UserTenantMembership,
 } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
-import { canManageParticipants } from "../shared/permissions";
+import { canActorManageParticipants } from "../shared/participantAuthorization";
 import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
@@ -44,32 +42,14 @@ export const handler = async (
   }
 
   try {
-    const membershipResp = await client.send(
-      new GetItemCommand({
-        TableName: membershipsTable,
-        Key: {
-          tenantId: { S: tenantId },
-          userId: { S: userId },
-        },
-        ConsistentRead: true,
-      }),
-    );
-    const membership = membershipResp.Item
-      ? (unmarshall(membershipResp.Item) as UserTenantMembership)
-      : undefined;
-    if (!membership) {
-      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
-    }
-
-    const tenantResp = await client.send(
-      new GetItemCommand({
-        TableName: tenantsTable,
-        Key: { tenantId: { S: tenantId } },
-        ConsistentRead: true,
-      }),
-    );
-    const tenant = tenantResp.Item ? (unmarshall(tenantResp.Item) as Tenant) : undefined;
-    if (!canManageParticipants(membership, tenant?.settings)) {
+    const canManage = await canActorManageParticipants({
+      client,
+      membershipsTable,
+      tenantsTable,
+      tenantId,
+      actorUserId: userId,
+    });
+    if (!canManage) {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
     }
 

--- a/backend/src/lambdas/getParticipants/index.ts
+++ b/backend/src/lambdas/getParticipants/index.ts
@@ -1,22 +1,18 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { GetItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import {
+  type Tenant,
   type ParticipantProfile,
   type ParticipantStatus,
+  type UserTenantMembership,
 } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
+import { canManageParticipants } from "../shared/permissions";
+import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
-
-function deriveParticipantStatus(
-  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
-): ParticipantStatus {
-  if (profile.authUserId) return "active";
-  if (profile.inviteSentAt) return "invited";
-  return "no_login";
-}
 
 type ParticipantListItem = ParticipantProfile & {
   status: ParticipantStatus;
@@ -26,17 +22,57 @@ export const handler = async (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
   const tableName = process.env.PARTICIPANTS_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const tenantsTable = process.env.TENANTS_TABLE;
   if (!tableName) {
     return {
       statusCode: 500,
       body: JSON.stringify({ error: "PARTICIPANTS_TABLE env var is not set" }),
     };
   }
+  if (!membershipsTable || !tenantsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "MEMBERSHIPS_TABLE or TENANTS_TABLE env var is not set" }),
+    };
+  }
 
-  const { tenantId } = getTenantContext(event);
+  const { tenantId, userId } = getTenantContext(event);
   const search = (event.queryStringParameters?.search || "").trim().toLowerCase();
+  if (!userId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
 
   try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: userId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const membership = membershipResp.Item
+      ? (unmarshall(membershipResp.Item) as UserTenantMembership)
+      : undefined;
+    if (!membership) {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const tenantResp = await client.send(
+      new GetItemCommand({
+        TableName: tenantsTable,
+        Key: { tenantId: { S: tenantId } },
+        ConsistentRead: true,
+      }),
+    );
+    const tenant = tenantResp.Item ? (unmarshall(tenantResp.Item) as Tenant) : undefined;
+    if (!canManageParticipants(membership, tenant?.settings)) {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
     const result = await client.send(
       new QueryCommand({
         TableName: tableName,

--- a/backend/src/lambdas/shared/participantAuthorization.ts
+++ b/backend/src/lambdas/shared/participantAuthorization.ts
@@ -1,0 +1,50 @@
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import type { Tenant, UserTenantMembership } from "@yogaswap/shared";
+import { canManageParticipants } from "./permissions";
+
+type DynamoSender = {
+  send: (command: GetItemCommand) => Promise<{ Item?: Record<string, unknown> }>;
+};
+
+/**
+ * Gemeinsamer AuthZ-Check fuer Participant-Endpunkte.
+ * Laedt Membership + Tenant und prueft danach zentral die Berechtigung
+ * via `canManageParticipants`.
+ */
+export async function canActorManageParticipants(params: {
+  client: DynamoSender;
+  membershipsTable: string;
+  tenantsTable: string;
+  tenantId: string;
+  actorUserId: string;
+}): Promise<boolean> {
+  const membershipResp = await params.client.send(
+    new GetItemCommand({
+      TableName: params.membershipsTable,
+      Key: {
+        tenantId: { S: params.tenantId },
+        userId: { S: params.actorUserId },
+      },
+      ConsistentRead: true,
+    }),
+  );
+
+  const membership = membershipResp.Item
+    ? (unmarshall(membershipResp.Item as Record<string, { S: string }>) as UserTenantMembership)
+    : undefined;
+  if (!membership) return false;
+
+  const tenantResp = await params.client.send(
+    new GetItemCommand({
+      TableName: params.tenantsTable,
+      Key: { tenantId: { S: params.tenantId } },
+      ConsistentRead: true,
+    }),
+  );
+  const tenant = tenantResp.Item
+    ? (unmarshall(tenantResp.Item as Record<string, { S: string }>) as Tenant)
+    : undefined;
+
+  return canManageParticipants(membership, tenant?.settings);
+}

--- a/backend/src/lambdas/shared/participantStatus.ts
+++ b/backend/src/lambdas/shared/participantStatus.ts
@@ -1,0 +1,14 @@
+import type { ParticipantProfile, ParticipantStatus } from "@yogaswap/shared";
+
+/**
+ * Zentrale Ableitung des ParticipantStatus fuer Backend-Lambdas.
+ * Wird von mehreren Endpunkten verwendet, damit die Statuslogik
+ * nicht pro Lambda dupliziert wird.
+ */
+export function deriveParticipantStatus(
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+): ParticipantStatus {
+  if (profile.authUserId) return "active";
+  if (profile.inviteSentAt) return "invited";
+  return "no_login";
+}

--- a/backend/src/lambdas/shared/permissions.ts
+++ b/backend/src/lambdas/shared/permissions.ts
@@ -1,0 +1,18 @@
+import type { TenantSettings, UserTenantMembership } from "@yogaswap/shared";
+
+/**
+ * Technische Kopie von `shared/src/permissions.ts`.
+ * Grund: Value-Import aus `@yogaswap/shared` fuehrt im Backend-Testsetup aktuell
+ * zu ESM/Jest-Interop-Problemen. Diese Datei kann entfallen, sobald die
+ * Toolchain vereinheitlicht ist.
+ */
+export function canManageParticipants(
+  membership: UserTenantMembership,
+  settings: TenantSettings | undefined,
+): boolean {
+  if (membership.role === "admin") return true;
+  if (membership.role === "instructor") {
+    return settings?.instructorCanManageParticipants ?? true;
+  }
+  return false;
+}

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -18,7 +18,12 @@ describe("updateParticipant Lambda", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...OLD_ENV, PARTICIPANTS_TABLE: "test-participants" };
+    process.env = {
+      ...OLD_ENV,
+      PARTICIPANTS_TABLE: "test-participants",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      TENANTS_TABLE: "test-tenants",
+    };
     mockSend.mockReset();
   });
 
@@ -31,12 +36,25 @@ describe("updateParticipant Lambda", () => {
       headers: {},
       pathParameters: { userId: "alice" },
       body: JSON.stringify({ email: "alice+new@example.com" }),
-      requestContext: {} as any,
+      requestContext: { authorizer: { principalId: "admin" } } as any,
       ...overrides,
     } as any);
 
   test("updates participant profile successfully", async () => {
     mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Demo" },
+        },
+      })
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
@@ -53,23 +71,45 @@ describe("updateParticipant Lambda", () => {
     expect(body.email).toBe("alice+new@example.com");
     expect(body.userId).toBe("alice");
     expect(body.status).toBe("no_login");
-    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(mockSend).toHaveBeenCalledTimes(4);
   });
 
   test("returns 404 if participant does not exist", async () => {
-    mockSend.mockResolvedValueOnce({ Item: undefined });
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(404);
     expect(JSON.parse(result.body).error).toBe("Participant not found");
   });
 
   test("returns 400 for invalid settings payload", async () => {
-    mockSend.mockResolvedValueOnce({
-      Item: {
-        tenantId: { S: "default-tenant" },
-        userId: { S: "alice" },
-      },
-    });
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+        },
+      });
 
     const result = await handler(
       makeEvent({
@@ -83,6 +123,16 @@ describe("updateParticipant Lambda", () => {
 
   test("derives invited/active status when inviteSentAt/authUserId are set", async () => {
     mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
@@ -105,6 +155,16 @@ describe("updateParticipant Lambda", () => {
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
           inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
         },
@@ -119,6 +179,40 @@ describe("updateParticipant Lambda", () => {
 
     expect(resultActive.statusCode).toBe(200);
     expect(JSON.parse(resultActive.body).status).toBe("active");
+  });
+
+  test("returns 403 when membership is missing", async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(403);
+  });
+
+  test("returns 403 when instructor is disabled by tenant setting", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          settings: {
+            M: {
+              instructorCanManageParticipants: { BOOL: false },
+            },
+          },
+        },
+      });
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+      }),
+    );
+    expect(result.statusCode).toBe(403);
   });
 });
 

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -7,11 +7,9 @@ import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import type {
   ParticipantProfile,
   ParticipantSettings,
-  Tenant,
-  UserTenantMembership,
 } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
-import { canManageParticipants } from "../shared/permissions";
+import { canActorManageParticipants } from "../shared/participantAuthorization";
 import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
@@ -74,32 +72,14 @@ export const handler = async (
   }
 
   try {
-    const membershipResp = await client.send(
-      new GetItemCommand({
-        TableName: membershipsTable,
-        Key: {
-          tenantId: { S: tenantId },
-          userId: { S: actorUserId },
-        },
-        ConsistentRead: true,
-      }),
-    );
-    const membership = membershipResp.Item
-      ? (unmarshall(membershipResp.Item) as UserTenantMembership)
-      : undefined;
-    if (!membership) {
-      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
-    }
-
-    const tenantResp = await client.send(
-      new GetItemCommand({
-        TableName: tenantsTable,
-        Key: { tenantId: { S: tenantId } },
-        ConsistentRead: true,
-      }),
-    );
-    const tenant = tenantResp.Item ? (unmarshall(tenantResp.Item) as Tenant) : undefined;
-    if (!canManageParticipants(membership, tenant?.settings)) {
+    const canManage = await canActorManageParticipants({
+      client,
+      membershipsTable,
+      tenantsTable,
+      tenantId,
+      actorUserId,
+    });
+    if (!canManage) {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
     }
 

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -7,9 +7,12 @@ import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import type {
   ParticipantProfile,
   ParticipantSettings,
-  ParticipantStatus,
+  Tenant,
+  UserTenantMembership,
 } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
+import { canManageParticipants } from "../shared/permissions";
+import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
@@ -21,22 +24,22 @@ type UpdateParticipantBody = {
   authUserId?: string | null;
 };
 
-function deriveParticipantStatus(
-  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
-): ParticipantStatus {
-  if (profile.authUserId) return "active";
-  if (profile.inviteSentAt) return "invited";
-  return "no_login";
-}
-
 export const handler = async (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
   const tableName = process.env.PARTICIPANTS_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const tenantsTable = process.env.TENANTS_TABLE;
   if (!tableName) {
     return {
       statusCode: 500,
       body: JSON.stringify({ error: "PARTICIPANTS_TABLE env var is not set" }),
+    };
+  }
+  if (!membershipsTable || !tenantsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "MEMBERSHIPS_TABLE or TENANTS_TABLE env var is not set" }),
     };
   }
 
@@ -65,9 +68,41 @@ export const handler = async (
     };
   }
 
-  const { tenantId } = getTenantContext(event);
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
 
   try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const membership = membershipResp.Item
+      ? (unmarshall(membershipResp.Item) as UserTenantMembership)
+      : undefined;
+    if (!membership) {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const tenantResp = await client.send(
+      new GetItemCommand({
+        TableName: tenantsTable,
+        Key: { tenantId: { S: tenantId } },
+        ConsistentRead: true,
+      }),
+    );
+    const tenant = tenantResp.Item ? (unmarshall(tenantResp.Item) as Tenant) : undefined;
+    if (!canManageParticipants(membership, tenant?.settings)) {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
     const existingResp = await client.send(
       new GetItemCommand({
         TableName: tableName,

--- a/projects/modules/apigatewayv2/main.tf
+++ b/projects/modules/apigatewayv2/main.tf
@@ -9,10 +9,28 @@ resource "aws_apigatewayv2_api" "this" {
   }
 }
 
+locals {
+  use_jwt_authorizer = var.jwt_issuer != "" && length(var.jwt_audience) > 0
+}
+
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.this.id
   name        = "$default"
   auto_deploy = true
+}
+
+resource "aws_apigatewayv2_authorizer" "jwt" {
+  count = local.use_jwt_authorizer ? 1 : 0
+
+  api_id           = aws_apigatewayv2_api.this.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "${var.name}-jwt-authorizer"
+
+  jwt_configuration {
+    issuer   = var.jwt_issuer
+    audience = var.jwt_audience
+  }
 }
 
 resource "aws_apigatewayv2_integration" "lambda" {
@@ -32,6 +50,8 @@ resource "aws_apigatewayv2_route" "this" {
   #route_key = "${each.value.method} ${each.key}"
   route_key = each.key
   target    = "integrations/${aws_apigatewayv2_integration.lambda[each.key].id}"
+  authorization_type = local.use_jwt_authorizer && contains(var.protected_routes, each.key) ? "JWT" : "NONE"
+  authorizer_id      = local.use_jwt_authorizer && contains(var.protected_routes, each.key) ? aws_apigatewayv2_authorizer.jwt[0].id : null
 }
 
 resource "aws_lambda_permission" "apigw" {

--- a/projects/modules/apigatewayv2/variables.tf
+++ b/projects/modules/apigatewayv2/variables.tf
@@ -12,3 +12,21 @@ variable "lambda_arns" {
   description = "Map von Lambda-Namen zu ihren ARNs"
   type        = map(string)
 }
+
+variable "jwt_issuer" {
+  description = "JWT issuer URL (z. B. Cognito User Pool issuer)"
+  type        = string
+  default     = ""
+}
+
+variable "jwt_audience" {
+  description = "JWT audience (z. B. Cognito App Client ID)"
+  type        = list(string)
+  default     = []
+}
+
+variable "protected_routes" {
+  description = "Routen, die JWT-Auth erzwingen (route_key-Format: 'METHOD /path')"
+  type        = list(string)
+  default     = []
+}

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -145,7 +145,13 @@ resource "aws_cloudfront_distribution" "spa" {
       cookies { 
         forward = "none" 
       }
-      headers      = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]
+      headers = [
+        "Authorization",
+        "x-tenant-id",
+        "Origin",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+      ]
     }
 
     compress = true

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -87,6 +87,13 @@ resource "aws_cloudfront_distribution" "spa" {
       cookies {
         forward = "none"
       }
+      headers = [
+        "Authorization",
+        "x-tenant-id",
+        "Origin",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+      ]
     }
     compress = true
   }

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -246,6 +246,16 @@ module "yogaswap_api" {
   name        = "${var.project}-api"
   lambda_arns = local.lambda_arns
   routes      = local.api_routes
+  jwt_issuer  = "https://cognito-idp.${var.region}.amazonaws.com/${aws_cognito_user_pool.yogaswap.id}"
+  jwt_audience = [
+    aws_cognito_user_pool_client.yogaswap_app.id,
+  ]
+  protected_routes = [
+    "GET /participants",
+    "PUT /participants/{userId}",
+    "POST /participants",
+    "GET /tenant-context",
+  ]
 }
 #---------------cloudfront------------------
 

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -140,10 +140,12 @@ locals {
     "get_participants" = {
       name             = "get-participants"
       file_name        = "getParticipants.zip"
-      table_arns       = [module.participants_table.table_arn]
-      dynamodb_actions = ["dynamodb:Query"]
+      table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
+      dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem"]
       tables = {
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "TENANTS_TABLE"      = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -151,10 +153,12 @@ locals {
     "update_participant" = {
       name             = "update-participant"
       file_name        = "updateParticipant.zip"
-      table_arns       = [module.participants_table.table_arn]
+      table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
       dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
       tables = {
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "TENANTS_TABLE"      = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []

--- a/shared/src/permissions.ts
+++ b/shared/src/permissions.ts
@@ -5,6 +5,16 @@ import type {
 } from "./types";
 
 /**
+ * Hinweis:
+ * Diese Datei ist die fachliche Source-of-Truth fuer Permissions.
+ * Aktuell existiert zusaetzlich eine technische Kopie in
+ * `backend/src/lambdas/shared/permissions.ts`, damit Backend-Tests/Lambda-Bundles
+ * ohne ESM/Jest-Interop-Probleme laufen.
+ * Bei Aenderungen bitte beide Stellen synchron halten, bis die Build-Toolchain
+ * vereinheitlicht ist.
+ */
+
+/**
  * Darf diese Membership Teilnehmer:innen einladen?
  * - Admin: immer ja
  * - Instructor: nur, wenn TenantSettings.instructorCanInviteParticipants === true
@@ -17,6 +27,24 @@ export function canInviteParticipants(
   if (membership.role === "admin") return true;
   if (membership.role === "instructor") {
     return !!settings?.instructorCanInviteParticipants;
+  }
+  return false;
+}
+
+/**
+ * Darf diese Membership Teilnehmerprofile verwalten (Liste/Update)?
+ * - Admin: immer ja
+ * - Instructor: abhängig von TenantSettings.instructorCanManageParticipants
+ *   - undefined => true (Default)
+ * - Participant: nie
+ */
+export function canManageParticipants(
+  membership: UserTenantMembership,
+  settings: TenantSettings | undefined,
+): boolean {
+  if (membership.role === "admin") return true;
+  if (membership.role === "instructor") {
+    return settings?.instructorCanManageParticipants ?? true;
   }
   return false;
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -101,6 +101,11 @@ export interface TenantSettings {
    * Wenn false/undefined: Teilnehmer:innen sehen alle freigeschalteten Kurse des Tenants.
    */
   participantsSeeOnlyOwnInstructors?: boolean;
+  /**
+   * Dürfen Instructor:innen Teilnehmerprofile (Liste/Updates) verwalten?
+   * Default für undefined: true (MVP-freundlich), kann tenant-spezifisch deaktiviert werden.
+   */
+  instructorCanManageParticipants?: boolean;
 }
 
 // Verknüpfung zwischen User und Tenant inkl. Rolle und optionalen Overrides.


### PR DESCRIPTION
## Summary
- implementiert serverseitige Authorization für `GET /participants` und `PUT /participants/{userId}` inkl. strict `403` bei fehlender/unerlaubter Membership
- ergänzt Tenant-Setting `instructorCanManageParticipants` (Default `true`) und zentrale Permission-Logik mit Backend-Refactor (shared helper für AuthZ + Statusableitung)
- ergänzt Validierung + Tests, erweitert `GET /participants` um Filter/Sortierung und stabilisiert den API/Auth-Pfad über CloudFront + API Gateway JWT-Authorizer

## Test plan
- [x] `npm test --prefix backend`
- [x] `npm run lint --prefix backend`
- [x] `npm test --prefix app -- src/api/participants.test.ts src/components/AdminPanel.test.tsx`
- [x] Browser-Smoke-Test über `https://app.yogaswap.de` (participants + tenant-context mit Authorization)

Made with [Cursor](https://cursor.com)