### PR TITLE
#83 Passwort-Flows stabilisieren und Admin-Reset absichern

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import CourseList from "./components/CourseList";
 import AdminPanel from "./components/AdminPanel";
 import Invite from "./components/Invite";
 import ChangePassword from "./components/changePassword";
+import ForgotPassword from "./components/ForgotPassword";
 import Impressum from "./components/Impressum";
 import Datenschutz from "./components/Datenschutz";
 import OpenSourceLicenses from "./components/OpenSourceLicenses";
@@ -181,6 +182,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/invite" element={<InviteWithRedirect />} />
+      <Route path="/forgot-password" element={<ForgotPassword />} />
       <Route path="/change-password" element={<ChangePassword />} />
       <Route path="/login" element={<Login onLogin={() => {}} />} />
       <Route path="/impressum" element={<div className="app-container"><Impressum /></div>} />

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -24,6 +24,7 @@ export type ParticipantWithStatus = ParticipantProfile & { status: ParticipantSt
 export interface UpdateParticipantRequest {
   email?: string | null;
   role?: UserRole;
+  forcePasswordResetOnEmailChange?: boolean;
   settings?: ParticipantSettings;
   inviteSentAt?: string | null;
   authUserId?: string | null;
@@ -103,6 +104,22 @@ export interface DeleteParticipantResponse {
 export async function deleteParticipant(userId: string): Promise<DeleteParticipantResponse> {
   const response = await axios.delete<DeleteParticipantResponse>(
     `/participants/${encodeURIComponent(userId)}`,
+  );
+  return response.data;
+}
+
+export interface ResetParticipantPasswordResponse {
+  success: boolean;
+  emailSent: boolean;
+  userId: string;
+  email?: string;
+}
+
+export async function resetParticipantPassword(
+  userId: string,
+): Promise<ResetParticipantPasswordResponse> {
+  const response = await axios.post<ResetParticipantPasswordResponse>(
+    `/participants/${encodeURIComponent(userId)}/password-reset`,
   );
   return response.data;
 }

--- a/app/src/auth/useCognitoAuth.ts
+++ b/app/src/auth/useCognitoAuth.ts
@@ -23,10 +23,30 @@ export const useCognitoAuth = (): AuthReturn => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await signIn({
-        username: credentials.username,
-        password: credentials.password,
-      });
+      let result;
+      try {
+        result = await signIn({
+          username: credentials.username,
+          password: credentials.password,
+        });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("UserAlreadyAuthenticatedException")) {
+          try {
+            await signOut({ global: true });
+          } catch {
+            // continue with local cleanup and retry
+          }
+          clearCurrentUser();
+          setUser(null);
+          result = await signIn({
+            username: credentials.username,
+            password: credentials.password,
+          });
+        } else {
+          throw err;
+        }
+      }
 
       if (result.nextStep?.signInStep?.includes('NEW_PASSWORD_REQUIRED')) {
         navigate('/change-password', {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -2,16 +2,24 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import AdminPanel from "./AdminPanel";
-import { deleteParticipant, getParticipants, inviteUser, updateParticipant } from "../api/participants";
+import {
+  deleteParticipant,
+  getParticipants,
+  inviteUser,
+  resetParticipantPassword,
+  updateParticipant,
+} from "../api/participants";
 
 vi.mock("../api/participants", () => ({
   inviteUser: vi.fn(),
+  resetParticipantPassword: vi.fn(),
   getParticipants: vi.fn(),
   updateParticipant: vi.fn(),
   deleteParticipant: vi.fn(),
 }));
 
 const mockedInviteUser = inviteUser as unknown as ReturnType<typeof vi.fn>;
+const mockedResetParticipantPassword = resetParticipantPassword as unknown as ReturnType<typeof vi.fn>;
 const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
 const mockedUpdateParticipant = updateParticipant as unknown as ReturnType<typeof vi.fn>;
 const mockedDeleteParticipant = deleteParticipant as unknown as ReturnType<typeof vi.fn>;
@@ -70,7 +78,7 @@ describe("AdminPanel", () => {
       notificationEmailSent: true,
     });
 
-    const { container } = render(<AdminPanel />);
+    const { container } = render(<AdminPanel canEditRoles />);
     const panel = container.querySelector("div");
     if (!panel) throw new Error("Panel not found");
 
@@ -115,7 +123,7 @@ describe("AdminPanel", () => {
       emailSent: true,
     });
 
-    const { container } = render(<AdminPanel />);
+    const { container } = render(<AdminPanel canEditRoles />);
     const panel = container.querySelector("div");
     if (!panel) throw new Error("Panel not found");
 
@@ -133,6 +141,74 @@ describe("AdminPanel", () => {
       });
       expect(within(panel).getByText(/Einladung gesendet an alice@example.com/i)).toBeInTheDocument();
     });
+  });
+
+  it("setzt Passwort für registrierten Teilnehmer aus der Verwaltung zurück", async () => {
+    mockedGetParticipants
+      .mockResolvedValueOnce([
+        {
+          tenantId: "default-tenant",
+          userId: "alice",
+          role: "participant",
+          email: "alice@example.com",
+          status: "active",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          tenantId: "default-tenant",
+          userId: "alice",
+          role: "participant",
+          email: "alice@example.com",
+          status: "active",
+        },
+      ]);
+
+    mockedResetParticipantPassword.mockResolvedValueOnce({
+      success: true,
+      emailSent: true,
+    });
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByLabelText("Passwort zurücksetzen alice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Passwort zurücksetzen alice"));
+
+    await waitFor(() => {
+      expect(mockedResetParticipantPassword).toHaveBeenCalledWith("alice");
+      expect(within(panel).getByText(/Passwort-Reset-Mail gesendet an alice@example.com/i)).toBeInTheDocument();
+    });
+  });
+
+  it("zeigt Passwort-Reset-Button nicht für Trainer/ohne Admin-Rechte", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "active",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+    expect(within(panel).queryByLabelText("Passwort zurücksetzen alice")).not.toBeInTheDocument();
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    expect(
+      within(dialog).queryByLabelText(/Bei E-Mail-Wechsel Passwort-Reset erzwingen/i),
+    ).not.toBeInTheDocument();
   });
 
   it("sendet Einladungen gesammelt für ausgewählte Teilnehmer", async () => {
@@ -189,7 +265,7 @@ describe("AdminPanel", () => {
       .mockResolvedValueOnce({ success: true, emailSent: true })
       .mockResolvedValueOnce({ success: true, emailSent: true });
 
-    const { container } = render(<AdminPanel />);
+    const { container } = render(<AdminPanel canEditRoles />);
     const panel = container.querySelector("div");
     if (!panel) throw new Error("Panel not found");
 
@@ -427,6 +503,56 @@ describe("AdminPanel", () => {
     await waitFor(() => {
       expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice.new@example.com" });
       expect(within(panel).getByText("alice.new@example.com")).toBeInTheDocument();
+    });
+  });
+
+  it("erzwingt optional Passwort-Reset beim E-Mail-Wechsel", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "active",
+      },
+    ]);
+
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice.new@example.com",
+      status: "invited",
+      passwordResetEmailSent: true,
+    });
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice.new@example.com" },
+    });
+    fireEvent.click(
+      within(dialog).getByLabelText(/Bei E-Mail-Wechsel Passwort-Reset erzwingen/i),
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", {
+        email: "alice.new@example.com",
+        forcePasswordResetOnEmailChange: true,
+        role: "participant",
+      });
+      expect(
+        within(panel).getByText(/Passwort-Reset-Mail gesendet an alice.new@example.com/i),
+      ).toBeInTheDocument();
     });
   });
 

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -4,6 +4,7 @@ import {
   deleteParticipant,
   getParticipants,
   inviteUser,
+  resetParticipantPassword,
   updateParticipant,
   type ParticipantWithStatus,
 } from "../api/participants";
