### PR TITLE
#67 Teilnehmer anlegen & bearbeiten (E-Mail optional)

### DIFF
--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import AdminPanel from "./AdminPanel";
-import { getParticipants, inviteUser } from "../api/participants";
+import { getParticipants, inviteUser, updateParticipant } from "../api/participants";
 
 vi.mock("../api/participants", () => ({
   inviteUser: vi.fn(),
@@ -12,6 +12,7 @@ vi.mock("../api/participants", () => ({
 
 const mockedInviteUser = inviteUser as unknown as ReturnType<typeof vi.fn>;
 const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdateParticipant = updateParticipant as unknown as ReturnType<typeof vi.fn>;
 
 describe("AdminPanel", () => {
   beforeEach(() => {
@@ -196,9 +197,83 @@ describe("AdminPanel", () => {
       expect(within(panel).getByText("Teilnehmerin")).toBeInTheDocument();
       expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
       expect(within(panel).getByLabelText("Status: ohne Login")).toBeInTheDocument();
-      expect(within(panel).getByLabelText("Bearbeiten alice")).toBeDisabled();
+      expect(within(panel).getByLabelText("Bearbeiten alice")).not.toBeDisabled();
       expect(within(panel).getByLabelText("Löschen alice")).toBeDisabled();
     });
+  });
+
+  it("bearbeitet E-Mail eines Teilnehmers über den Stift", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice.new@example.com",
+      status: "no_login",
+    });
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+    fireEvent.change(emailInput, { target: { value: "alice.new@example.com" } });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice.new@example.com" });
+      expect(within(panel).getByText("alice.new@example.com")).toBeInTheDocument();
+    });
+  });
+
+  it("validiert E-Mail Format beim Bearbeiten", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/gültige E-Mail-Adresse/i)).toBeInTheDocument();
+    });
+    expect(mockedUpdateParticipant).not.toHaveBeenCalled();
   });
 
   it("lädt Teilnehmerliste neu mit Suchbegriff", async () => {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -202,6 +202,56 @@ describe("AdminPanel", () => {
     });
   });
 
