### PR TITLE
#96 Rollenmodell schaerfen: Trainer-Rechte in Teilnehmerverwaltung klar trennen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ YogaSwap ermöglicht Yogastudios in einer Multi-Tenant-Architektur die Verwaltun
 
 ---
 
+## 🧠 Hintergrund
+
+Die Idee zu YogaSwap entstand aus einem konkreten Problem aus der Praxis: Eine Freundin, die als Yogatrainerin arbeitet, hat sich darüber beschwert, wie zeitaufwendig es ist, Absagen zu koordinieren und passende Ersatztermine zu finden – oft verbunden mit vielen Abstimmungen über WhatsApp.
+
+Viele Teilnehmende fragen nach Nachholterminen, aber die verfügbaren Alternativen passen nicht immer. Dadurch bleiben Plätze ungenutzt, obwohl gleichzeitig Nachfrage besteht. Der Wunsch nach einer Lösung war zuerst nur eine Notiz im Hinterkopf und wurde später zur Grundlage dieses Projekts.
+
+Gestartet ist YogaSwap als einfache React-Anwendung, statisch ausgeliefert über S3. Die Zielarchitektur mit AWS Lambda, API Gateway, DynamoDB sowie S3 und CloudFront für das Frontend war dabei von Anfang an angelegt.
+
+Im weiteren Verlauf wurde die Anwendung Schritt für Schritt ausgebaut: Logik in AWS Lambda ausgelagert, Datenmodelle konsequent in DynamoDB überführt und später um AWS Cognito (Authentifizierung) sowie AWS SES (E-Mail-Benachrichtigungen) ergänzt.
+
+Durch diese Entwicklung hat sich gezeigt, dass YogaSwap nicht nur als Einzel-Lösung funktioniert, sondern als Multi-Tenant-fähige SaaS-Plattform weitergedacht werden kann – ein Architektur- und Produktmodell, mit dem ich zu Beginn noch keine praktische Erfahrung hatte.
+
+Bei der Ausarbeitung habe ich AI bewusst als Sparringspartner genutzt, um Entscheidungen zu reflektieren, Ansätze zu vergleichen und die Architektur iterativ weiterzuentwickeln.
+
+---
+
 ## ✨ Features
 
 - **Kursplatz-Tausch** – Teilnehmende können Kursplätze untereinander tauschen

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -53,7 +53,7 @@ describe("AdminPanel", () => {
       expect(within(panel).getByLabelText("Status: ohne Login")).toBeInTheDocument();
       expect(within(panel).getByLabelText("Einladen alice")).not.toBeDisabled();
       expect(within(panel).getByLabelText("Bearbeiten alice")).not.toBeDisabled();
-      expect(within(panel).getByLabelText("Löschen alice")).not.toBeDisabled();
+      expect(within(panel).queryByLabelText("Löschen alice")).not.toBeInTheDocument();
     });
   });
 
@@ -204,11 +204,7 @@ describe("AdminPanel", () => {
       expect(within(panel).getByText("alice")).toBeInTheDocument();
     });
     expect(within(panel).queryByLabelText("Passwort zurücksetzen alice")).not.toBeInTheDocument();
-    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
-    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
-    expect(
-      within(dialog).queryByLabelText(/Bei E-Mail-Wechsel Passwort-Reset erzwingen/i),
-    ).not.toBeInTheDocument();
+    expect(within(panel).getByLabelText("Bearbeiten alice")).toBeDisabled();
   });
 
   it("sendet Einladungen gesammelt für ausgewählte Teilnehmer", async () => {
@@ -503,6 +499,44 @@ describe("AdminPanel", () => {
     await waitFor(() => {
       expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice.new@example.com" });
       expect(within(panel).getByText("alice.new@example.com")).toBeInTheDocument();
+    });
+  });
+
+  it("Trainer darf E-Mail für eingeladenen Teilnehmer korrigieren", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "wrong@example.com",
+        status: "invited",
+      },
+    ]);
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice@example.com",
+      status: "invited",
+    });
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByLabelText("Bearbeiten alice")).not.toBeDisabled();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice@example.com" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice@example.com" });
     });
   });
 

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -237,6 +237,8 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setEditingError("");
     setEditingSaving(false);
   };