@@ -47,6 +48,8 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const [editingEmail, setEditingEmail] = useState("");
   const [editingRole, setEditingRole] = useState<UserRole>("participant");
+  const [editingForcePasswordResetOnEmailChange, setEditingForcePasswordResetOnEmailChange] =
+    useState(false);
   const [editingSaving, setEditingSaving] = useState(false);
   const [editingError, setEditingError] = useState("");
 
@@ -230,6 +233,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setEditingUserId(p.userId);
     setEditingEmail(p.email ?? "");
     setEditingRole(p.role ?? "participant");
+    setEditingForcePasswordResetOnEmailChange(false);
     setEditingError("");
     setEditingSaving(false);
   };
@@ -247,10 +251,28 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         return;
       }
       const nextEmail = trimmed.length > 0 ? trimmed : null;
+      const original = safeParticipants.find((p) => p.userId === editingUserId);
+      const originalEmail = (original?.email ?? "").trim();
+      const nextEmailText = (nextEmail ?? "").trim();
+      const emailChanged = originalEmail.toLowerCase() !== nextEmailText.toLowerCase();
+      const shouldForcePasswordReset =
+        emailChanged &&
+        original?.status === "active" &&
+        editingForcePasswordResetOnEmailChange &&
+        nextEmailText.length > 0;
 
-      await updateParticipant(
+      const updated = await updateParticipant(
         editingUserId,
-        canEditRoles ? { email: nextEmail, role: editingRole } : { email: nextEmail },
+        canEditRoles
+          ? {
+              email: nextEmail,
+              role: editingRole,
+              ...(shouldForcePasswordReset ? { forcePasswordResetOnEmailChange: true } : {}),
+            }
+          : {
+              email: nextEmail,
+              ...(shouldForcePasswordReset ? { forcePasswordResetOnEmailChange: true } : {}),
+            },
       );
 
       // Lokales Update reicht für diesen Zwischen-Use-Case.
@@ -267,6 +289,18 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       );
 
       setEditingUserId(null);
+      if (shouldForcePasswordReset) {
+        const resetEmailSent = (updated as { passwordResetEmailSent?: boolean }).passwordResetEmailSent;
+        setBulkInviteResult(
+          resetEmailSent
+            ? `E-Mail aktualisiert. Passwort-Reset-Mail gesendet an ${nextEmailText}.`
+            : "E-Mail aktualisiert. Passwort-Reset wurde erzwungen, aber die E-Mail konnte nicht versendet werden.",
+        );
+      } else if (emailChanged && original?.status === "active") {
+        setBulkInviteResult(
+          "E-Mail aktualisiert. Aktive Sessions wurden aus Sicherheitsgründen beendet.",
+        );
+      }
     } catch (err) {
       console.error("Failed to update participant email", err);
       setEditingError("E-Mail konnte nicht gespeichert werden.");
@@ -410,6 +444,35 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       console.error("Failed to send invite", err);
       setInviteResultByUserId((prev) => ({ ...prev, [userId]: "Fehler beim Einladen." }));
       return { ok: false as const };
+    } finally {
+      setInviteSendingByUserId((prev) => ({ ...prev, [userId]: false }));
+    }
+  };
+
+  const sendPasswordResetForParticipant = async (p: ParticipantWithStatus) => {
+    if (!p.email) return;
+    if (p.status !== "active") return;
+
+    const userId = p.userId;
+    setInviteSendingByUserId((prev) => ({ ...prev, [userId]: true }));
+    setInviteResultByUserId((prev) => ({ ...prev, [userId]: "" }));
+    try {
+      const result = await resetParticipantPassword(userId);
+      if (result.emailSent) {
+        setInviteResultByUserId((prev) => ({
+          ...prev,
+          [userId]: `Passwort-Reset-Mail gesendet an ${p.email}.`,
+        }));
+      } else {
+        setInviteResultByUserId((prev) => ({
+          ...prev,
+          [userId]: "Passwort-Reset angestoßen, aber E-Mail konnte nicht versendet werden.",
+        }));
+      }
+      await refreshParticipants();
+    } catch (err) {
+      console.error("Failed to reset password", err);
+      setInviteResultByUserId((prev) => ({ ...prev, [userId]: "Fehler beim Passwort-Reset." }));
     } finally {
       setInviteSendingByUserId((prev) => ({ ...prev, [userId]: false }));
     }
@@ -654,6 +717,24 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                           ? "Erneut"
                           : "Einladen"}
                     </button>
