### PR TITLE
#78 Teilnehmer bearbeiten: Rollenfeld im Dialog (nur Admin)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -147,7 +147,7 @@ function MainApp() {
 
       {currentUser && canInvite && (
         <section className="main-section main-section-admin">
-          <AdminPanel />
+          <AdminPanel canEditRoles={(membership?.role ?? currentUser.role) === "admin"} />
         </section>
       )}
 

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -23,6 +23,7 @@ export type ParticipantWithStatus = ParticipantProfile & { status: ParticipantSt
 
 export interface UpdateParticipantRequest {
   email?: string | null;
+  role?: UserRole;
   settings?: ParticipantSettings;
   inviteSentAt?: string | null;
   authUserId?: string | null;

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -430,6 +430,50 @@ describe("AdminPanel", () => {
     });
   });
 
+  it("zeigt Rollenfeld im Bearbeiten-Dialog nur fuer Admin und speichert Rolle mit", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "instructor",
+      email: "alice@example.com",
+      status: "no_login",
+    });
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    expect(within(dialog).getByLabelText("Rolle bearbeiten")).toBeInTheDocument();
+
+    fireEvent.change(within(dialog).getByLabelText("Rolle bearbeiten"), {
+      target: { value: "instructor" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", {
+        email: "alice@example.com",
+        role: "instructor",
+      });
+      expect(within(panel).getByText("Kursleitung")).toBeInTheDocument();
+    });
+  });
+
   it("validiert E-Mail Format beim Bearbeiten", async () => {
     mockedGetParticipants.mockResolvedValueOnce([
       {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -14,6 +14,7 @@ const ROLE_LABELS_DE: Record<UserRole, string> = {
   instructor: "Kursleitung",
   participant: "Teilnehmerin",
 };
+const ROLE_OPTIONS: UserRole[] = ["participant", "instructor", "admin"];
 
 function getRoleLabel(role: UserRole | undefined): string {
   if (!role) return "-";
@@ -33,7 +34,11 @@ function getStatusPresentation(status: ParticipantWithStatus["status"]): {
   return { color: "#6b7280", label: "ohne Login" };
 }
 
-export default function AdminPanel() {
+type AdminPanelProps = {
+  canEditRoles?: boolean;
+};
+
+export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [participants, setParticipants] = useState<ParticipantWithStatus[]>([]);
   const [participantsLoading, setParticipantsLoading] = useState(false);
   const [participantsError, setParticipantsError] = useState("");
@@ -41,6 +46,7 @@ export default function AdminPanel() {
 
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const [editingEmail, setEditingEmail] = useState("");
+  const [editingRole, setEditingRole] = useState<UserRole>("participant");
   const [editingSaving, setEditingSaving] = useState(false);
   const [editingError, setEditingError] = useState("");
 
@@ -223,6 +229,7 @@ export default function AdminPanel() {
   const startEditEmail = (p: ParticipantWithStatus) => {
     setEditingUserId(p.userId);
     setEditingEmail(p.email ?? "");
+    setEditingRole(p.role ?? "participant");
     setEditingError("");
     setEditingSaving(false);
   };
@@ -241,7 +248,10 @@ export default function AdminPanel() {
       }
       const nextEmail = trimmed.length > 0 ? trimmed : null;
 
-      await updateParticipant(editingUserId, { email: nextEmail });
+      await updateParticipant(
+        editingUserId,
+        canEditRoles ? { email: nextEmail, role: editingRole } : { email: nextEmail },
+      );
 
       // Lokales Update reicht für diesen Zwischen-Use-Case.
       setParticipants((prev) =>
@@ -250,6 +260,7 @@ export default function AdminPanel() {
             ? {
                 ...p,
                 email: nextEmail ?? undefined,
+                role: canEditRoles ? editingRole : p.role,
               }
             : p,
         ),
@@ -700,6 +711,21 @@ export default function AdminPanel() {
                 disabled={editingSaving}
                 className="dialog-field"
               />
+              {canEditRoles && (
+                <select
+                  aria-label="Rolle bearbeiten"
+                  value={editingRole}
+                  onChange={(e) => setEditingRole(e.target.value as UserRole)}
+                  disabled={editingSaving}
+                  className="dialog-field"
+                >
+                  {ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {ROLE_LABELS_DE[role]}
+                    </option>
+                  ))}
+                </select>
+              )}
               {editingError && <p style={{ color: "crimson", margin: 0 }}>{editingError}</p>}
             </div>
 
@@ -828,9 +854,11 @@ export default function AdminPanel() {
                 disabled={createSaving}
                 className="dialog-field"
               >
-                <option value="participant">Teilnehmer</option>
-                <option value="instructor">Kursleiter</option>
-                <option value="admin">Admin</option>
+                {ROLE_OPTIONS.map((role) => (
+                  <option key={role} value={role}>
+                    {ROLE_LABELS_DE[role]}
+                  </option>
+                ))}
               </select>
 
               {createError && <p style={{ color: "crimson", margin: 0 }}>{createError}</p>}

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -74,6 +74,88 @@ describe("updateParticipant Lambda", () => {
     expect(mockSend).toHaveBeenCalledTimes(4);
   });
 
+  test("updates participant role when actor is admin", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Demo" },
+        },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // actor role check
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+        },
+      }) // target participant
+      .mockResolvedValueOnce({}) // memberships PutItem (role change)
+      .mockResolvedValueOnce({}); // participants PutItem
+
+    const result = await handler(
+      makeEvent({
+        body: JSON.stringify({ role: "instructor" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-memberships",
+        Item: expect.objectContaining({
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          role: { S: "instructor" },
+        }),
+      }),
+    );
+  });
+
+  test("returns 403 when non-admin tries to change role", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }); // actor role check
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+        body: JSON.stringify({ role: "participant" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can change roles/);
+  });
+
   test("returns 404 if participant does not exist", async () => {
     mockSend
       .mockResolvedValueOnce({

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -7,6 +7,7 @@ import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import type {
   ParticipantProfile,
   ParticipantSettings,
+  UserRole,
 } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
 import { canActorManageParticipants } from "../shared/participantAuthorization";
@@ -20,6 +21,7 @@ type UpdateParticipantBody = {
   settings?: ParticipantSettings;
   inviteSentAt?: string | null;
   authUserId?: string | null;
+  role?: UserRole;
 };
 
 export const handler = async (
@@ -80,7 +82,8 @@ export const handler = async (
     const hasOtherMutationKeys =
       Object.prototype.hasOwnProperty.call(body, "email") ||
       Object.prototype.hasOwnProperty.call(body, "settings") ||
-      Object.prototype.hasOwnProperty.call(body, "inviteSentAt");
+      Object.prototype.hasOwnProperty.call(body, "inviteSentAt") ||
+      Object.prototype.hasOwnProperty.call(body, "role");
 
     // Allow a participant to self-link their own Cognito `sub` once after sign-up.
     // This is required for participants created via invitation to move from "invited" -> "active".
@@ -99,6 +102,23 @@ export const handler = async (
       });
       if (!canManage) {
         return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "role")) {
+      const actorMembershipResp = await client.send(
+        new GetItemCommand({
+          TableName: membershipsTable,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: actorUserId },
+          },
+          ConsistentRead: true,
+        }),
+      );
+      const actorMembershipRole = actorMembershipResp.Item?.role?.S;
+      if (actorMembershipRole !== "admin") {
+        return { statusCode: 403, body: JSON.stringify({ error: "Only admins can change roles" }) };
       }
     }
 
@@ -160,6 +180,26 @@ export const handler = async (
       } else {
         delete updated.authUserId;
       }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "role")) {
+      const nextRole = body.role;
+      if (!nextRole || !["admin", "instructor", "participant"].includes(nextRole)) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: "Invalid role value" }),
+        };
+      }
+      await client.send(
+        new PutItemCommand({
+          TableName: membershipsTable,
+          Item: marshall({
+            tenantId,
+            userId,
+            role: nextRole,
+          }),
+        }),
+      );
     }
 
     await client.send(


### PR DESCRIPTION
## Summary
- Erweitert den Dialog **Teilnehmer bearbeiten** um ein Rollenfeld unter der E-Mail, analog zum Dialog **Teilnehmer anlegen**.
- Rollenbearbeitung ist im Frontend nur fuer Admins sichtbar/aktiv (`canEditRoles`) und nutzt zentral `ROLE_LABELS_DE`.
- Backend `updateParticipant` unterstuetzt Rollenupdates inkl. Admin-only-Absicherung und Validierung der erlaubten Rollen.

## Test plan
- [x] `cd backend && npm test -- updateParticipant/index.test.ts`
- [x] `cd app && npm test -- AdminPanel.test.tsx participants.test.ts`
- [ ] Manuell: Als Admin im Bearbeiten-Dialog Rolle aendern und speichern
- [ ] Manuell: Als Nicht-Admin darf im Bearbeiten-Dialog kein Rollenfeld sichtbar sein

## Related
- Closes #78

Made with [Cursor](https://cursor.com)