+  const canEditEmailForParticipant = (p: ParticipantWithStatus): boolean =>
+    canEditRoles || (p.status !== "active" && !p.authUserId);
 
   const saveEditEmail = async () => {
     if (!editingUserId) return;
@@ -255,6 +257,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       const originalEmail = (original?.email ?? "").trim();
       const nextEmailText = (nextEmail ?? "").trim();
       const emailChanged = originalEmail.toLowerCase() !== nextEmailText.toLowerCase();
+      if (!canEditRoles && original?.status === "active" && emailChanged) {
+        setEditingError("E-Mail von registrierten Teilnehmern kann nur von Admins geändert werden.");
+        return;
+      }
       const shouldForcePasswordReset =
         emailChanged &&
         original?.status === "active" &&
@@ -737,29 +743,40 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     )}
                     <button
                       type="button"
-                      title={`Bearbeiten ${p.userId}`}
+                      title={
+                        !canEditEmailForParticipant(p)
+                          ? "E-Mail von registrierten Teilnehmern nur für Admin"
+                          : `Bearbeiten ${p.userId}`
+                      }
                       aria-label={`Bearbeiten ${p.userId}`}
-                      disabled={participantsLoading || editingSaving || !!deleteRunningByUserId[p.userId]}
+                      disabled={
+                        participantsLoading ||
+                        editingSaving ||
+                        !!deleteRunningByUserId[p.userId] ||
+                        !canEditEmailForParticipant(p)
+                      }
                       onClick={() => startEditEmail(p)}
                     >
                       <Pencil size={14} aria-hidden="true" />
                     </button>
-                    <button
-                      type="button"
-                      title={`Löschen ${p.userId}`}
-                      aria-label={`Löschen ${p.userId}`}
-                      disabled={
-                        participantsLoading ||
-                        editingSaving ||
-                        createSaving ||
-                        bulkInviteSending ||
-                        !!inviteSendingByUserId[p.userId] ||
-                        !!deleteRunningByUserId[p.userId]
-                      }
-                      onClick={() => setDeleteTarget(p)}
-                    >
-                      <Trash2 size={14} aria-hidden="true" />
-                    </button>
+                    {canEditRoles && (
+                      <button
+                        type="button"
+                        title={`Löschen ${p.userId}`}
+                        aria-label={`Löschen ${p.userId}`}
+                        disabled={
+                          participantsLoading ||
+                          editingSaving ||
+                          createSaving ||
+                          bulkInviteSending ||
+                          !!inviteSendingByUserId[p.userId] ||
+                          !!deleteRunningByUserId[p.userId]
+                        }
+                        onClick={() => setDeleteTarget(p)}
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                      </button>
+                    )}
                   </div>
                   {inviteResultByUserId[p.userId] && (
                     <div style={{ gridColumn: "1 / -1", color: "#374151", fontSize: 12 }}>

--- a/backend/src/lambdas/deleteParticipant/index.test.ts
+++ b/backend/src/lambdas/deleteParticipant/index.test.ts
@@ -70,6 +70,13 @@ describe("deleteParticipant Lambda", () => {
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      }) // actor role check
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
           email: { S: "alice@example.com" },
         },
@@ -109,6 +116,13 @@ describe("deleteParticipant Lambda", () => {
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
           authUserId: { S: "sub-123" },
           email: { S: "alice@example.com" },
@@ -127,7 +141,7 @@ describe("deleteParticipant Lambda", () => {
       notificationEmailSent: true,
     });
     // No scan and no profile delete in this case.
-    expect(mockSend).toHaveBeenCalledTimes(4);
+    expect(mockSend).toHaveBeenCalledTimes(5);
     expect(sesMockSend).toHaveBeenCalledTimes(1);
   });
 
@@ -144,6 +158,13 @@ describe("deleteParticipant Lambda", () => {
         Item: {
           tenantId: { S: "default-tenant" },
           name: { S: "Demo" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
         },
       })
       .mockResolvedValueOnce({
@@ -170,6 +191,36 @@ describe("deleteParticipant Lambda", () => {
 
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(403);
+  });
+
+  test("returns 403 when actor is instructor (not admin)", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Demo" },
+        },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }); // explicit role check
+
+    const result = await handler(
+      makeEvent({ requestContext: { authorizer: { principalId: "instructor-1" } } as any }),
+    );
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can delete participants/);
   });
 });
 