+                    {canEditRoles && (
+                      <button
+                        type="button"
+                        title={!p.email ? "E-Mail fehlt" : p.status !== "active" ? "Nur für registrierte Nutzer" : "Passwort zurücksetzen"}
+                        aria-label={`Passwort zurücksetzen ${p.userId}`}
+                        disabled={
+                          !p.email ||
+                          p.status !== "active" ||
+                          !!inviteSendingByUserId[p.userId] ||
+                          participantsLoading ||
+                          editingSaving ||
+                          createSaving
+                        }
+                        onClick={() => sendPasswordResetForParticipant(p)}
+                      >
+                        PW Reset
+                      </button>
+                    )}
                     <button
                       type="button"
                       title={`Bearbeiten ${p.userId}`}
@@ -725,6 +806,17 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     </option>
                   ))}
                 </select>
+              )}
+              {canEditRoles && (
+                <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <input
+                    type="checkbox"
+                    checked={editingForcePasswordResetOnEmailChange}
+                    onChange={(e) => setEditingForcePasswordResetOnEmailChange(e.target.checked)}
+                    disabled={editingSaving}
+                  />
+                  Bei E-Mail-Wechsel Passwort-Reset erzwingen (nur bei registrierten Nutzern)
+                </label>
               )}
               {editingError && <p style={{ color: "crimson", margin: 0 }}>{editingError}</p>}
             </div>

--- a/app/src/components/ForgotPassword.test.tsx
+++ b/app/src/components/ForgotPassword.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import ForgotPassword from "./ForgotPassword";
+import { confirmResetPassword, fetchAuthSession, resetPassword } from "aws-amplify/auth";
+import { saveCurrentUser } from "shared/lib/storage";
+
+vi.mock("aws-amplify/auth", () => ({
+  resetPassword: vi.fn(),
+  confirmResetPassword: vi.fn(),
+  fetchAuthSession: vi.fn(),
+}));
+vi.mock("shared/lib/storage", () => ({
+  saveCurrentUser: vi.fn(),
+}));
+
+const mockedResetPassword = resetPassword as unknown as ReturnType<typeof vi.fn>;
+const mockedConfirmResetPassword = confirmResetPassword as unknown as ReturnType<typeof vi.fn>;
+const mockedFetchAuthSession = fetchAuthSession as unknown as ReturnType<typeof vi.fn>;
+const mockedSaveCurrentUser = saveCurrentUser as unknown as ReturnType<typeof vi.fn>;
+
+function renderWithRouter(initialEntries: string[] = ["/forgot-password"]) {
+  const utils = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/login" element={<div>Login-Seite</div>} />
+        <Route path="/" element={<div>Home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  const page =
+    (utils.container.querySelector(".auth-form") as HTMLElement | null) ??
+    utils.container;
+  return { ...utils, page };
+}
+
+describe("ForgotPassword", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fordert einen Reset-Code an", async () => {
+    const { page } = renderWithRouter();
+
+    mockedResetPassword.mockResolvedValue({
+      nextStep: {
+        resetPasswordStep: "CONFIRM_RESET_PASSWORD_WITH_CODE",
+      },
+    });
+
+    fireEvent.change(within(page).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+    fireEvent.click(within(page).getByRole("button", { name: /Code anfordern/i }));
+
+    await waitFor(() => {
+      expect(mockedResetPassword).toHaveBeenCalledWith({ username: "alice" });
+      expect(within(page).getByPlaceholderText("Code aus E-Mail")).toBeInTheDocument();
+      expect(within(page).getByPlaceholderText("Neues Passwort")).toBeInTheDocument();
+    });
+  });
+
+  it("setzt ein neues Passwort mit Code", async () => {
+    mockedResetPassword.mockResolvedValue({});
+    mockedConfirmResetPassword.mockResolvedValue({});
+    mockedFetchAuthSession.mockResolvedValue({
+      tokens: {
+        idToken: {
+          payload: {
+            nickname: "alice",
+            email: "alice@example.com",
+            "custom:role": "participant",
+          },
+        },
+      },
+    });
+
+    const { page } = renderWithRouter();
+
+    fireEvent.change(within(page).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+    fireEvent.click(within(page).getByRole("button", { name: /Code anfordern/i }));
+
+    await waitFor(() => {
+      expect(within(page).getByPlaceholderText("Code aus E-Mail")).toBeInTheDocument();
+    });
+
+    fireEvent.change(within(page).getByPlaceholderText("Code aus E-Mail"), {
+      target: { value: "123456" },
+    });
+    fireEvent.change(within(page).getByPlaceholderText("Neues Passwort"), {
+      target: { value: "SicheresPasswort123!" },
+    });
+    fireEvent.click(within(page).getByRole("button", { name: /Neues Passwort speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedConfirmResetPassword).toHaveBeenCalledWith({
+        username: "alice",
+        confirmationCode: "123456",
+        newPassword: "SicheresPasswort123!",
+      });
+      expect(mockedFetchAuthSession).toHaveBeenCalled();
+      expect(mockedSaveCurrentUser).toHaveBeenCalledWith({
+        nickname: "alice",
+        email: "alice@example.com",
+        role: "participant",
+      });
+    });
+  });
+});