+  it("legt einen Teilnehmer über + Neu an (Nickname Pflicht, E-Mail optional)", async () => {
+    mockedGetParticipants
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          tenantId: "default-tenant",
+          userId: "alice",
+          role: "participant",
+          email: "alice@example.com",
+          status: "no_login",
+        },
+      ]);
+
+    mockedInviteUser.mockResolvedValueOnce({
+      success: true,
+      emailSent: false,
+    });
+
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice@example.com",
+      status: "no_login",
+    });
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice@example.com" },
+    });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Anlegen$/i }));
+
+    await waitFor(() => {
+      expect(mockedInviteUser).toHaveBeenCalledWith({ nickname: "alice", role: "participant" });
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice@example.com" });
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+  });
+
   it("bearbeitet E-Mail eines Teilnehmers über den Stift", async () => {
     mockedGetParticipants.mockResolvedValueOnce([
       {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -3,6 +3,7 @@ import { Pencil, Plus, Trash2 } from "lucide-react";
 import {
   getParticipants,
   inviteUser,
+  updateParticipant,
   type ParticipantWithStatus,
 } from "../api/participants";
 import type { UserRole } from "shared/types";
@@ -44,6 +45,33 @@ export default function AdminPanel() {
   const [participantsLoading, setParticipantsLoading] = useState(false);
   const [participantsError, setParticipantsError] = useState("");
   const [participantsSearch, setParticipantsSearch] = useState("");
+
+  const [editingUserId, setEditingUserId] = useState<string | null>(null);
+  const [editingEmail, setEditingEmail] = useState("");
+  const [editingSaving, setEditingSaving] = useState(false);
+  const [editingError, setEditingError] = useState("");
+
+  const refreshParticipants = async () => {
+    setParticipantsLoading(true);
+    setParticipantsError("");
+    try {
+      const searchValue = participantsSearch.trim();
+      const list = await getParticipants(
+        searchValue
+          ? {
+              search: searchValue,
+            }
+          : undefined,
+      );
+      const safeList = Array.isArray(list) ? list : [];
+      setParticipants(safeList);
+    } catch (err) {
+      console.error("Failed to load participants", err);
+      setParticipantsError("Konnte Teilnehmer nicht laden.");
+    } finally {
+      setParticipantsLoading(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -88,6 +116,8 @@ export default function AdminPanel() {
     setMessage("");
     setError("");
 
+    let inviteSucceeded = false;
+
     try {
       const effectiveRole = foreignManaged ? "participant" : role;
       const payload = foreignManaged
@@ -99,6 +129,7 @@ export default function AdminPanel() {
       if (result.error === "Nickname already exists") {
         setError("Dieser Spitzname ist bereits vergeben.");
       } else if (result.success) {
+        inviteSucceeded = true;
         if (foreignManaged) {
           setMessage(
             `✅ Teilnehmer '${nickname}' wurde ohne Login angelegt.\n` +
@@ -128,9 +159,57 @@ export default function AdminPanel() {
     } finally {
       setLoading(false);
     }
+
+    // Zwischenschritt: Liste nach erfolgreichem Anlegen/Einladen aktualisieren,
+    // damit die gespeicherte E-Mail sofort sichtbar ist.
+    if (inviteSucceeded) await refreshParticipants();
   };
 
   const safeParticipants = Array.isArray(participants) ? participants : [];
+
+  const startEditEmail = (p: ParticipantWithStatus) => {
+    setEditingUserId(p.userId);
+    setEditingEmail(p.email ?? "");
+    setEditingError("");
+    setEditingSaving(false);
+  };
+
+  const saveEditEmail = async () => {
+    if (!editingUserId) return;
+    setEditingSaving(true);
+    setEditingError("");
+    try {
+      const trimmed = editingEmail.trim();
+      const isValidEmailOrEmpty =
+        trimmed.length === 0 || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
+      if (!isValidEmailOrEmpty) {
+        setEditingError("Bitte eine gültige E-Mail-Adresse eingeben (oder leer lassen).");
+        return;
+      }
+      const nextEmail = trimmed.length > 0 ? trimmed : null;
+
+      await updateParticipant(editingUserId, { email: nextEmail });
+
+      // Lokales Update reicht für diesen Zwischen-Use-Case.
+      setParticipants((prev) =>
+        prev.map((p) =>
+          p.userId === editingUserId
+            ? {
+                ...p,
+                email: nextEmail ?? undefined,
+              }
+            : p,
+        ),
+      );
+
+      setEditingUserId(null);
+    } catch (err) {
+      console.error("Failed to update participant email", err);
+      setEditingError("E-Mail konnte nicht gespeichert werden.");
+    } finally {
+      setEditingSaving(false);
+    }
+  };
   
   return (
     <div className="admin-panel">
@@ -283,7 +362,13 @@ export default function AdminPanel() {
                   </span>
                   <span style={{ color: p.email ? "#111827" : "#9ca3af" }}>{p.email ?? "-"}</span>
                   <div style={{ display: "flex", gap: "0.25rem", justifyContent: "flex-end" }}>
-                    <button type="button" title={`Bearbeiten ${p.userId}`} aria-label={`Bearbeiten ${p.userId}`} disabled>
+                    <button
+                      type="button"
+                      title={`Bearbeiten ${p.userId}`}
+                      aria-label={`Bearbeiten ${p.userId}`}
+                      disabled={participantsLoading || editingSaving}
+                      onClick={() => startEditEmail(p)}
+                    >
                       <Pencil size={14} aria-hidden="true" />
                     </button>
                     <button type="button" title={`Löschen ${p.userId}`} aria-label={`Löschen ${p.userId}`} disabled>
@@ -297,6 +382,46 @@ export default function AdminPanel() {
           </div>
         )}
       </div>
+
+      {editingUserId && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Teilnehmer E-Mail bearbeiten">
+          <div className="modal">
+            <h4>Teilnehmer bearbeiten</h4>
+            <p style={{ marginTop: 0, color: "#4b5563" }}>
+              User: <strong>{editingUserId}</strong>
+            </p>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <label>
+                E-Mail
+                <input
+                  type="email"
+                  placeholder="E-Mail"
+                  value={editingEmail}
+                  onChange={(e) => setEditingEmail(e.target.value)}
+                  disabled={editingSaving}
+                  style={{ width: "100%", padding: "0.5rem", borderRadius: 8, border: "1px solid #ddd", fontSize: 16 }}
+                />
+              </label>
+              {editingError && <p style={{ color: "crimson", margin: 0 }}>{editingError}</p>}
+            </div>
+
+            <div className="modal-actions">
+              <button type="button" onClick={() => setEditingUserId(null)} disabled={editingSaving}>
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={saveEditEmail}
+                disabled={editingSaving}
+              >
+                {editingSaving ? "Speichere..." : "Speichern"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -51,6 +51,15 @@ export default function AdminPanel() {
   const [editingSaving, setEditingSaving] = useState(false);
   const [editingError, setEditingError] = useState("");
 
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createNickname, setCreateNickname] = useState("");
+  const [createEmail, setCreateEmail] = useState("");
+  const [createRole, setCreateRole] = useState<"participant" | "instructor" | "admin">(
+    "participant",
+  );
+  const [createSaving, setCreateSaving] = useState(false);
+  const [createError, setCreateError] = useState("");
+
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
     setParticipantsError("");
@@ -210,6 +219,58 @@ export default function AdminPanel() {
       setEditingSaving(false);
     }
   };
+
+  const openCreate = () => {
+    setCreateOpen(true);
+    setCreateNickname("");
+    setCreateEmail("");
+    setCreateRole("participant");
+    setCreateError("");
+    setCreateSaving(false);
+  };
+
+  const saveCreate = async () => {
+    const nicknameValue = createNickname.trim();
+    const emailValue = createEmail.trim();
+    if (!nicknameValue) {
+      setCreateError("Bitte einen Nickname eingeben.");
+      return;
+    }
+    const isValidEmailOrEmpty =
+      emailValue.length === 0 || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue);
+    if (!isValidEmailOrEmpty) {
+      setCreateError("Bitte eine gültige E-Mail-Adresse eingeben (oder leer lassen).");
+      return;
+    }
+
+    setCreateSaving(true);
+    setCreateError("");
+    try {
+      // #67: Teilnehmer anlegen ohne Einladung (kein Cognito/SES).
+      // Wir legen zunächst ohne E-Mail an, speichern E-Mail (falls vorhanden) danach separat im Profil.
+      const result = await inviteUser({ nickname: nicknameValue, role: createRole });
+      if (result.error === "Nickname already exists") {
+        setCreateError("Dieser Spitzname ist bereits vergeben.");
+        return;
+      }
+      if (!result.success) {
+        setCreateError("Teilnehmer konnte nicht angelegt werden.");
+        return;
+      }
+
+      if (emailValue.length > 0) {
+        await updateParticipant(nicknameValue, { email: emailValue });
+      }
+
+      setCreateOpen(false);
+      await refreshParticipants();
+    } catch (err) {
+      console.error("Failed to create participant", err);
+      setCreateError("Teilnehmer konnte nicht angelegt werden.");
+    } finally {
+      setCreateSaving(false);
+    }
+  };
   
   return (
     <div className="admin-panel">
@@ -285,7 +346,13 @@ export default function AdminPanel() {
       <div style={{ marginTop: "1rem", paddingTop: "1rem", borderTop: "1px solid #eee" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.5rem" }}>
           <h3 style={{ margin: 0 }}>Teilnehmer verwalten</h3>
-          <button type="button" title="Neuer Teilnehmer (folgt)" aria-label="Neuer Teilnehmer" disabled>
+          <button
+            type="button"
+            title="Neuer Teilnehmer"
+            aria-label="Neuer Teilnehmer"
+            onClick={openCreate}
+            disabled={createSaving || editingSaving}
+          >
             <span style={{ display: "inline-flex", alignItems: "center", gap: "0.25rem" }}>
               <Plus size={16} aria-hidden="true" />
               Neu
@@ -417,6 +484,90 @@ export default function AdminPanel() {
                 disabled={editingSaving}
               >
                 {editingSaving ? "Speichere..." : "Speichern"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {createOpen && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Teilnehmer anlegen">
+          <div className="modal">
+            <h4>Teilnehmer anlegen</h4>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <label>
+                Nickname
+                <input
+                  type="text"
+                  placeholder="Spitzname"
+                  value={createNickname}
+                  onChange={(e) => setCreateNickname(e.target.value)}
+                  disabled={createSaving}
+                  style={{
+                    width: "100%",
+                    padding: "0.5rem",
+                    borderRadius: 8,
+                    border: "1px solid #ddd",
+                    fontSize: 16,
+                  }}
+                />
+              </label>
+
+              <label>
+                E-Mail (optional)
+                <input
+                  type="email"
+                  placeholder="E-Mail"
+                  value={createEmail}
+                  onChange={(e) => setCreateEmail(e.target.value)}
+                  disabled={createSaving}
+                  style={{
+                    width: "100%",
+                    padding: "0.5rem",
+                    borderRadius: 8,
+                    border: "1px solid #ddd",
+                    fontSize: 16,
+                  }}
+                />
+              </label>
+
+              <label>
+                Rolle
+                <select
+                  value={createRole}
+                  onChange={(e) =>
+                    setCreateRole(e.target.value as "participant" | "instructor" | "admin")
+                  }
+                  disabled={createSaving}
+                  style={{
+                    width: "100%",
+                    padding: "0.5rem",
+                    borderRadius: 8,
+                    border: "1px solid #ddd",
+                    fontSize: 16,
+                  }}
+                >
+                  <option value="participant">Teilnehmer</option>
+                  <option value="instructor">Kursleiter</option>
+                  <option value="admin">Admin</option>
+                </select>
+              </label>
+
+              {createError && <p style={{ color: "crimson", margin: 0 }}>{createError}</p>}
+            </div>
+
+            <div className="modal-actions">
+              <button type="button" onClick={() => setCreateOpen(false)} disabled={createSaving}>
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={saveCreate}
+                disabled={createSaving}
+              >
+                {createSaving ? "Lege an..." : "Anlegen"}
               </button>
             </div>
           </div>

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -4,6 +4,7 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { signIn, confirmSignIn, fetchAuthSession } from "@aws-amplify/auth";
 import { saveCurrentUser } from "shared/lib/storage";
 import { User, UserRole } from "shared/types";
+import { updateParticipant } from "../api/participants";
 
 export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   const [searchParams] = useSearchParams();
@@ -82,6 +83,17 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
         };
         saveCurrentUser(user);
         console.log('User nach Passwort-Setzen gespeichert:', user);
+
+        // After an invite user completes sign-up, link their Cognito `sub` to the
+        // corresponding participant profile so the status moves invited -> active.
+        const sub = payload.sub as string | undefined;
+        if (typeof sub === "string" && sub.trim()) {
+          try {
+            await updateParticipant(user.nickname, { authUserId: sub });
+          } catch (err) {
+            console.error("Failed to link participant authUserId", err);
+          }
+        }
       }
 
       // success

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -214,5 +214,42 @@ describe("updateParticipant Lambda", () => {
     );
     expect(result.statusCode).toBe(403);
   });
+
+  test("allows self-linking authUserId when participant links their own sub", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "alice" } } as any,
+        body: JSON.stringify({ authUserId: "cognito-sub-123" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).status).toBe("active");
+    // Only: 1) existing participant lookup + 2) PutItem
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects self-linking when other fields are present", async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined }); // membership lookup -> forbidden
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "alice" } } as any,
+        body: JSON.stringify({ authUserId: "cognito-sub-123", email: "x@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(403);
+  });
 });
 

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -72,15 +72,31 @@ export const handler = async (
   }
 
   try {
-    const canManage = await canActorManageParticipants({
-      client,
-      membershipsTable,
-      tenantsTable,
-      tenantId,
-      actorUserId,
-    });
-    if (!canManage) {
-      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    const hasAuthUserId =
+      Object.prototype.hasOwnProperty.call(body, "authUserId") &&
+      typeof body.authUserId === "string" &&
+      body.authUserId.trim().length > 0;
+
+    const hasOtherMutationKeys =
+      Object.prototype.hasOwnProperty.call(body, "email") ||
+      Object.prototype.hasOwnProperty.call(body, "settings") ||
+      Object.prototype.hasOwnProperty.call(body, "inviteSentAt");
+
+    // Allow a participant to self-link their own Cognito `sub` once after sign-up.
+    // This is required for participants created via invitation to move from "invited" -> "active".
+    const isSelfAuthLink = actorUserId === userId && hasAuthUserId && !hasOtherMutationKeys;
+
+    if (!isSelfAuthLink) {
+      const canManage = await canActorManageParticipants({
+        client,
+        membershipsTable,
+        tenantsTable,
+        tenantId,
+        actorUserId,
+      });
+      if (!canManage) {
+        return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+      }
     }
 
     const existingResp = await client.send(


### PR DESCRIPTION
## Summary
- AdminPanel: Teilnehmer in der Liste anlegen ("+ Neu") mit Nickname-Pflicht und optionaler E-Mail
- AdminPanel: Teilnehmer-E-Mail über den Stift bearbeiten (Modal + Speichern) inkl. E-Mail-Validierung
- Invite-Flow: nach Passwort-Setup wird `authUserId` (Cognito `sub`) ins Teilnehmerprofil gelinkt, damit Status von "eingeladen" auf "registriert" wechselt
- Backend: `PUT /participants/{userId}` erlaubt Self-Linking von `authUserId` (nur für den eigenen User und ohne weitere Mutationen)

## Test plan
- [x] `npm test --prefix app -- AdminPanel.test.tsx`
- [x] `npm test --prefix backend -- updateParticipant/index.test.ts`
- [x] `npm run lint --prefix app`
- [ ] manuell: "+ Neu" → anlegen → Teilnehmer erscheint in Liste
- [ ] manuell: Stift → E-Mail ändern → speichern → E-Mail in Liste aktualisiert

Made with [Cursor](https://cursor.com)