--- a/backend/src/lambdas/deleteParticipant/index.ts
+++ b/backend/src/lambdas/deleteParticipant/index.ts
@@ -54,6 +54,20 @@ export const handler = async (
     if (!canManage) {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
     }
+    const actorMembershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = actorMembershipResp.Item?.role?.S;
+    if (actorRole !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Only admins can delete participants" }) };
+    }
 
     const existingResp = await client.send(
       new GetItemCommand({

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -119,7 +119,7 @@ describe("updateParticipant Lambda", () => {
     expect(body.email).toBe("alice+new@example.com");
     expect(body.userId).toBe("alice");
     expect(body.status).toBe("no_login");
-    expect(mockSend).toHaveBeenCalledTimes(4);
+    expect(mockSend).toHaveBeenCalledTimes(5);
   });
 
   test("updates participant role when actor is admin", async () => {
@@ -215,6 +215,13 @@ describe("updateParticipant Lambda", () => {
       })
       .mockResolvedValueOnce({
         Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
       })
       .mockResolvedValueOnce({ Item: undefined });
     const result = await handler(makeEvent());
@@ -394,6 +401,13 @@ describe("updateParticipant Lambda", () => {
       .mockResolvedValueOnce({
         Item: {
           tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
           email: { S: "alice@example.com" },
           authUserId: { S: "sub-123" },
@@ -441,6 +455,13 @@ describe("updateParticipant Lambda", () => {
         Item: {
           tenantId: { S: "default-tenant" },
           name: { S: "Demo" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
         },
       })
       .mockResolvedValueOnce({
@@ -547,6 +568,85 @@ describe("updateParticipant Lambda", () => {
 
     expect(result.statusCode).toBe(403);
     expect(JSON.parse(result.body).error).toMatch(/Only admins can force password reset/i);
+  });
+
+  test("allows instructor to update email for invited participant", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // actor role check (email change)
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "old@example.com" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+        },
+      })
+      .mockResolvedValueOnce({});
+    cognitoMockSend.mockResolvedValue({});
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+        body: JSON.stringify({ email: "new@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+  });
+
+  test("returns 403 when instructor tries to change email of active participant", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // actor role check (email change)
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "old@example.com" },
+          authUserId: { S: "sub-123" },
+        },
+      });
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+        body: JSON.stringify({ email: "new@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can change email of registered participants/i);
   });
 
   test("rejects self-linking when other fields are present", async () => {

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -129,7 +129,8 @@ export const handler = async (
       body.forcePasswordResetOnEmailChange === true;
 
     let actorMembershipRole: string | undefined;
-    if (requestsRoleChange || requestsForcedPasswordReset) {
+    const requestsEmailChange = Object.prototype.hasOwnProperty.call(body, "email");
+    if (requestsRoleChange || requestsForcedPasswordReset || requestsEmailChange) {
       const actorMembershipResp = await client.send(
         new GetItemCommand({
           TableName: membershipsTable,
@@ -177,6 +178,20 @@ export const handler = async (
 
     const existing = unmarshall(existingResp.Item) as ParticipantProfile;
     const existingCognitoUsername = existingResp.Item.cognitoUsername?.S;
+    const existingStatus = deriveParticipantStatus(existing);
+    if (requestsEmailChange) {
+      const requestedEmail = typeof body.email === "string" ? body.email.trim() : body.email;
+      const currentEmail = (existing.email ?? "").trim().toLowerCase();
+      const nextEmail = (requestedEmail ?? "").trim().toLowerCase();
+      const emailChanged = currentEmail !== nextEmail;
+      const hasAuthLink = !!existing.authUserId;
+      if (emailChanged && actorMembershipRole !== "admin" && (existingStatus === "active" || hasAuthLink)) {
+        return {
+          statusCode: 403,
+          body: JSON.stringify({ error: "Only admins can change email of registered participants" }),
+        };
+      }
+    }
     let passwordResetTriggered = false;
     let passwordResetEmailSent = false;
     const updated: ParticipantProfile = {


### PR DESCRIPTION
## Summary
- Schaerft das Rollenmodell in der Teilnehmerverwaltung: Trainer duerfen E-Mail nur vor Aktivierung korrigieren, nicht bei registrierten Teilnehmern.
- Schliesst kritische Trainer-Umwege: Passwort-Reset und Delete sind nicht nur im UI verborgen, sondern backendseitig mit 403 abgesichert.
- Ergaenzt Tests fuer Admin-vs-Trainer-Pfade (Update/Delete), damit UI- und API-Verhalten konsistent bleiben.

## Test plan
- [x] `npm run test --prefix app -- src/components/AdminPanel.test.tsx`
- [x] `npm run test --prefix backend -- src/lambdas/updateParticipant/index.test.ts`
- [x] `npm run test --prefix backend -- src/lambdas/deleteParticipant/index.test.ts`
- [x] `npm run lint --prefix backend`

Made with [Cursor](https://cursor.com)