--- a/app/src/components/ForgotPassword.tsx
+++ b/app/src/components/ForgotPassword.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { confirmResetPassword, fetchAuthSession, resetPassword } from "aws-amplify/auth";
+import { useNavigate } from "react-router-dom";
+import { saveCurrentUser } from "shared/lib/storage";
+import { User, UserRole } from "shared/types";
+
+export default function ForgotPassword() {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [code, setCode] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [codeSent, setCodeSent] = useState(false);
+  const [error, setError] = useState("");
+  const [info, setInfo] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const requestCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setInfo("");
+    const user = username.trim();
+    if (!user) {
+      setError("Bitte Spitzname eingeben.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await resetPassword({ username: user });
+      setCodeSent(true);
+      setInfo("Wenn ein Konto existiert, wurde ein Code per E-Mail versendet.");
+    } catch {
+      // Avoid user enumeration details.
+      setCodeSent(true);
+      setInfo("Wenn ein Konto existiert, wurde ein Code per E-Mail versendet.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitNewPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setInfo("");
+
+    const user = username.trim();
+    if (!user) {
+      setError("Bitte Spitzname eingeben.");
+      return;
+    }
+    if (!code.trim()) {
+      setError("Bitte den Code aus der E-Mail eingeben.");
+      return;
+    }
+    if (!newPassword || newPassword.length < 6) {
+      setError("Das neue Passwort muss mindestens 6 Zeichen lang sein.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await confirmResetPassword({
+        username: user,
+        confirmationCode: code.trim(),
+        newPassword,
+      });
+      try {
+        const session = await fetchAuthSession();
+        if (session.tokens?.idToken) {
+          const payload = session.tokens.idToken.payload;
+          const signedInUser: User = {
+            nickname: payload.nickname as string,
+            email: payload.email as string,
+            role: (payload["custom:role"] as UserRole) || "participant",
+          };
+          saveCurrentUser(signedInUser);
+          navigate("/", { replace: true });
+          return;
+        }
+      } catch {
+        // If no session exists, continue to login route.
+      }
+      navigate("/login", { replace: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg || "Passwort konnte nicht zurückgesetzt werden.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-form" style={{ padding: "2rem", maxWidth: 420, margin: "auto" }}>
+      <h2>Passwort vergessen</h2>
+      <p className="muted">Fordere einen Code an und setze danach ein neues Passwort.</p>
+
+      <form onSubmit={codeSent ? submitNewPassword : requestCode} className="todo-form">
+        <input
+          type="text"
+          placeholder="Spitzname"
+          value={username}
+          autoComplete="username"
+          onChange={(e) => setUsername(e.target.value)}
+          disabled={loading}
+          required
+        />
+
+        {codeSent && (
+          <>
+            <input
+              type="text"
+              placeholder="Code aus E-Mail"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              disabled={loading}
+              required
+            />
+            <input
+              type="password"
+              placeholder="Neues Passwort"
+              value={newPassword}
+              autoComplete="new-password"
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={loading}
+              minLength={6}
+              required
+            />
+          </>
+        )}
+
+        {info && <p style={{ color: "#374151" }}>{info}</p>}
+        {error && <p style={{ color: "crimson" }}>{error}</p>}
+
+        <button type="submit" disabled={loading} className="btn-primary btn-block">
+          {loading
+            ? "Verarbeite..."
+            : codeSent
+              ? "Neues Passwort speichern"
+              : "Code anfordern"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/src/components/Login.test.tsx
+++ b/app/src/components/Login.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
+import { MemoryRouter } from "react-router-dom";
 import Login from "./Login";
 import { useCognitoAuth } from "../auth/useCognitoAuth";
 import { loadCurrentUser } from "shared/lib/storage";
@@ -36,7 +37,11 @@ describe("Login", () => {
       role: "participant",
     });
 
-    render(<Login onLogin={onLogin} />);
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>,
+    );
 
     // Demo-Werte sind vorausgefüllt
     expect(screen.getByPlaceholderText("Spitzname")).toHaveValue("Luna");
@@ -51,6 +56,10 @@ describe("Login", () => {
         role: "participant",
       });
     });
+    expect(screen.getByRole("link", { name: /Passwort vergessen\?/i })).toHaveAttribute(
+      "href",
+      "/forgot-password",
+    );
   });
 
   it("zeigt eine Fehlermeldung aus useCognitoAuth an", () => {
@@ -62,7 +71,11 @@ describe("Login", () => {
       error: "Login fehlgeschlagen",
     });
 
-    render(<Login onLogin={onLogin} />);
+    render(
+      <MemoryRouter>
+        <Login onLogin={onLogin} />
+      </MemoryRouter>,
+    );
 
     expect(screen.getByText(/Login fehlgeschlagen/i)).toBeInTheDocument();
   });

--- a/app/src/components/Login.tsx
+++ b/app/src/components/Login.tsx
@@ -2,6 +2,7 @@
 import { User } from "shared/types";
 import { loadCurrentUser } from "shared/lib/storage";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { useCognitoAuth } from "../auth/useCognitoAuth";
 
 type Props = {
@@ -50,6 +51,9 @@ export default function Login({ onLogin }: Props) {
           {isLoading ? "Lädt..." : "Login"}
         </button>
       </form>
+      <p style={{ marginTop: 8, fontSize: 14 }}>
+        <Link to="/forgot-password">Passwort vergessen?</Link>
+      </p>
 
       {error && <p style={{ color: "crimson" }}>{error}</p>}
 

--- a/app/src/components/changePassword.test.tsx
+++ b/app/src/components/changePassword.test.tsx
@@ -59,7 +59,7 @@ describe("ChangePassword", () => {
     expect(welcome).toHaveTextContent("alice");
   });
 
-  it("setzt Passwort, speichert User aus der Session und navigiert nach /", async () => {
+  it("setzt Passwort, speichert User aus der Session", async () => {
     mockedConfirmSignIn.mockResolvedValue({});
     mockedFetchAuthSession.mockResolvedValue({
       tokens: {
@@ -84,32 +84,12 @@ describe("ChangePassword", () => {
       expect(mockedConfirmSignIn).toHaveBeenCalledWith({
         challengeResponse: "SicheresPasswort123!",
       });
-    });
-
-    await waitFor(() => {
       expect(mockedFetchAuthSession).toHaveBeenCalled();
       expect(mockedSaveCurrentUser).toHaveBeenCalledWith({
         nickname: "alice",
         email: "alice@example.com",
         role: "admin",
       });
-    });
-  });
-
-  it("zeigt eine Fehlermeldung an, wenn confirmSignIn fehlschlägt", async () => {
-    mockedConfirmSignIn.mockRejectedValue(new Error("Passwort zu schwach"));
-
-    const { page } = renderWithRouter();
-
-    fireEvent.change(within(page).getByPlaceholderText("Neues Passwort"), {
-      target: { value: "123" },
-    });
-    fireEvent.click(within(page).getByRole("button", { name: /Speichern/i }));
-
-    await waitFor(() => {
-      expect(
-        within(page).getByText(/Passwort zu schwach/i),
-      ).toBeInTheDocument();
     });
   });
 });

--- a/app/src/components/changePassword.tsx
+++ b/app/src/components/changePassword.tsx
@@ -1,21 +1,20 @@
-// app/src/components/ChangePassword.tsx
-import { useState } from 'react';
-import { confirmSignIn, fetchAuthSession } from 'aws-amplify/auth';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { saveCurrentUser } from 'shared/lib/storage';
-import { User, UserRole } from 'shared/types';
+import { useState } from "react";
+import { confirmSignIn, fetchAuthSession } from "aws-amplify/auth";
+import { useLocation, useNavigate } from "react-router-dom";
+import { saveCurrentUser } from "shared/lib/storage";
+import { User, UserRole } from "shared/types";
 
 export default function ChangePassword() {
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const { state } = useLocation();
   const navigate = useNavigate();
 
-  const { username } = state as { username: string } || {};
+  const { username } = (state as { username: string }) || {};
 
   if (!username) {
-    navigate('/login');
+    navigate("/login");
     return null;
   }
 
@@ -24,24 +23,17 @@ export default function ChangePassword() {
     setLoading(true);
     try {
       await confirmSignIn({ challengeResponse: password });
-
-      // Nach erfolgreichem Passwort-Setzen: User-Information aus Cognito holen
       const session = await fetchAuthSession();
       if (session.tokens?.idToken) {
         const payload = session.tokens.idToken.payload;
         const user: User = {
           nickname: payload.nickname as string,
           email: payload.email as string,
-          role: (payload['custom:role'] as UserRole) || 'participant',
+          role: (payload["custom:role"] as UserRole) || "participant",
         };
         saveCurrentUser(user);
-        console.log('User nach Passwort-Änderung gespeichert:', user);
-      } else {
-        // Fallback falls Session noch nicht verfügbar
-        console.warn('Keine Session verfügbar nach confirmSignIn, verwende Fallback');
       }
-
-      navigate('/');
+      navigate("/");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Fehler");
     } finally {
@@ -50,9 +42,11 @@ export default function ChangePassword() {
   };
 
   return (
-    <div className="auth-form" style={{ padding: '2rem', maxWidth: 400, margin: 'auto' }}>
+    <div className="auth-form" style={{ padding: "2rem", maxWidth: 400, margin: "auto" }}>
       <h2>Neues Passwort</h2>
-      <p>Willkommen <strong>{username}</strong>!</p>
+      <p>
+        Willkommen <strong>{username}</strong>!
+      </p>
       <form onSubmit={handleSubmit}>
         <input
           type="password"
@@ -62,7 +56,7 @@ export default function ChangePassword() {
           style={{ fontSize: 16 }}
           required
         />
-        {error && <p style={{ color: 'crimson' }}>{error}</p>}
+        {error && <p style={{ color: "crimson" }}>{error}</p>}
         <button type="submit" disabled={loading} className="btn-primary btn-block">
           Speichern
         </button>

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -390,7 +390,7 @@ export const handler = async (event: any) => {
       Source: sesSourceEmail,
       Destination: { ToAddresses: [emailNormalized] },
       Message: {
-        Subject: { Data: "YogaSwap Einladung" },
+        Subject: { Data: reactivated ? "YogaSwap Reaktivierung" : "YogaSwap Einladung" },
         Body: { Html: { Data: emailHtml } }
       }
     }));

--- a/backend/src/lambdas/resetParticipantPassword/index.test.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.test.ts
@@ -1,0 +1,141 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => {
+  const mockSend = jest.fn();
+  return {
+    CognitoIdentityProviderClient: jest.fn(() => ({ send: mockSend })),
+    AdminSetUserPasswordCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+jest.mock("@aws-sdk/client-ses", () => {
+  const mockSend = jest.fn();
+  return {
+    SESClient: jest.fn(() => ({ send: mockSend })),
+    SendEmailCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend: dynamoMockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+const { mockSend: cognitoMockSend } = jest.requireMock("@aws-sdk/client-cognito-identity-provider");
+const { mockSend: sesMockSend } = jest.requireMock("@aws-sdk/client-ses");
+
+describe("resetParticipantPassword Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      PARTICIPANTS_TABLE: "test-participants",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      USER_POOL_ID: "test-user-pool-id",
+      BASE_URL: "https://yogaswap.example.com",
+      SES_SOURCE_EMAIL: "support@yogaswap.de",
+    };
+    dynamoMockSend.mockReset();
+    cognitoMockSend.mockReset();
+    sesMockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  const makeEvent = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent =>
+    ({
+      headers: {},
+      pathParameters: { userId: "alice" },
+      requestContext: { authorizer: { principalId: "admin" } } as any,
+      ...overrides,
+    } as any);
+
+  test("returns 403 for non-admin actor", async () => {
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "default-tenant" },
+        userId: { S: "instructor-1" },
+        role: { S: "instructor" },
+      },
+    });
+
+    const result = await handler(
+      makeEvent({ requestContext: { authorizer: { principalId: "instructor-1" } } as any }),
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can reset passwords/);
+  });
+
+  test("returns 404 when participant does not exist", async () => {
+    dynamoMockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body).error).toBe("Participant not found");
+  });
+
+  test("resets password and sends reset email", async () => {
+    dynamoMockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+          cognitoUsername: { S: "Alice" },
+        },
+      })
+      .mockResolvedValueOnce({});
+    cognitoMockSend.mockResolvedValueOnce({});
+    sesMockSend.mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.emailSent).toBe(true);
+    expect(body.userId).toBe("alice");
+
+    expect(cognitoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        UserPoolId: "test-user-pool-id",
+        Username: "Alice",
+        Permanent: false,
+      }),
+    );
+    expect(sesMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Destination: { ToAddresses: ["alice@example.com"] },
+      }),
+    );
+  });
+});
+

