### PR TITLE
#82 Invite-Flow: Branding + Passwortmanager-kompatibles Setup

### DIFF
--- a/app/src/components/Invite.test.tsx
+++ b/app/src/components/Invite.test.tsx
@@ -30,7 +30,7 @@ function renderWithParams(search: string, onSuccess?: () => void) {
       </Routes>
     </MemoryRouter>,
   );
-  const panels = utils.container.querySelectorAll("div[style*='Passwort-Setup']");
+  const panels = utils.container.querySelectorAll("div[style*='max-width: 480px']");
   const panel = (panels[panels.length - 1] as HTMLElement) ?? utils.container;
   return { ...utils, panel };
 }
@@ -51,7 +51,7 @@ describe("Invite", () => {
     const { panel } = renderWithParams("?nickname=alice");
 
     fireEvent.click(
-      within(panel).getByRole("button", { name: /Passwort setzen/i }),
+      within(panel).getByRole("button", { name: /Zugang aktivieren/i }),
     );
 
     await waitFor(() => {
@@ -70,7 +70,7 @@ describe("Invite", () => {
       { target: { value: "temp-123" } },
     );
     fireEvent.click(
-      within(panel).getByRole("button", { name: /Passwort setzen/i }),
+      within(panel).getByRole("button", { name: /Zugang aktivieren/i }),
     );
 
     await waitFor(() => {
@@ -82,7 +82,7 @@ describe("Invite", () => {
     });
   });
 
-  it("führt den vollständigen Passwort-Setup-Flow aus und speichert den User", async () => {
+  it("führt den vollständigen Zugang-aktivieren-Flow aus und speichert den User", async () => {
     const onSuccess = vi.fn();
 
     mockedSignIn.mockResolvedValue({
@@ -117,7 +117,7 @@ describe("Invite", () => {
     });
 
     fireEvent.click(
-      within(panel).getByRole("button", { name: /Passwort setzen/i }),
+      within(panel).getByRole("button", { name: /Zugang aktivieren/i }),
     );
 
     await waitFor(() => {
@@ -156,7 +156,7 @@ describe("Invite", () => {
     });
 
     fireEvent.click(
-      within(panel).getByRole("button", { name: /Passwort setzen/i }),
+      within(panel).getByRole("button", { name: /Zugang aktivieren/i }),
     );
 
     await waitFor(() => {

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -165,13 +165,42 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
 
   return (
     <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem", border: "1px solid #eee", borderRadius: 8 }}>
-      <h2>Passwort-Setup</h2>
-      {emailDisplay && <p>Für: <strong>{emailDisplay}</strong></p>}
-      <p>Benutzername: <strong>{nicknameParam}</strong></p>
+      <h2>Willkommen bei YogaSwap</h2>
+      <p className="muted" style={{ marginTop: 0 }}>
+        Hallo <strong>{nicknameParam}</strong>,
+      </p>
+      <p className="muted" style={{ marginTop: 0 }}>
+        Aktiviere deinen Zugang mit dem temporaeren Passwort aus der Einladung.
+      </p>
+      {emailDisplay && (
+        <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
+          Einladung gesendet an {emailDisplay}
+        </p>
+      )}
 
       <form onSubmit={handleSubmit} className="invite-form">
+        {/* Password managers need an explicit username field. */}
         <input
           type="text"
+          name="username"
+          autoComplete="username"
+          value={usernameForSignIn}
+          readOnly
+          tabIndex={-1}
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: "-10000px",
+            width: 1,
+            height: 1,
+            opacity: 0,
+            pointerEvents: "none",
+          }}
+        />
+        <input
+          type="password"
+          name="temporary-password"
+          autoComplete="current-password"
           aria-label="Temporäres Passwort"
           value={tempPassword}
           onChange={(e) => setTempPassword(e.target.value.trim())}
@@ -183,6 +212,8 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
 
         <input
           type="password"
+          name="new-password"
+          autoComplete="new-password"
           aria-label="Neues Passwort"
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
@@ -200,7 +231,7 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
           disabled={loading || !authCleared}
           className="btn-primary btn-block"
         >
-          {loading ? "Verarbeite…" : "Passwort setzen"}
+          {loading ? "Verarbeite…" : "Zugang aktivieren"}
         </button>
       </form>
     </div>

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -195,7 +195,7 @@ export const handler = async (event: any) => {
         const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
         const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
         const reactivatedHtml = `
-          <h2>Hi ${nicknameRaw}!</h2>
+          <h2>Hallo ${nicknameRaw}!</h2>
           <p>Dein Zugang zu YogaSwap wurde fuer dieses Studio reaktiviert.</p>
           <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
           <p><a href="${baseUrl}">Zur Anmeldung</a></p>
@@ -362,18 +362,21 @@ export const handler = async (event: any) => {
   // Send invitation email (temp password shown in email body)
   const emailHtml = reactivated
     ? `
-      <h2>Hi ${nicknameRaw}!</h2>
+      <h2>Hallo ${nicknameRaw}!</h2>
       <p>Dein Zugang zu YogaSwap wurde für dieses Studio reaktiviert.</p>
       <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
       <p><a href="${baseUrl}">Zur Anmeldung</a></p>
     `
     : `
-      <h2>Hi ${nicknameRaw}!</h2>
+      <h2>Hallo ${nicknameRaw}!</h2>
       <p>Du wurdest zu YogaSwap eingeladen.</p>
       <p><a href="${link}">Klicke hier, um dein temporäres Passwort einzugeben und ein neues Passwort zu setzen</a></p>
-      <p><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong>
-        <br/><code style="background:#f0f0f0;padding:4px 8px;border-radius:4px;">${rawPassword}</code>
-      </p>
+      <div style="margin-top:12px;">
+        <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
+        <div>
+          <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
+        </div>
+      </div>
       <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
     `;
 


### PR DESCRIPTION
## Summary
- Ueberarbeitet die Invite-Seite mit klarerem YogaSwap-Branding und nutzerfreundlicherem Wording ("Zugang aktivieren" statt technischem Passwort-Setup-Text).
- Verbessert die Passwortmanager-Erkennung durch explizite `autocomplete`/`name`-Felder (`username`, `current-password`, `new-password`), damit der Login-Name korrekt gespeichert wird.
- Vereinheitlicht Ansprache auf "Hallo" und optimiert den Passwort-Block in der Einladungs-Mail fuer stabilere Darstellung in Mail-Clients.

## Test plan
- [x] `cd app && npm test -- Invite.test.tsx`
- [x] `cd backend && npm test -- createParticipants/index.test.ts`
- [ ] Manuell: Invite-Link oeffnen und pruefen, dass Branding/Copy klar auf YogaSwap hinweist
- [ ] Manuell: iCloud/Browser-Passwortmanager pruefen, dass Username statt temporaerem Passwort als Login gespeichert wird
- [ ] Manuell: Einladungs-Mail in Zielclient pruefen (Passwortblock ohne Ueberlappung)

## Related
- Closes #82
- Inhaltliche Erweiterungen fuer Tenant-/Rechts-/Kontaktinfos in Mails: #87

Made with [Cursor](https://cursor.com)