### PR TITLE
#84 Bugfix: Neuer Admin kann Teilnehmerliste laden

### DIFF
--- a/backend/src/lambdas/getParticipants/index.test.ts
+++ b/backend/src/lambdas/getParticipants/index.test.ts
@@ -341,6 +341,37 @@ describe("getParticipants Lambda", () => {
     expect(result.statusCode).toBe(403);
   });
 
+  test("allows admin with mixed-case userId from token context", async () => {
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "Karin" },
+        role: { S: "admin" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        name: { S: "Demo" },
+      },
+    });
+    mockSend.mockResolvedValueOnce({
+      Items: [{ tenantId: { S: "default-tenant" }, userId: { S: "alice" } }],
+    });
+    mockSend.mockResolvedValueOnce({
+      Items: [{ tenantId: { S: "default-tenant" }, userId: { S: "alice" }, role: { S: "participant" } }],
+    });
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "Karin" } } as any,
+      }),
+    );
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(Array.isArray(body)).toBe(true);
+  });
+
   test("returns 403 for participant role", async () => {
     mockSend.mockResolvedValueOnce({
       Item: {

--- a/backend/src/lambdas/shared/tenantContext.test.ts
+++ b/backend/src/lambdas/shared/tenantContext.test.ts
@@ -31,7 +31,7 @@ describe("getTenantContext (lambda shared)", () => {
     });
   });
 
-  it("normalisiert userId aus JWT-Claims auf lowercase", () => {
+  it("behaelt userId aus JWT-Claims in Originalschreibweise", () => {
     const event = makeEvent({
       requestContext: {
         authorizer: {
@@ -41,7 +41,7 @@ describe("getTenantContext (lambda shared)", () => {
     });
 
     const ctx = getTenantContext(event);
-    expect(ctx.userId).toBe("maya");
+    expect(ctx.userId).toBe("Maya");
   });
 
   it("verwendet principalId, wenn kein nickname im JWT vorhanden ist", () => {

--- a/backend/src/lambdas/shared/tenantContext.ts
+++ b/backend/src/lambdas/shared/tenantContext.ts
@@ -20,7 +20,7 @@ export function getTenantContext(event: APIGatewayProxyEvent): TenantContext {
     null;
   const userId =
     typeof userIdRaw === "string" && userIdRaw.trim()
-      ? userIdRaw.trim().toLowerCase()
+      ? userIdRaw.trim()
       : null;
 
   const headers = event.headers || {};


### PR DESCRIPTION
## Summary
- Behebt den Fall, dass frisch registrierte Admins (mit gemischter Gross-/Kleinschreibung im Nickname) beim Laden von `/participants` eine Non-Array-Response bekommen und das Frontend mit `Unexpected /participants response format` abbricht.
- Ursache war die Normalisierung von `userId` auf lowercase im shared `tenantContext`, wodurch die Membership-Abfrage den Actor nicht gefunden hat.
- `tenantContext` behaelt nun die Originalschreibweise der `userId` bei; Regressionstest fuer Mixed-Case-Admin (`Karin`) wurde ergaenzt.

## Test plan
- [x] `cd backend && npm test -- shared/tenantContext.test.ts getParticipants/index.test.ts updateParticipant/index.test.ts getTenantContext/index.test.ts`
- [x] Manuell reproduziert/verifiziert: frisch registrierter Admin kann Teilnehmerliste laden

## Related
- Closes #84

Made with [Cursor](https://cursor.com)