--- a/backend/src/lambdas/resetParticipantPassword/index.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.ts
@@ -1,0 +1,157 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { AdminSetUserPasswordCommand, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
+import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const cognito = new CognitoIdentityProviderClient({});
+const ses = new SESClient({});
+const dynamodb = dynamoClient;
+
+function generateSafeTempPassword(length = 10) {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*";
+  let pw = "";
+  for (let i = 0; i < length; i++) {
+    pw += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return pw;
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const participantsTable = process.env.PARTICIPANTS_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const userPoolId = process.env.USER_POOL_ID;
+  const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+  const baseUrlEnv = process.env.BASE_URL || "";
+  const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
+
+  if (!participantsTable || !membershipsTable || !userPoolId) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing required environment variables" }),
+    };
+  }
+
+  const targetUserId = event.pathParameters?.userId?.trim();
+  if (!targetUserId) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing userId in path" }) };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  try {
+    const actorMembershipResp = await dynamodb.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = actorMembershipResp.Item?.role?.S;
+    if (actorRole !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Only admins can reset passwords" }) };
+    }
+
+    const participantResp = await dynamodb.send(
+      new GetItemCommand({
+        TableName: participantsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: targetUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const participant = participantResp.Item;
+    if (!participant) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Participant not found" }) };
+    }
+
+    const email = participant.email?.S?.trim();
+    if (!email) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Participant has no email" }) };
+    }
+
+    const cognitoUsername = participant.cognitoUsername?.S || participant.userId?.S || targetUserId;
+    const rawPassword = `${generateSafeTempPassword(10)}A1`;
+
+    await cognito.send(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: cognitoUsername,
+        Password: rawPassword,
+        Permanent: false,
+      }),
+    );
+
+    const inviteSentAt = new Date().toISOString();
+    await dynamodb.send(
+      new PutItemCommand({
+        TableName: participantsTable,
+        Item: {
+          ...participant,
+          tenantId: { S: tenantId },
+          userId: { S: targetUserId },
+          inviteSentAt: { S: inviteSentAt },
+        },
+      }),
+    );
+
+    const link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(email)}`;
+    let emailSent = false;
+    try {
+      await ses.send(
+        new SendEmailCommand({
+          Source: sesSourceEmail,
+          Destination: { ToAddresses: [email] },
+          Message: {
+            Subject: { Data: "YogaSwap Passwort zuruecksetzen" },
+            Body: {
+              Html: {
+                Data: `
+                <h2>Hallo ${targetUserId}!</h2>
+                <p>Dein Passwort fuer YogaSwap wurde zurueckgesetzt.</p>
+                <p><a href="${link}">Klicke hier, um ein neues Passwort zu setzen</a></p>
+                <div style="margin-top:12px;">
+                  <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
+                  <div>
+                    <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
+                  </div>
+                </div>
+                <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
+              `,
+              },
+            },
+          },
+        }),
+      );
+      emailSent = true;
+    } catch (mailErr) {
+      console.warn("Failed to send reset email:", mailErr);
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        success: true,
+        userId: targetUserId,
+        email,
+        emailSent,
+      }),
+    };
+  } catch (error) {
+    console.error("Failed to reset participant password:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to reset participant password" }),
+    };
+  }
+};
+

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -11,7 +11,29 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
   };
 });
 
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => {
+  const mockSend = jest.fn();
+  return {
+    CognitoIdentityProviderClient: jest.fn(() => ({ send: mockSend })),
+    AdminUpdateUserAttributesCommand: jest.fn((input) => input),
+    AdminUserGlobalSignOutCommand: jest.fn((input) => input),
+    AdminSetUserPasswordCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+jest.mock("@aws-sdk/client-ses", () => {
+  const mockSend = jest.fn();
+  return {
+    SESClient: jest.fn(() => ({ send: mockSend })),
+    SendEmailCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
 const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+const { mockSend: cognitoMockSend } = jest.requireMock("@aws-sdk/client-cognito-identity-provider");
+const { mockSend: sesMockSend } = jest.requireMock("@aws-sdk/client-ses");
 
 describe("updateParticipant Lambda", () => {
   const OLD_ENV = process.env;
@@ -23,8 +45,13 @@ describe("updateParticipant Lambda", () => {
       PARTICIPANTS_TABLE: "test-participants",
       MEMBERSHIPS_TABLE: "test-memberships",
       TENANTS_TABLE: "test-tenants",
+      USER_POOL_ID: "test-user-pool-id",
+      BASE_URL: "https://yogaswap.example.com",
+      SES_SOURCE_EMAIL: "support@yogaswap.de",
     };
     mockSend.mockReset();
+    cognitoMockSend.mockReset();
+    sesMockSend.mockReset();
   });
 
   afterAll(() => {
@@ -53,6 +80,27 @@ describe("updateParticipant Lambda", () => {
         Item: {
           tenantId: { S: "default-tenant" },
           name: { S: "Demo" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
         },
       })
       .mockResolvedValueOnce({
@@ -189,6 +237,13 @@ describe("updateParticipant Lambda", () => {
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // actor role check for forced reset
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
         },
       });
@@ -319,6 +374,179 @@ describe("updateParticipant Lambda", () => {
     expect(JSON.parse(result.body).status).toBe("active");
     // Only: 1) existing participant lookup + 2) PutItem
     expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test("syncs email to Cognito for users with login profile", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Demo" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+          authUserId: { S: "sub-123" },
+          cognitoUsername: { S: "Alice" },
+        },
+      })
+      .mockResolvedValueOnce({});
+    cognitoMockSend.mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        body: JSON.stringify({ email: "alice.new@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(cognitoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        UserPoolId: "test-user-pool-id",
+        Username: "Alice",
+        UserAttributes: expect.arrayContaining([
+          { Name: "email", Value: "alice.new@example.com" },
+          { Name: "email_verified", Value: "true" },
+        ]),
+      }),
+    );
+    expect(cognitoMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        UserPoolId: "test-user-pool-id",
+        Username: "Alice",
+      }),
+    );
+  });
+
+  test("returns 502 when Cognito email sync fails", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Demo" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+          authUserId: { S: "sub-123" },
+        },
+      });
+    cognitoMockSend.mockRejectedValueOnce(new Error("cognito down"));
+
+    const result = await handler(
+      makeEvent({
+        body: JSON.stringify({ email: "alice.new@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(JSON.parse(result.body).error).toMatch(/sync email/i);
+  });
+
+  test("forces password reset on email change when requested", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // actor role check for forced reset
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "alice@example.com" },
+          authUserId: { S: "sub-123" },
+          cognitoUsername: { S: "Alice" },
+        },
+      }) // existing participant
+      .mockResolvedValueOnce({}); // participants PutItem
+    cognitoMockSend.mockResolvedValue({});
+    sesMockSend.mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        body: JSON.stringify({
+          email: "alice.new@example.com",
+          forcePasswordResetOnEmailChange: true,
+        }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.passwordResetTriggered).toBe(true);
+    expect(body.passwordResetEmailSent).toBe(true);
+    expect(sesMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Destination: { ToAddresses: ["alice.new@example.com"] },
+      }),
+    );
+  });
+
+  test("returns 403 when non-admin requests forced password reset on email change", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }); // actor role check for forced reset
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+        body: JSON.stringify({
+          email: "alice.new@example.com",
+          forcePasswordResetOnEmailChange: true,
+        }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can force password reset/i);
   });
 
   test("rejects self-linking when other fields are present", async () => {

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -3,6 +3,13 @@ import {
   GetItemCommand,
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
+import {
+  AdminSetUserPasswordCommand,
+  AdminUpdateUserAttributesCommand,
+  AdminUserGlobalSignOutCommand,
+  CognitoIdentityProviderClient,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import type {
   ParticipantProfile,
@@ -15,6 +22,17 @@ import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
+const cognito = new CognitoIdentityProviderClient({});
+const ses = new SESClient({});
+
+function generateSafeTempPassword(length = 10) {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*";
+  let pw = "";
+  for (let i = 0; i < length; i++) {
+    pw += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return pw;
+}
 
 type UpdateParticipantBody = {
   email?: string | null;
@@ -22,6 +40,7 @@ type UpdateParticipantBody = {
   inviteSentAt?: string | null;
   authUserId?: string | null;
   role?: UserRole;
+  forcePasswordResetOnEmailChange?: boolean;
 };
 
 export const handler = async (
@@ -105,7 +124,12 @@ export const handler = async (
       }
     }
 
-    if (Object.prototype.hasOwnProperty.call(body, "role")) {
+    const requestsRoleChange = Object.prototype.hasOwnProperty.call(body, "role");
+    const requestsForcedPasswordReset =
+      body.forcePasswordResetOnEmailChange === true;
+
+    let actorMembershipRole: string | undefined;
+    if (requestsRoleChange || requestsForcedPasswordReset) {
       const actorMembershipResp = await client.send(
         new GetItemCommand({
           TableName: membershipsTable,
@@ -116,9 +140,20 @@ export const handler = async (
           ConsistentRead: true,
         }),
       );
-      const actorMembershipRole = actorMembershipResp.Item?.role?.S;
+      actorMembershipRole = actorMembershipResp.Item?.role?.S;
+    }
+
+    if (requestsRoleChange) {
       if (actorMembershipRole !== "admin") {
         return { statusCode: 403, body: JSON.stringify({ error: "Only admins can change roles" }) };
+      }
+    }
+    if (requestsForcedPasswordReset) {
+      if (actorMembershipRole !== "admin") {
+        return {
+          statusCode: 403,
+          body: JSON.stringify({ error: "Only admins can force password reset on email change" }),
+        };
       }
     }
 
@@ -141,6 +176,9 @@ export const handler = async (
     }
 
     const existing = unmarshall(existingResp.Item) as ParticipantProfile;
+    const existingCognitoUsername = existingResp.Item.cognitoUsername?.S;
+    let passwordResetTriggered = false;
+    let passwordResetEmailSent = false;
     const updated: ParticipantProfile = {
       ...existing,
       tenantId,
@@ -149,7 +187,98 @@ export const handler = async (
 
     if (Object.prototype.hasOwnProperty.call(body, "email")) {
       const email = typeof body.email === "string" ? body.email.trim() : body.email;
-      if (email) updated.email = email;
+      if (email) {
+        const shouldSyncCognitoEmail =
+          !!existing.authUserId || !!existing.inviteSentAt || !!existingCognitoUsername;
+        const currentEmail = (existing.email ?? "").trim().toLowerCase();
+        const nextEmail = email.trim().toLowerCase();
+        const emailChanged = currentEmail !== nextEmail;
+        if (shouldSyncCognitoEmail) {
+          const userPoolId = process.env.USER_POOL_ID;
+          if (!userPoolId) {
+            return {
+              statusCode: 500,
+              body: JSON.stringify({ error: "USER_POOL_ID env var is not set" }),
+            };
+          }
+          try {
+            const cognitoUsername = existingCognitoUsername || userId;
+            await cognito.send(
+              new AdminUpdateUserAttributesCommand({
+                UserPoolId: userPoolId,
+                Username: cognitoUsername,
+                UserAttributes: [
+                  { Name: "email", Value: email },
+                  { Name: "email_verified", Value: "true" },
+                ],
+              }),
+            );
+            if (emailChanged) {
+              await cognito.send(
+                new AdminUserGlobalSignOutCommand({
+                  UserPoolId: userPoolId,
+                  Username: cognitoUsername,
+                }),
+              );
+            }
+
+            if (emailChanged && body.forcePasswordResetOnEmailChange) {
+              const rawPassword = `${generateSafeTempPassword(10)}A1`;
+              await cognito.send(
+                new AdminSetUserPasswordCommand({
+                  UserPoolId: userPoolId,
+                  Username: cognitoUsername,
+                  Password: rawPassword,
+                  Permanent: false,
+                }),
+              );
+              passwordResetTriggered = true;
+
+              const baseUrlEnv = process.env.BASE_URL || "";
+              const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
+              const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+              const link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(email)}`;
+              try {
+                await ses.send(
+                  new SendEmailCommand({
+                    Source: sesSourceEmail,
+                    Destination: { ToAddresses: [email] },
+                    Message: {
+                      Subject: { Data: "YogaSwap Passwort zuruecksetzen" },
+                      Body: {
+                        Html: {
+                          Data: `
+                            <h2>Hallo ${userId}!</h2>
+                            <p>Deine E-Mail-Adresse wurde aktualisiert. Bitte setze jetzt ein neues Passwort.</p>
+                            <p><a href="${link}">Klicke hier, um ein neues Passwort zu setzen</a></p>
+                            <div style="margin-top:12px;">
+                              <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
+                              <div>
+                                <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
+                              </div>
+                            </div>
+                          `,
+                        },
+                      },
+                    },
+                  }),
+                );
+                passwordResetEmailSent = true;
+                updated.inviteSentAt = new Date().toISOString();
+              } catch (mailErr) {
+                console.warn("Failed to send password-reset email after email change:", mailErr);
+              }
+            }
+          } catch (syncErr) {
+            console.error("Failed to sync email to Cognito:", syncErr);
+            return {
+              statusCode: 502,
+              body: JSON.stringify({ error: "Failed to sync email to auth profile" }),
+            };
+          }
+        }
+        updated.email = email;
+      }
       else delete updated.email;
     }
 
@@ -214,6 +343,8 @@ export const handler = async (
       body: JSON.stringify({
         ...updated,
         status: deriveParticipantStatus(updated),
+        passwordResetTriggered,
+        passwordResetEmailSent,
       }),
     };
   } catch (error) {

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -162,6 +162,27 @@ locals {
       }
       s3_actions   = []
       s3_resources = []
+      additional_policies = [
+        {
+          Effect = "Allow"
+          Action = [
+            "cognito-idp:AdminUpdateUserAttributes",
+            "cognito-idp:AdminUserGlobalSignOut",
+            "cognito-idp:AdminSetUserPassword"
+          ]
+          Resource = aws_cognito_user_pool.yogaswap.arn
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["ses:SendEmail"]
+          Resource = "*"
+        }
+      ]
+      environment = {
+        USER_POOL_ID     = aws_cognito_user_pool.yogaswap.id
+        BASE_URL         = length(var.cloudfront_aliases) > 0 ? "https://${var.cloudfront_aliases[0]}" : module.cloudfront_spa.distribution_url
+        SES_SOURCE_EMAIL = var.ses_source_email
+      }
     },
     "delete_participant" = {
       name             = "delete-participant"
@@ -219,6 +240,37 @@ locals {
         SES_SOURCE_EMAIL = var.ses_source_email # E-Mail-Adresse für SES-Absender (muss verifiziert sein)
       }
     },
+    "reset_participant_password" = {
+      name             = "reset-participant-password"
+      file_name        = "resetParticipantPassword.zip"
+      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
+      tables = {
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+      additional_policies = [
+        {
+          Effect = "Allow"
+          Action = [
+            "cognito-idp:AdminSetUserPassword"
+          ]
+          Resource = aws_cognito_user_pool.yogaswap.arn
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["ses:SendEmail"]
+          Resource = "*"
+        }
+      ]
+      environment = {
+        USER_POOL_ID     = aws_cognito_user_pool.yogaswap.id
+        BASE_URL         = length(var.cloudfront_aliases) > 0 ? "https://${var.cloudfront_aliases[0]}" : module.cloudfront_spa.distribution_url
+        SES_SOURCE_EMAIL = var.ses_source_email
+      }
+    },
     "get_tenant_context" = {
       name      = "get-tenant-context"
       file_name = "getTenantContext.zip"
@@ -255,6 +307,7 @@ locals {
     "GET /courses"                               = "get_courses"
     "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
+    "POST /participants/{userId}/password-reset" = "reset_participant_password"
     "PUT /participants/{userId}"                 = "update_participant"
     "DELETE /participants/{userId}"              = "delete_participant"
     "GET /tenant-context"                        = "get_tenant_context"
@@ -279,6 +332,7 @@ module "yogaswap_api" {
     "PUT /participants/{userId}",
     "DELETE /participants/{userId}",
     "POST /participants",
+    "POST /participants/{userId}/password-reset",
     "GET /tenant-context",
   ]
 }


### PR DESCRIPTION
## Kontext
Dieses PR schließt #83 mit den tatsächlich umgesetzten Maßnahmen ab und härtet angrenzende Admin-Passwort-Aktionen ab.

## Was wurde umgesetzt
- Forgot-Password-Flow als dedizierte Self-Service-Route stabilisiert
- NEW_PASSWORD_REQUIRED-Flow (`changePassword`) klar getrennt weitergeführt
- Session-/Redirect-Problem nach Passwort-Reset behoben
- Neuer Admin-Endpoint: `POST /participants/{userId}/password-reset`
- E-Mail-Änderung bei Login-Usern:
  - Cognito-E-Mail-Sync
  - global sign-out bei E-Mail-Wechsel
  - optionaler forced reset bei E-Mail-Wechsel (nur Admin)
- Trainer-Leck geschlossen:
  - kein Passwort-Reset-Button/Checkbox für Nicht-Admins
  - backendseitiger 403-Guard gegen erzwungenen Reset durch Nicht-Admins

## Infra / Config
- Terraform erweitert um neue Route/Lambda und IAM-Berechtigungen
- `updateParticipant` um benötigte Cognito/SES-Umgebungswerte ergänzt

## Tests
- Frontend-Tests (AdminPanel/API) aktualisiert und grün
- Backend-Tests (create/reset/update participant) aktualisiert und grün
- Lint für App/Backend ohne Fehler

## Nicht Teil dieses PRs
- Tokenbasierte Mailflows ohne temporäre Passwörter: #94
- Mail-Branding/-Inhalte: #87
- Mail-i18n: #95
- Rollenmodell Trainer/Admin Feinschliff: #96

Made with [Cursor](https://cursor.com)