### PR TITLE
Finalize issue #94: token invite/recovery hardening

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,15 +30,7 @@ function MainApp() {
   // App.tsx
   useEffect(() => {
     const initAuth = async () => {
-      // 1. Versuche, User aus localStorage zu laden
-      const stored = loadCurrentUser();
-      if (stored) {
-        console.log('User aus localStorage geladen:', stored);
-        setCurrentUser(stored);
-        return;  // Checkmark Fertig!
-      }
-
-      // 2. Falls kein localStorage: Prüfe Cognito-Session
+      // Always verify Cognito session first. localStorage is only a fallback cache.
       try {
         const session = await fetchAuthSession();
         if (session.tokens?.idToken) {
@@ -53,11 +45,18 @@ function MainApp() {
           saveCurrentUser(user);  // Checkmark Speichern für später!
           setCurrentUser(user);
           console.log('User aus Cognito-Session geladen:', user);
+          return;
         }
       } catch (err) {
         console.log('Keine aktive Session:', err);
-        // Kein User → Login-Seite
       }
+
+      // No valid session: clear stale storage and logged-in state.
+      const stored = loadCurrentUser();
+      if (stored) {
+        clearCurrentUser();
+      }
+      setCurrentUser(null);
     };
 
     initAuth();
@@ -106,7 +105,7 @@ function MainApp() {
 
   // Logout-Handler
   const handleLogout = async () => {
-    logout();
+    await logout();
     clearCurrentUser();
     setCurrentUser(null);
   };

--- a/app/src/api/auth.test.ts
+++ b/app/src/api/auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import { startPasswordResetFromToken } from "./auth";
+
+vi.mock("axios");
+
+describe("startPasswordResetFromToken", () => {
+  beforeEach(() => {
+    vi.mocked(axios.post).mockReset();
+  });
+
+  it("ruft POST /auth/password-reset/from-token mit token+tenantId als Query-Params auf (encoded)", async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: { success: true, username: "Alice" },
+    });
+
+    const result = await startPasswordResetFromToken({
+      token: "t+/=",
+      tenantId: "tenant 1",
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/auth/password-reset/from-token?token=t%2B%2F%3D&tenantId=tenant%201",
+    );
+    expect(result).toEqual({ success: true, username: "Alice" });
+  });
+
+  it("wirft Error mit backend error-Message", async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { error: "Token already used or expired" } },
+      message: "Request failed with status code 400",
+    });
+
+    await expect(
+      startPasswordResetFromToken({ token: "t1", tenantId: "tenant-1" }),
+    ).rejects.toThrow(/Token already used or expired/i);
+  });
+});
+

--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+
+export interface StartPasswordResetFromTokenRequest {
+  tenantId: string;
+  token: string;
+}
+
+export interface StartPasswordResetFromTokenResponse {
+  success: boolean;
+  username: string;
+}
+
+function readErrorMessageFromData(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  const errorValue = record.error;
+  if (typeof errorValue === "string" && errorValue.trim()) return errorValue;
+  const messageValue = record.message;
+  if (typeof messageValue === "string" && messageValue.trim()) return messageValue;
+  return null;
+}
+
+function readErrorMessageFromUnknownError(err: unknown): string | null {
+  if (!err || typeof err !== "object") return null;
+  const record = err as Record<string, unknown>;
+  const response = record.response;
+  if (!response || typeof response !== "object") return null;
+  const responseRecord = response as Record<string, unknown>;
+  return readErrorMessageFromData(responseRecord.data);
+}
+
+export async function startPasswordResetFromToken(
+  req: StartPasswordResetFromTokenRequest,
+): Promise<StartPasswordResetFromTokenResponse> {
+  const { tenantId, token } = req;
+  try {
+    const response = await axios.post<StartPasswordResetFromTokenResponse>(
+      `/auth/password-reset/from-token?token=${encodeURIComponent(token)}&tenantId=${encodeURIComponent(tenantId)}`,
+    );
+    return response.data;
+  } catch (err: unknown) {
+    const messageFromResponse = readErrorMessageFromUnknownError(err);
+    if (messageFromResponse) {
+      throw new Error(messageFromResponse);
+    }
+    if (err instanceof Error) {
+      throw new Error(err.message || "Request failed");
+    }
+    throw new Error("Request failed");
+  }
+}
+

--- a/app/src/api/participants.test.ts
+++ b/app/src/api/participants.test.ts
@@ -33,7 +33,7 @@ describe("inviteUser", () => {
     expect(result).toEqual({ success: true, emailSent: true });
   });
 
-  it("gibt { error: 'Request failed' } bei Serverfehler (z. B. Nickname exists)", async () => {
+  it("gibt Backend-Fehlertext bei Serverfehler zurück", async () => {
     vi.mocked(axios.post).mockRejectedValueOnce({
       response: { data: { error: "Nickname already exists" } },
     });
@@ -44,7 +44,7 @@ describe("inviteUser", () => {
       role: "participant",
     });
 
-    expect(result).toEqual({ error: "Request failed" });
+    expect(result).toEqual({ error: "Nickname already exists" });
   });
 
   it("gibt { error: 'Request failed' } bei Netzwerkfehler ohne response", async () => {

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -27,6 +27,7 @@ export interface UpdateParticipantRequest {
   forcePasswordResetOnEmailChange?: boolean;
   settings?: ParticipantSettings;
   inviteSentAt?: string | null;
+  inviteCompletedAt?: string | null;
   authUserId?: string | null;
 }
 

--- a/app/src/api/participants.ts
+++ b/app/src/api/participants.ts
@@ -49,11 +49,28 @@ export async function inviteUser(data: InviteUserRequest): Promise<InviteUserRes
     return response.data; // { success: true } oder { error: "Nickname already exists" }
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      const backendError =
+        typeof error.response?.data?.error === "string"
+          ? error.response.data.error
+          : undefined;
+      const statusText =
+        typeof error.response?.status === "number"
+          ? `HTTP ${error.response.status}`
+          : undefined;
+      const message = backendError || statusText || error.message || "Request failed";
       console.error('Einladung fehlgeschlagen:', error.response?.data || error.message);
+      return { error: message };
     } else {
+      const genericBackendError =
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        typeof (error as { response?: { data?: { error?: unknown } } }).response?.data?.error === "string"
+          ? (error as { response?: { data?: { error?: string } } }).response?.data?.error
+          : undefined;
       console.error('Einladung fehlgeschlagen:', error);
+      return { error: genericBackendError || "Request failed" };
     }
-    return { error: "Request failed" };
   }
 }
 

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -376,6 +376,74 @@ describe("AdminPanel", () => {
       expect(mockedInviteUser).toHaveBeenCalledWith({ nickname: "alice", role: "participant" });
       expect(mockedUpdateParticipant).not.toHaveBeenCalled();
       expect(
+        within(panel).getByText(/Reaktivierung: Info-Mail gesendet an bestehende Profil-E-Mail\./i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("sendet bei Reaktivierung mit E-Mail-Ueberschreiben die neue E-Mail direkt beim Invite", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "invited",
+      },
+    ]);
+    mockedInviteUser.mockResolvedValueOnce({
+      success: true,
+      emailSent: true,
+      reactivated: true,
+      username: "alice",
+    });
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice.new@example.com",
+      status: "invited",
+    });
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice.new@example.com" },
+    });
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText(/Reaktivierung erkannt fuer bestehenden Teilnehmer: alice/i),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      within(dialog).getByRole("checkbox", {
+        name: /Eingegebene E-Mail fuer Reaktivierung uebernehmen/i,
+      }),
+    );
+    expect(within(dialog).getByText(/Mail geht an: alice\.new@example\.com/i)).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^(Reaktivieren|Anlegen)$/i }));
+
+    await waitFor(() => {
+      expect(mockedInviteUser).toHaveBeenCalledWith({
+        nickname: "alice",
+        role: "participant",
+      });
+      expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", {
+        email: "alice.new@example.com",
+      });
+      expect(
         within(panel).getByText(/Reaktivierung: Info-Mail gesendet an alice\.new@example\.com\./i),
       ).toBeInTheDocument();
     });
@@ -584,9 +652,6 @@ describe("AdminPanel", () => {
         forcePasswordResetOnEmailChange: true,
         role: "participant",
       });
-      expect(
-        within(panel).getByText(/Passwort-Reset-Mail gesendet an alice.new@example.com/i),
-      ).toBeInTheDocument();
     });
   });
 

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -424,7 +424,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       });
 
       if (result.error) {
-        setInviteResultByUserId((prev) => ({ ...prev, [userId]: "Fehler beim Einladen." }));
+        setInviteResultByUserId((prev) => ({
+          ...prev,
+          [userId]: `Fehler beim Einladen: ${result.error}`,
+        }));
         return { ok: false as const };
       }
 
@@ -446,7 +449,17 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       }
 
       if (refreshAfter) {
-        await refreshParticipants();
+        try {
+          await refreshParticipants();
+        } catch (refreshErr) {
+          console.warn("Invite succeeded but participant refresh failed", refreshErr);
+          setInviteResultByUserId((prev) => ({
+            ...prev,
+            [userId]:
+              "Einladung gesendet, aber die Liste konnte nicht aktualisiert werden. Bitte Seite neu laden.",
+          }));
+          return { ok: true as const };
+        }
       }
       return { ok: true as const };
     } catch (err) {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -352,6 +352,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setCreateSaving(true);
     setCreateError("");
     try {
+      const shouldPreUpdateEmailForReactivation =
+        !!createReactivationUserId && createOverwriteEmailOnReactivate && emailValue.length > 0;
+
+      if (shouldPreUpdateEmailForReactivation) {
+        await updateParticipant(createReactivationUserId, { email: emailValue });
+      }
+
       // #67: Teilnehmer anlegen ohne Einladung (kein Cognito/SES).
       // Wir legen zunächst ohne E-Mail an, speichern E-Mail (falls vorhanden) danach separat im Profil.
       const result = await inviteUser({ nickname: nicknameValue, role: createRole });
@@ -364,7 +371,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         return;
       }
 
-      if (emailValue.length > 0 && (!result.reactivated || createOverwriteEmailOnReactivate)) {
+      if (
+        emailValue.length > 0 &&
+        (!result.reactivated || createOverwriteEmailOnReactivate) &&
+        !shouldPreUpdateEmailForReactivation
+      ) {
         await updateParticipant(result.username ?? nicknameValue.toLowerCase(), { email: emailValue });
       } else if (emailValue.length > 0 && result.reactivated && !createOverwriteEmailOnReactivate) {
         setBulkInviteResult(
@@ -374,11 +385,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
 
       const effectiveEmail = emailValue || createEmail;
       if (result.reactivated) {
+        const reactivationNotificationTarget =
+          createOverwriteEmailOnReactivate && emailValue
+            ? emailValue
+            : "bestehende Profil-E-Mail";
         if (result.emailSent) {
           setBulkInviteResult(
-            effectiveEmail
-              ? `Reaktivierung: Info-Mail gesendet an ${effectiveEmail}.`
-              : "Reaktivierung: Info-Mail wurde gesendet.",
+            `Reaktivierung: Info-Mail gesendet an ${reactivationNotificationTarget}.`,
           );
         } else {
           setBulkInviteResult("Reaktivierung erfolgt, aber E-Mail konnte nicht versendet werden.");
@@ -954,8 +967,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       onChange={(e) => setCreateOverwriteEmailOnReactivate(e.target.checked)}
                       disabled={createSaving}
                     />
-                    E-Mail bei Reaktivierung ueberschreiben
+                    Eingegebene E-Mail fuer Reaktivierung uebernehmen
                   </label>
+                  <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                    {createOverwriteEmailOnReactivate && createEmail.trim()
+                      ? `Mail geht an: ${createEmail.trim()}`
+                      : "Mail geht an: bestehende Profil-E-Mail"}
+                  </p>
                 </>
               )}
               {createActiveConflict && (

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -408,7 +408,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     options?: { refreshAfter?: boolean },
   ) => {
     if (!p.email) return;
-    if (p.status === "active") return;
+    if (p.status === "active" && !canEditRoles) return;
 
     const refreshAfter = options?.refreshAfter ?? true;
     const userId = p.userId;
@@ -431,9 +431,12 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       if (result.emailSent) {
         setInviteResultByUserId((prev) => ({
           ...prev,
-          [userId]: result.reactivated
-            ? `Zugang reaktiviert. Info-Mail gesendet an ${p.email}.`
-            : `Einladung gesendet an ${p.email}.`,
+          [userId]:
+            result.reactivated
+              ? `Zugang reaktiviert. Info-Mail gesendet an ${p.email}.`
+              : p.status === "active"
+                ? `Einladungslink zur Passwort-Recovery gesendet an ${p.email}.`
+                : `Einladung gesendet an ${p.email}.`,
         }));
       } else {
         setInviteResultByUserId((prev) => ({
@@ -671,7 +674,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                         !p.email
                           ? "E-Mail fehlt"
                           : p.status === "active"
-                            ? "Bereits registriert"
+                            ? "Bereits registriert (kein Sammelversand)"
                             : "Auswählen"
                       }
                       onChange={(e) => toggleSelectedInviteUserId(p.userId, e.target.checked)}
@@ -700,16 +703,24 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       title={
                         !p.email
                           ? "E-Mail fehlt"
-                          : p.status === "active"
+                          : p.status === "active" && !canEditRoles
                             ? "Bereits registriert"
-                            : p.status === "invited"
-                              ? "Einladung erneut senden"
-                              : "Einladung senden"
+                            : p.status === "active" && canEditRoles
+                              ? "Einladungslink (Recovery) erneut an registrierte Nutzerin senden"
+                              : p.status === "invited"
+                                ? "Einladung erneut senden"
+                                : "Einladung senden"
                       }
-                      aria-label={`${p.status === "invited" ? "Erneut einladen" : "Einladen"} ${p.userId}`}
+                      aria-label={
+                        p.status === "active" && canEditRoles
+                          ? `Einladungslink senden ${p.userId}`
+                          : p.status === "invited"
+                            ? `Erneut einladen ${p.userId}`
+                            : `Einladen ${p.userId}`
+                      }
                       disabled={
                         !p.email ||
-                        p.status === "active" ||
+                        (p.status === "active" && !canEditRoles) ||
                         !!inviteSendingByUserId[p.userId] ||
                         participantsLoading ||
                         editingSaving ||
@@ -719,9 +730,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     >
                       {inviteSendingByUserId[p.userId]
                         ? "..."
-                        : p.status === "invited"
-                          ? "Erneut"
-                          : "Einladen"}
+                        : p.status === "active" && canEditRoles
+                          ? "Link"
+                          : p.status === "invited"
+                            ? "Erneut"
+                            : "Einladen"}
                     </button>
                     {canEditRoles && (
                       <button

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -427,6 +427,8 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     const userId = p.userId;
     const effectiveRole: UserRole = p.role ?? "participant";
 
+    // Avoid stale global status text from previous create/bulk actions.
+    setBulkInviteResult("");
     setInviteSendingByUserId((prev) => ({ ...prev, [userId]: true }));
     setInviteResultByUserId((prev) => ({ ...prev, [userId]: "" }));
     try {
@@ -489,6 +491,8 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     if (p.status !== "active") return;
 
     const userId = p.userId;
+    // Avoid stale global status text from previous create/bulk actions.
+    setBulkInviteResult("");
     setInviteSendingByUserId((prev) => ({ ...prev, [userId]: true }));
     setInviteResultByUserId((prev) => ({ ...prev, [userId]: "" }));
     try {

--- a/app/src/components/ForgotPassword.test.tsx
+++ b/app/src/components/ForgotPassword.test.tsx
@@ -3,22 +3,22 @@ import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import ForgotPassword from "./ForgotPassword";
-import { confirmResetPassword, fetchAuthSession, resetPassword } from "aws-amplify/auth";
-import { saveCurrentUser } from "shared/lib/storage";
+import { confirmResetPassword, resetPassword, signOut } from "aws-amplify/auth";
+import { clearCurrentUser } from "shared/lib/storage";
 
 vi.mock("aws-amplify/auth", () => ({
   resetPassword: vi.fn(),
   confirmResetPassword: vi.fn(),
-  fetchAuthSession: vi.fn(),
+  signOut: vi.fn(),
 }));
 vi.mock("shared/lib/storage", () => ({
-  saveCurrentUser: vi.fn(),
+  clearCurrentUser: vi.fn(),
 }));
 
 const mockedResetPassword = resetPassword as unknown as ReturnType<typeof vi.fn>;
 const mockedConfirmResetPassword = confirmResetPassword as unknown as ReturnType<typeof vi.fn>;
-const mockedFetchAuthSession = fetchAuthSession as unknown as ReturnType<typeof vi.fn>;
-const mockedSaveCurrentUser = saveCurrentUser as unknown as ReturnType<typeof vi.fn>;
+const mockedSignOut = signOut as unknown as ReturnType<typeof vi.fn>;
+const mockedClearCurrentUser = clearCurrentUser as unknown as ReturnType<typeof vi.fn>;
 
 function renderWithRouter(initialEntries: string[] = ["/forgot-password"]) {
   const utils = render(
@@ -39,6 +39,7 @@ function renderWithRouter(initialEntries: string[] = ["/forgot-password"]) {
 describe("ForgotPassword", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedSignOut.mockResolvedValue(undefined);
   });
 
   it("fordert einen Reset-Code an", async () => {
@@ -65,17 +66,6 @@ describe("ForgotPassword", () => {
   it("setzt ein neues Passwort mit Code", async () => {
     mockedResetPassword.mockResolvedValue({});
     mockedConfirmResetPassword.mockResolvedValue({});
-    mockedFetchAuthSession.mockResolvedValue({
-      tokens: {
-        idToken: {
-          payload: {
-            nickname: "alice",
-            email: "alice@example.com",
-            "custom:role": "participant",
-          },
-        },
-      },
-    });
 
     const { page } = renderWithRouter();
 
@@ -94,7 +84,7 @@ describe("ForgotPassword", () => {
     fireEvent.change(within(page).getByPlaceholderText("Neues Passwort"), {
       target: { value: "SicheresPasswort123!" },
     });
-    fireEvent.click(within(page).getByRole("button", { name: /Neues Passwort speichern/i }));
+    fireEvent.click(within(page).getByRole("button", { name: /Neues Passwort setzen/i }));
 
     await waitFor(() => {
       expect(mockedConfirmResetPassword).toHaveBeenCalledWith({
@@ -102,12 +92,8 @@ describe("ForgotPassword", () => {
         confirmationCode: "123456",
         newPassword: "SicheresPasswort123!",
       });
-      expect(mockedFetchAuthSession).toHaveBeenCalled();
-      expect(mockedSaveCurrentUser).toHaveBeenCalledWith({
-        nickname: "alice",
-        email: "alice@example.com",
-        role: "participant",
-      });
+      expect(mockedSignOut).toHaveBeenCalled();
+      expect(mockedClearCurrentUser).toHaveBeenCalled();
     });
   });
 });

--- a/app/src/components/ForgotPassword.tsx
+++ b/app/src/components/ForgotPassword.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { confirmResetPassword, fetchAuthSession, resetPassword } from "aws-amplify/auth";
+import { confirmResetPassword, resetPassword, signOut } from "aws-amplify/auth";
 import { useNavigate } from "react-router-dom";
-import { saveCurrentUser } from "shared/lib/storage";
-import { User, UserRole } from "shared/types";
+import { clearCurrentUser } from "shared/lib/storage";
 
 export default function ForgotPassword() {
   const navigate = useNavigate();
@@ -64,23 +63,21 @@ export default function ForgotPassword() {
         confirmationCode: code.trim(),
         newPassword,
       });
+      // Password reset should never "auto-login" from this view.
+      // We force a clean auth state and redirect to login.
       try {
-        const session = await fetchAuthSession();
-        if (session.tokens?.idToken) {
-          const payload = session.tokens.idToken.payload;
-          const signedInUser: User = {
-            nickname: payload.nickname as string,
-            email: payload.email as string,
-            role: (payload["custom:role"] as UserRole) || "participant",
-          };
-          saveCurrentUser(signedInUser);
-          navigate("/", { replace: true });
-          return;
-        }
+        await signOut({ global: true });
       } catch {
-        // If no session exists, continue to login route.
+        // ignore when no active session exists
       }
-      navigate("/login", { replace: true });
+      clearCurrentUser();
+      navigate("/login", {
+        replace: true,
+        state: {
+          info:
+            "Passwort wurde zurueckgesetzt. Bitte melde dich mit deinem neuen Passwort an.",
+        },
+      });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg || "Passwort konnte nicht zurückgesetzt werden.");
@@ -135,7 +132,7 @@ export default function ForgotPassword() {
           {loading
             ? "Verarbeite..."
             : codeSent
-              ? "Neues Passwort speichern"
+              ? "Neues Passwort setzen"
               : "Code anfordern"}
         </button>
       </form>

--- a/app/src/components/Invite.test.tsx
+++ b/app/src/components/Invite.test.tsx
@@ -220,7 +220,7 @@ describe("Invite", () => {
     });
 
     fireEvent.click(
-      within(panel).getByRole("button", { name: /Neues Passwort speichern/i }),
+      within(panel).getByRole("button", { name: /Passwort zuruecksetzen/i }),
     );
 
     await waitFor(() => {

--- a/app/src/components/Invite.test.tsx
+++ b/app/src/components/Invite.test.tsx
@@ -240,5 +240,23 @@ describe("Invite", () => {
       });
     });
   });
+
+  it("zeigt klare Meldung, wenn Token zu anderem Flow gehoert", async () => {
+    mockedStartPasswordResetFromToken.mockRejectedValue(
+      new Error("Token purpose is invalid"),
+    );
+
+    const { panel } = renderWithParams(
+      "?tenantId=default-tenant&token=t1&nickname=Alice&email=alice@example.com",
+    );
+
+    await waitFor(() => {
+      expect(
+        within(panel).getByText(
+          /Dieser Link gehoert zu einem anderen Vorgang\. Bitte nutze den neuesten Link aus deiner E-Mail\./i,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });
 

--- a/app/src/components/Invite.test.tsx
+++ b/app/src/components/Invite.test.tsx
@@ -3,23 +3,34 @@ import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Invite from "./Invite";
-import { signIn, confirmSignIn, fetchAuthSession } from "@aws-amplify/auth";
+import { signIn, confirmSignIn, fetchAuthSession, signOut, confirmResetPassword } from "@aws-amplify/auth";
 import { saveCurrentUser } from "shared/lib/storage";
 
 vi.mock("@aws-amplify/auth", () => ({
   signIn: vi.fn(),
   confirmSignIn: vi.fn(),
   fetchAuthSession: vi.fn(),
+  signOut: vi.fn(),
+  confirmResetPassword: vi.fn(),
 }));
 
 vi.mock("shared/lib/storage", () => ({
   saveCurrentUser: vi.fn(),
 }));
 
+vi.mock("../api/auth", () => ({
+  startPasswordResetFromToken: vi.fn(),
+}));
+
 const mockedSignIn = signIn as unknown as ReturnType<typeof vi.fn>;
 const mockedConfirmSignIn = confirmSignIn as unknown as ReturnType<typeof vi.fn>;
 const mockedFetchAuthSession = fetchAuthSession as unknown as ReturnType<typeof vi.fn>;
+const mockedSignOut = signOut as unknown as ReturnType<typeof vi.fn>;
+const mockedConfirmResetPassword = confirmResetPassword as unknown as ReturnType<typeof vi.fn>;
 const mockedSaveCurrentUser = saveCurrentUser as unknown as ReturnType<typeof vi.fn>;
+const { startPasswordResetFromToken } = await import("../api/auth");
+const mockedStartPasswordResetFromToken =
+  startPasswordResetFromToken as unknown as ReturnType<typeof vi.fn>;
 
 function renderWithParams(search: string, onSuccess?: () => void) {
   const utils = render(
@@ -39,6 +50,7 @@ describe("Invite", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockedSignOut.mockResolvedValue(undefined);
   });
 
   it("zeigt 'Ungültiger Link.', wenn kein nickname-Parameter vorhanden ist", () => {
@@ -165,6 +177,67 @@ describe("Invite", () => {
           /Benutzername oder temporäres Passwort ist falsch\. Bitte Admin um neue Einladung\./i,
         ),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("unterstützt Token-Flow: ruft startPasswordResetFromToken auf und setzt Passwort per Code", async () => {
+    mockedStartPasswordResetFromToken.mockResolvedValue({
+      success: true,
+      username: "Alice",
+    });
+
+    mockedConfirmResetPassword.mockResolvedValue(undefined);
+    mockedSignIn.mockResolvedValue({ nextStep: { signInStep: "DONE" } });
+    mockedFetchAuthSession.mockResolvedValue({
+      tokens: {
+        idToken: {
+          payload: {
+            nickname: "alice",
+            email: "alice@example.com",
+            "custom:role": "participant",
+          },
+        },
+      },
+    });
+
+    const { panel } = renderWithParams(
+      "?tenantId=default-tenant&token=t1&nickname=Alice&email=alice@example.com",
+    );
+
+    await waitFor(() => {
+      expect(mockedStartPasswordResetFromToken).toHaveBeenCalledWith({
+        tenantId: "default-tenant",
+        token: "t1",
+      });
+    });
+
+    // code + new password
+    fireEvent.change(within(panel).getByPlaceholderText(/Code aus E-Mail/i), {
+      target: { value: "123456" },
+    });
+    fireEvent.change(within(panel).getByPlaceholderText(/Neues Passwort/i), {
+      target: { value: "SicheresPasswort123!" },
+    });
+
+    fireEvent.click(
+      within(panel).getByRole("button", { name: /Neues Passwort speichern/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockedConfirmResetPassword).toHaveBeenCalledWith({
+        username: "Alice",
+        confirmationCode: "123456",
+        newPassword: "SicheresPasswort123!",
+      });
+      expect(mockedSignIn).toHaveBeenCalledWith({
+        username: "Alice",
+        password: "SicheresPasswort123!",
+      });
+      expect(mockedSaveCurrentUser).toHaveBeenCalledWith({
+        nickname: "alice",
+        email: "alice@example.com",
+        role: "participant",
+      });
     });
   });
 });

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -1,10 +1,11 @@
 // src/components/Invite.tsx
 import React, { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { signIn, confirmSignIn, fetchAuthSession, signOut } from "@aws-amplify/auth";
-import { saveCurrentUser } from "shared/lib/storage";
+import { signIn, confirmSignIn, fetchAuthSession, signOut, confirmResetPassword } from "@aws-amplify/auth";
+import { saveCurrentUser, clearCurrentUser } from "shared/lib/storage";
 import { User, UserRole } from "shared/types";
 import { updateParticipant } from "../api/participants";
+import { startPasswordResetFromToken } from "../api/auth";
 
 export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   const [searchParams] = useSearchParams();
@@ -13,6 +14,9 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   // nickname (username) and optional email for display
   const nicknameParam = searchParams.get("nickname") || "";
   const emailDisplay = searchParams.get("email") || "";
+  const tokenParam = searchParams.get("token");
+  const tenantIdParam = searchParams.get("tenantId");
+  const tokenMode = !!tokenParam && !!tenantIdParam;
 
   // Beim Aufruf der Invite-Seite: localStorage leeren, falls anderer User
   useEffect(() => {
@@ -35,23 +39,34 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   // Invite-Flow: sicherstellen, dass kein anderer Cognito-User eingeloggt ist.
   // Sonst wirft Amplify bei signIn() -> UserAlreadyAuthenticatedException.
   useEffect(() => {
-    if (!nicknameParam) return;
+    if (!nicknameParam && !tokenMode) return;
     setAuthCleared(false);
     (async () => {
       try {
-        await signOut();
+        await signOut({ global: true });
       } catch {
         // Wenn niemand eingeloggt ist, ist signOut ein No-Op.
       }
+      // Token-Flow ist "public": wir wollen auf keinen Fall einen alten localStorage-User behalten.
+      if (tokenMode) {
+        try {
+          clearCurrentUser();
+        } catch {
+          // ignore
+        }
+      }
       setAuthCleared(true);
     })();
-  }, [nicknameParam]);
+  }, [nicknameParam, tokenMode]);
 
   // user inputs
   const [tempPassword, setTempPassword] = useState("");
+  const [code, setCode] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
+  const [usernameForReset, setUsernameForReset] = useState("");
 
   // Wir blockieren den Submit, bis ein eventuelles vorheriges signOut abgeschlossen ist.
   // Sonst kann Amplify bei signIn() -> UserAlreadyAuthenticatedException werfen.
@@ -60,7 +75,44 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   
   const usernameForSignIn = nicknameParam ? nicknameParam.trim() : "";
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  // Token-Flow: Beim Laden wird serverseitig der Cognito-Code-Reset angestoßen.
+  useEffect(() => {
+    if (!tokenMode) return;
+    if (!authCleared) return;
+    if (!tokenParam || !tenantIdParam) return;
+
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      setCodeSent(false);
+      setUsernameForReset("");
+      try {
+        const resp = await startPasswordResetFromToken({
+          token: tokenParam,
+          tenantId: tenantIdParam,
+        });
+        if (cancelled) return;
+
+        setUsernameForReset(resp.username as string);
+        setCodeSent(true);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg || "Token konnte nicht verarbeitet werden.");
+        setCodeSent(false);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tokenMode, authCleared, tokenParam, tenantIdParam]);
+
+  const handleSubmitTempPassword = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setLoading(true);
@@ -161,79 +213,196 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
     }
   };
 
-  if (!nicknameParam) return <p>Ungültiger Link.</p>;
+  const handleSubmitTokenReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    if (!tokenMode) {
+      setError("Ungültiger Modus.");
+      setLoading(false);
+      return;
+    }
+    if (!usernameForReset) {
+      setError("Token konnte nicht aufgelöst werden.");
+      setLoading(false);
+      return;
+    }
+    if (!code.trim()) {
+      setError("Bitte den Code aus der E-Mail eingeben.");
+      setLoading(false);
+      return;
+    }
+    if (!newPassword || newPassword.length < 6) {
+      setError("Das neue Passwort muss mindestens 6 Zeichen lang sein.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      await confirmResetPassword({
+        username: usernameForReset,
+        confirmationCode: code.trim(),
+        newPassword,
+      });
+
+      // Wichtig: confirmResetPassword setzt nicht zwingend eine Session.
+      // Deshalb explizit mit neuem Passwort einloggen, damit Axios danach ein JWT hat.
+      try {
+        await signOut({ global: true });
+      } catch {
+        // ignore
+      }
+      await signIn({ username: usernameForReset, password: newPassword });
+
+      const session = await fetchAuthSession();
+      if (session.tokens?.idToken) {
+        const payload = session.tokens.idToken.payload;
+        const user: User = {
+          nickname: payload.nickname as string,
+          email: payload.email as string,
+          role: (payload["custom:role"] as UserRole) || "participant",
+        };
+        saveCurrentUser(user);
+
+        const sub = payload.sub as string | undefined;
+        if (typeof sub === "string" && sub.trim()) {
+          try {
+            await updateParticipant(usernameForReset, { authUserId: sub });
+          } catch (err) {
+            console.error("Failed to link participant authUserId", err);
+          }
+        }
+      }
+
+      onSuccess?.();
+      navigate("/", { replace: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg || "Passwort konnte nicht gesetzt werden.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!nicknameParam && !tokenMode) return <p>Ungültiger Link.</p>;
 
   return (
     <div style={{ maxWidth: 480, margin: "2rem auto", padding: "1rem", border: "1px solid #eee", borderRadius: 8 }}>
       <h2>Willkommen bei YogaSwap</h2>
       <p className="muted" style={{ marginTop: 0 }}>
-        Hallo <strong>{nicknameParam}</strong>,
+        Hallo <strong>{nicknameParam || usernameForReset}</strong>,
       </p>
-      <p className="muted" style={{ marginTop: 0 }}>
-        Aktiviere deinen Zugang mit dem temporaeren Passwort aus der Einladung.
-      </p>
-      {emailDisplay && (
-        <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
-          Einladung gesendet an {emailDisplay}
-        </p>
+      {tokenMode ? (
+        <>
+          <p className="muted" style={{ marginTop: 0 }}>
+            Aktiviere deinen Zugang, indem du den Code aus der E-Mail eingibst.
+          </p>
+          {emailDisplay && (
+            <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
+              Code wird an {emailDisplay} gesendet
+            </p>
+          )}
+
+          <form onSubmit={handleSubmitTokenReset} className="invite-form">
+            <input
+              type="text"
+              placeholder="Code aus E-Mail"
+              value={code}
+              autoComplete="one-time-code"
+              onChange={(e) => setCode(e.target.value)}
+              disabled={loading || !codeSent}
+              required
+              style={{ marginBottom: 12 }}
+              aria-label="Code aus E-Mail"
+            />
+            <input
+              type="password"
+              name="new-password"
+              autoComplete="new-password"
+              aria-label="Neues Passwort"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={loading || !codeSent}
+              className="dialog-field"
+              style={{ marginBottom: 12 }}
+              placeholder="Neues Passwort"
+              minLength={6}
+              required
+            />
+
+            {error && <p style={{ color: "red" }}>{error}</p>}
+
+            <button type="submit" disabled={loading || !authCleared || !codeSent} className="btn-primary btn-block">
+              {loading ? "Verarbeite…" : "Neues Passwort speichern"}
+            </button>
+          </form>
+        </>
+      ) : (
+        <>
+          <p className="muted" style={{ marginTop: 0 }}>
+            Aktiviere deinen Zugang mit dem temporaeren Passwort aus der Einladung.
+          </p>
+          {emailDisplay && (
+            <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
+              Einladung gesendet an {emailDisplay}
+            </p>
+          )}
+
+          <form onSubmit={handleSubmitTempPassword} className="invite-form">
+            {/* Password managers need an explicit username field. */}
+            <input
+              type="text"
+              name="username"
+              autoComplete="username"
+              value={usernameForSignIn}
+              readOnly
+              tabIndex={-1}
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                left: "-10000px",
+                width: 1,
+                height: 1,
+                opacity: 0,
+                pointerEvents: "none",
+              }}
+            />
+            <input
+              type="password"
+              name="temporary-password"
+              autoComplete="current-password"
+              aria-label="Temporäres Passwort"
+              value={tempPassword}
+              onChange={(e) => setTempPassword(e.target.value.trim())}
+              disabled={loading}
+              className="dialog-field"
+              style={{ marginBottom: 12 }}
+              placeholder="Temporäres Passwort"
+            />
+
+            <input
+              type="password"
+              name="new-password"
+              autoComplete="new-password"
+              aria-label="Neues Passwort"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={loading}
+              className="dialog-field"
+              style={{ marginBottom: 12 }}
+              placeholder="Neues Passwort"
+              minLength={6}
+            />
+
+            {error && <p style={{ color: "red" }}>{error}</p>}
+
+            <button type="submit" disabled={loading} className="btn-primary btn-block">
+              {loading ? "Verarbeite…" : "Zugang aktivieren"}
+            </button>
+          </form>
+        </>
       )}
-
-      <form onSubmit={handleSubmit} className="invite-form">
-        {/* Password managers need an explicit username field. */}
-        <input
-          type="text"
-          name="username"
-          autoComplete="username"
-          value={usernameForSignIn}
-          readOnly
-          tabIndex={-1}
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            left: "-10000px",
-            width: 1,
-            height: 1,
-            opacity: 0,
-            pointerEvents: "none",
-          }}
-        />
-        <input
-          type="password"
-          name="temporary-password"
-          autoComplete="current-password"
-          aria-label="Temporäres Passwort"
-          value={tempPassword}
-          onChange={(e) => setTempPassword(e.target.value.trim())}
-          disabled={loading}
-          className="dialog-field"
-          style={{ marginBottom: 12 }}
-          placeholder="Temporäres Passwort"
-        />
-
-        <input
-          type="password"
-          name="new-password"
-          autoComplete="new-password"
-          aria-label="Neues Passwort"
-          value={newPassword}
-          onChange={(e) => setNewPassword(e.target.value)}
-          disabled={loading}
-          className="dialog-field"
-          style={{ marginBottom: 12 }}
-          placeholder="Neues Passwort"
-          minLength={6}
-        />
-
-        {error && <p style={{ color: "red" }}>{error}</p>}
-
-        <button
-          type="submit"
-          disabled={loading || !authCleared}
-          className="btn-primary btn-block"
-        >
-          {loading ? "Verarbeite…" : "Zugang aktivieren"}
-        </button>
-      </form>
     </div>
   );
 }

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -20,6 +20,15 @@ function parseMode(modeRaw: string | null): AuthViewMode | null {
   return null;
 }
 
+function mapTokenStartErrorMessage(rawMessage: string): string {
+  const msg = rawMessage.trim();
+  if (!msg) return "Token konnte nicht verarbeitet werden.";
+  if (msg.includes("Token purpose is invalid")) {
+    return "Dieser Link gehoert zu einem anderen Vorgang. Bitte nutze den neuesten Link aus deiner E-Mail.";
+  }
+  return msg;
+}
+
 export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -137,7 +146,7 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
       } catch (err: unknown) {
         if (cancelled) return;
         const msg = err instanceof Error ? err.message : String(err);
-        setError(msg || "Token konnte nicht verarbeitet werden.");
+        setError(mapTokenStartErrorMessage(msg));
         setCodeSent(false);
       } finally {
         if (!cancelled) setLoading(false);

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -7,6 +7,19 @@ import { User, UserRole } from "shared/types";
 import { updateParticipant } from "../api/participants";
 import { startPasswordResetFromToken } from "../api/auth";
 
+type AuthViewMode = "invite_activation" | "password_recovery" | "admin_reset";
+
+function parseMode(modeRaw: string | null): AuthViewMode | null {
+  const v = (modeRaw || "").trim().toLowerCase();
+  if (!v) return null;
+  if (v === "invite_activation" || v === "password_recovery" || v === "admin_reset") return v;
+  // Backward compatibility for older links
+  if (v === "invite-activation") return "invite_activation";
+  if (v === "password-recovery") return "password_recovery";
+  if (v === "admin-reset") return "admin_reset";
+  return null;
+}
+
 export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -16,7 +29,31 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
   const emailDisplay = searchParams.get("email") || "";
   const tokenParam = searchParams.get("token");
   const tenantIdParam = searchParams.get("tenantId");
+  const modeParam = parseMode(searchParams.get("mode"));
   const tokenMode = !!tokenParam && !!tenantIdParam;
+  const authMode: AuthViewMode = tokenMode
+    ? modeParam ?? "password_recovery"
+    : "invite_activation";
+
+  const modeCopy: Record<AuthViewMode, { subtitle: string; submitLabel: string }> = {
+    invite_activation: {
+      subtitle: "Aktiviere deinen Zugang, indem du den Code aus der E-Mail eingibst.",
+      submitLabel: "Zugang aktivieren",
+    },
+    password_recovery: {
+      subtitle: "Setze dein Passwort zurueck. Gib dazu den Code aus der E-Mail ein.",
+      submitLabel: "Passwort zuruecksetzen",
+    },
+    admin_reset: {
+      subtitle: "Dein Passwort wurde durch das Studio zurueckgesetzt. Gib den Code aus der E-Mail ein.",
+      submitLabel: "Passwort setzen",
+    },
+  };
+
+  const subtitleText =
+    tokenMode
+      ? modeCopy[authMode].subtitle
+      : "Aktiviere deinen Zugang mit dem temporaeren Passwort aus der Einladung.";
 
   // Beim Aufruf der Invite-Seite: localStorage leeren, falls anderer User
   useEffect(() => {
@@ -295,9 +332,7 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
       </p>
       {tokenMode ? (
         <>
-          <p className="muted" style={{ marginTop: 0 }}>
-            Aktiviere deinen Zugang, indem du den Code aus der E-Mail eingibst.
-          </p>
+          <p className="muted" style={{ marginTop: 0 }}>{subtitleText}</p>
           {emailDisplay && (
             <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
               Code wird an {emailDisplay} gesendet
@@ -334,15 +369,13 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
             {error && <p style={{ color: "red" }}>{error}</p>}
 
             <button type="submit" disabled={loading || !authCleared || !codeSent} className="btn-primary btn-block">
-              {loading ? "Verarbeite…" : "Neues Passwort speichern"}
+              {loading ? "Verarbeite…" : modeCopy[authMode].submitLabel}
             </button>
           </form>
         </>
       ) : (
         <>
-          <p className="muted" style={{ marginTop: 0 }}>
-            Aktiviere deinen Zugang mit dem temporaeren Passwort aus der Einladung.
-          </p>
+          <p className="muted" style={{ marginTop: 0 }}>{subtitleText}</p>
           {emailDisplay && (
             <p className="muted" style={{ marginTop: 0, fontSize: 12 }}>
               Einladung gesendet an {emailDisplay}
@@ -398,7 +431,7 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
             {error && <p style={{ color: "red" }}>{error}</p>}
 
             <button type="submit" disabled={loading} className="btn-primary btn-block">
-              {loading ? "Verarbeite…" : "Zugang aktivieren"}
+              {loading ? "Verarbeite…" : modeCopy[authMode].submitLabel}
             </button>
           </form>
         </>

--- a/app/src/components/Login.tsx
+++ b/app/src/components/Login.tsx
@@ -2,7 +2,7 @@
 import { User } from "shared/types";
 import { loadCurrentUser } from "shared/lib/storage";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useCognitoAuth } from "../auth/useCognitoAuth";
 
 type Props = {
@@ -14,16 +14,24 @@ const DEMO_USERNAME = "Luna";
 const DEMO_PASSWORD = "Hallo123!";
 
 export default function Login({ onLogin }: Props) {
+  const { state } = useLocation();
+  const navigate = useNavigate();
   const [username, setUsername] = useState(DEMO_USERNAME);
   const [password, setPassword] = useState(DEMO_PASSWORD);
   const { login, isLoading, error } = useCognitoAuth();
+  const infoMessage = typeof (state as { info?: unknown } | null)?.info === "string"
+    ? (state as { info: string }).info
+    : "";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const success = await login({ username, password });
     if (success) {
       const user = loadCurrentUser();
-      onLogin(user!);
+      if (user) {
+        onLogin(user);
+      }
+      navigate("/", { replace: true });
     }
   };
 
@@ -55,6 +63,7 @@ export default function Login({ onLogin }: Props) {
         <Link to="/forgot-password">Passwort vergessen?</Link>
       </p>
 
+      {infoMessage && <p style={{ color: "#374151" }}>{infoMessage}</p>}
       {error && <p style={{ color: "crimson" }}>{error}</p>}
 
       <p style={{ fontSize: 12, opacity: 0.8 }}>

--- a/app/src/components/changePassword.test.tsx
+++ b/app/src/components/changePassword.test.tsx
@@ -78,7 +78,7 @@ describe("ChangePassword", () => {
     fireEvent.change(within(page).getByPlaceholderText("Neues Passwort"), {
       target: { value: "SicheresPasswort123!" },
     });
-    fireEvent.click(within(page).getByRole("button", { name: /Speichern/i }));
+    fireEvent.click(within(page).getByRole("button", { name: /Passwort festlegen/i }));
 
     await waitFor(() => {
       expect(mockedConfirmSignIn).toHaveBeenCalledWith({

--- a/app/src/components/changePassword.tsx
+++ b/app/src/components/changePassword.tsx
@@ -58,7 +58,7 @@ export default function ChangePassword() {
         />
         {error && <p style={{ color: "crimson" }}>{error}</p>}
         <button type="submit" disabled={loading} className="btn-primary btn-block">
-          Speichern
+          Passwort festlegen
         </button>
       </form>
     </div>

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -9,6 +9,8 @@ jest.mock('@aws-sdk/client-cognito-identity-provider', () => {
     AdminCreateUserCommand: jest.fn((input) => input),
     AdminAddUserToGroupCommand: jest.fn((input) => input),
     AdminSetUserPasswordCommand: jest.fn((input) => input),
+    AdminUpdateUserAttributesCommand: jest.fn((input) => input),
+    AdminGetUserCommand: jest.fn((input) => input),
     mockSend,
   };
 });
@@ -39,6 +41,13 @@ const { mockSend: cognitoMockSend } = jest.requireMock('@aws-sdk/client-cognito-
 const { mockSend: sesMockSend } = jest.requireMock('@aws-sdk/client-ses');
 const { mockSend: dynamoMockSend } = jest.requireMock('@aws-sdk/client-dynamodb');
 
+function adminGetUserResponse(username: string, sub = `sub-${username}`) {
+  return {
+    Username: username,
+    UserAttributes: [{ Name: 'sub', Value: sub }],
+  };
+}
+
 describe('createParticipants Lambda', () => {
   const OLD_ENV = process.env;
 
@@ -49,6 +58,8 @@ describe('createParticipants Lambda', () => {
       USER_POOL_ID: 'test-user-pool-id',
       BASE_URL: 'https://yogaswap.example.com',
       SES_SOURCE_EMAIL: 'yogaswap@example.com',
+      AUTH_TOKENS_TABLE: 'test-auth-tokens-table',
+      AUTH_TOKEN_TTL_SECONDS: '3600',
       MEMBERSHIPS_TABLE: 'test-memberships-table',
       PARTICIPANTS_TABLE: 'test-participants-table',
     };
@@ -132,7 +143,9 @@ describe('createParticipants Lambda', () => {
   test('successfully creates a new user', async () => {
     cognitoMockSend
       .mockResolvedValueOnce({}) // AdminCreateUserCommand
-      .mockResolvedValueOnce({}); // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce({}) // AdminSetUserPasswordCommand (token flow bootstrap)
+      .mockResolvedValueOnce({}) // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce(adminGetUserResponse('testuser')); // AdminGetUserCommand (sync sub / canonical username)
     sesMockSend.mockResolvedValueOnce({}); // SendEmailCommand
 
     const event = baseEvent({
@@ -150,9 +163,11 @@ describe('createParticipants Lambda', () => {
     expect(body.username).toBe('testuser');
     expect(body.emailSent).toBe(true);
     expect(body.tempPassword).toBeUndefined(); // Should not be in response if email sent
+    expect(body.link).toMatch(/\/invite\?/);
+    expect(body.link).toMatch(/token=/);
 
     // Verify Cognito calls
-    expect(cognitoMockSend).toHaveBeenCalledTimes(2);
+    expect(cognitoMockSend).toHaveBeenCalledTimes(4);
     expect(cognitoMockSend).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -170,7 +185,22 @@ describe('createParticipants Lambda', () => {
       expect.objectContaining({
         UserPoolId: 'test-user-pool-id',
         Username: 'testuser',
+        Permanent: true,
+      })
+    );
+    expect(cognitoMockSend).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        UserPoolId: 'test-user-pool-id',
+        Username: 'testuser',
         GroupName: 'participant',
+      })
+    );
+    expect(cognitoMockSend).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        UserPoolId: 'test-user-pool-id',
+        Username: 'testuser',
       })
     );
 
@@ -211,7 +241,9 @@ describe('createParticipants Lambda', () => {
   test('keeps first entered casing as canonical user id', async () => {
     cognitoMockSend
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(adminGetUserResponse('Kai'));
     sesMockSend.mockResolvedValueOnce({});
 
     const event = baseEvent({
@@ -252,7 +284,9 @@ describe('createParticipants Lambda', () => {
     cognitoMockSend
       .mockRejectedValueOnce(usernameExistsError) // AdminCreateUserCommand fails
       .mockResolvedValueOnce({}) // AdminSetUserPasswordCommand succeeds
-      .mockResolvedValueOnce({}); // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce({}) // AdminUpdateUserAttributesCommand
+      .mockResolvedValueOnce({}) // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce(adminGetUserResponse('existinguser')); // AdminGetUserCommand
     sesMockSend.mockResolvedValueOnce({}); // SendEmailCommand
     dynamoMockSend.mockResolvedValueOnce({ Item: undefined }); // participant profile lookup -> no authUserId
 
@@ -270,24 +304,37 @@ describe('createParticipants Lambda', () => {
     expect(body.username).toBe('existinguser');
 
     // Verify password reset was called
-    expect(cognitoMockSend).toHaveBeenCalledTimes(3);
+    expect(cognitoMockSend).toHaveBeenCalledTimes(5);
     expect(cognitoMockSend).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         UserPoolId: 'test-user-pool-id',
         Username: 'existinguser',
-        Permanent: false,
+        Permanent: true,
+      })
+    );
+    expect(cognitoMockSend).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        UserPoolId: 'test-user-pool-id',
+        Username: 'existinguser',
+        UserAttributes: expect.arrayContaining([
+          { Name: 'email', Value: 'existing@example.com' },
+          { Name: 'email_verified', Value: 'true' },
+        ]),
       })
     );
   });
 
-  test('reactivates existing login without password reset when authUserId exists', async () => {
+  test('registered user with authUserId gets token invite resend when AUTH_TOKENS_TABLE is set', async () => {
     const usernameExistsError = new Error('User already exists');
     (usernameExistsError as any).name = 'UsernameExistsException';
 
     cognitoMockSend
       .mockRejectedValueOnce(usernameExistsError) // AdminCreateUserCommand fails
-      .mockResolvedValueOnce({}); // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce({}) // AdminUpdateUserAttributesCommand (sync email for reset code)
+      .mockResolvedValueOnce({}) // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce(adminGetUserResponse('existinguser', 'sub-123')); // AdminGetUserCommand
     sesMockSend.mockResolvedValueOnce({});
     dynamoMockSend
       .mockResolvedValueOnce({
@@ -311,11 +358,60 @@ describe('createParticipants Lambda', () => {
     const body = JSON.parse(result.body);
     expect(body.success).toBe(true);
     expect(body.emailSent).toBe(true);
-    expect(body.reactivated).toBe(true);
+    expect(body.reactivated).toBe(false);
+    expect(body.link).toMatch(/token=/);
     expect(body.tempPassword).toBeUndefined();
 
-    // No AdminSetUserPassword call in reactivation path.
-    expect(cognitoMockSend).toHaveBeenCalledTimes(2);
+    expect(cognitoMockSend).toHaveBeenCalledTimes(4);
+    expect(cognitoMockSend).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        UserPoolId: 'test-user-pool-id',
+        Username: 'existinguser',
+        UserAttributes: expect.arrayContaining([
+          { Name: 'email', Value: 'existing@example.com' },
+          { Name: 'email_verified', Value: 'true' },
+        ]),
+      }),
+    );
+  });
+
+  test('reactivates existing login without token table (legacy email only)', async () => {
+    const usernameExistsError = new Error('User already exists');
+    (usernameExistsError as any).name = 'UsernameExistsException';
+
+    delete process.env.AUTH_TOKENS_TABLE;
+
+    cognitoMockSend
+      .mockRejectedValueOnce(usernameExistsError)
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(adminGetUserResponse('legacyuser', 'sub-legacy'));
+    sesMockSend.mockResolvedValueOnce({});
+    dynamoMockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: 'default-tenant' },
+          userId: { S: 'legacyuser' },
+          authUserId: { S: 'sub-legacy' },
+        },
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    const event = baseEvent({
+      email: 'legacy@example.com',
+      nickname: 'legacyuser',
+      role: 'participant',
+    });
+
+    const result = await handler(event);
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.reactivated).toBe(true);
+    expect(body.link).not.toMatch(/token=/);
+
+    expect(cognitoMockSend).toHaveBeenCalledTimes(3);
+    process.env.AUTH_TOKENS_TABLE = 'test-auth-tokens-table';
   });
 
   test('sends reactivation email when existing active user is reactivated without request email', async () => {
@@ -380,7 +476,7 @@ describe('createParticipants Lambda', () => {
     const result = await handler(event);
 
     expect(result.statusCode).toBe(500);
-    expect(JSON.parse(result.body).error).toBe('Failed to reset password');
+    expect(JSON.parse(result.body).error).toBe('Failed to prepare existing user');
   });
 
   test('returns 500 if user creation fails with non-UsernameExists error', async () => {
@@ -402,7 +498,9 @@ describe('createParticipants Lambda', () => {
     const groupError = new Error('Group assignment failed');
     cognitoMockSend
       .mockResolvedValueOnce({}) // AdminCreateUserCommand
-      .mockRejectedValueOnce(groupError); // AdminAddUserToGroupCommand fails
+      .mockResolvedValueOnce({}) // AdminSetUserPasswordCommand
+      .mockRejectedValueOnce(groupError) // AdminAddUserToGroupCommand fails
+      .mockResolvedValueOnce(adminGetUserResponse('testuser')); // AdminGetUserCommand
     sesMockSend.mockResolvedValueOnce({}); // SendEmailCommand
 
     const event = baseEvent({
@@ -418,10 +516,12 @@ describe('createParticipants Lambda', () => {
     expect(JSON.parse(result.body).success).toBe(true);
   });
 
-  test('returns tempPassword if email sending fails', async () => {
+  test('returns inviteToken if email sending fails', async () => {
     cognitoMockSend
       .mockResolvedValueOnce({}) // AdminCreateUserCommand
-      .mockResolvedValueOnce({}); // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce({}) // AdminSetUserPasswordCommand
+      .mockResolvedValueOnce({}) // AdminAddUserToGroupCommand
+      .mockResolvedValueOnce(adminGetUserResponse('testuser')); // AdminGetUserCommand
     sesMockSend.mockRejectedValueOnce(new Error('SES error')); // SendEmailCommand fails
 
     const event = baseEvent({
@@ -436,7 +536,8 @@ describe('createParticipants Lambda', () => {
     const body = JSON.parse(result.body);
     expect(body.success).toBe(true);
     expect(body.emailSent).toBe(false);
-    expect(body.tempPassword).toBeDefined();
+    expect(body.tempPassword).toBeUndefined();
+    expect(body.inviteToken).toBeDefined();
     expect(body.warning).toContain('E-Mail konnte nicht versendet werden');
 
     // Even if SES fails, inviteSentAt should be stored so status becomes "invited".
@@ -453,7 +554,9 @@ describe('createParticipants Lambda', () => {
   test('handles event.body as object (not string)', async () => {
     cognitoMockSend
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(adminGetUserResponse('testuser'));
     sesMockSend.mockResolvedValueOnce({});
 
     const event = {
@@ -474,7 +577,9 @@ describe('createParticipants Lambda', () => {
     process.env.BASE_URL = '';
     cognitoMockSend
       .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(adminGetUserResponse('testuser'));
     sesMockSend.mockResolvedValueOnce({});
 
     const event = baseEvent({

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -334,6 +334,7 @@ describe('createParticipants Lambda', () => {
     cognitoMockSend
       .mockRejectedValueOnce(usernameExistsError) // AdminCreateUserCommand fails
       .mockResolvedValueOnce({}) // AdminUpdateUserAttributesCommand (sync email for reset code)
+      .mockResolvedValueOnce({}) // AdminSetUserPasswordCommand (normalize state for reset flow)
       .mockResolvedValueOnce({}) // AdminAddUserToGroupCommand
       .mockResolvedValueOnce(adminGetUserResponse('existinguser', 'sub-123')); // AdminGetUserCommand
     sesMockSend.mockResolvedValueOnce({});
@@ -363,7 +364,7 @@ describe('createParticipants Lambda', () => {
     expect(body.link).toMatch(/token=/);
     expect(body.tempPassword).toBeUndefined();
 
-    expect(cognitoMockSend).toHaveBeenCalledTimes(4);
+    expect(cognitoMockSend).toHaveBeenCalledTimes(5);
     expect(cognitoMockSend).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -32,6 +32,7 @@ jest.mock('@aws-sdk/client-dynamodb', () => {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     GetItemCommand: jest.fn((input) => input),
     PutItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
     ScanCommand: jest.fn((input) => input),
     mockSend,
   };

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -507,7 +507,7 @@ export const handler = async (event: any) => {
   const nowSeconds = Math.floor(Date.now() / 1000);
 
   let oneTimeToken: string | undefined;
-  let link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
+  let link = `${baseUrl}/invite?mode=invite_activation&nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
 
   // Token nur für "echte Einladung" (nicht für Reaktivierung ohne Passwortreset).
   if (!reactivated && tokensTable) {
@@ -533,7 +533,7 @@ export const handler = async (event: any) => {
     }
 
     if (oneTimeToken) {
-      link = `${baseUrl}/invite?tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(
+      link = `${baseUrl}/invite?mode=invite_activation&tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(
         oneTimeToken,
       )}&nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
     }

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -209,6 +209,17 @@ export const handler = async (event: any) => {
     }
   }
 
+  // Security hardening (#94): For new/invite flows with email we require token-table mode.
+  // Existing login reactivation without token table remains allowed (no temp password mail).
+  if (hasEmail && !tokensTable && !existingAuthUserId) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: "AUTH_TOKENS_TABLE is required for secure invite flow",
+      }),
+    };
+  }
+
   // Email optional: if missing/empty, skip Cognito and SES and only write membership to DynamoDB.
   if (!hasEmail) {
     const reactivated = !!existingAuthUserId;
@@ -528,6 +539,15 @@ export const handler = async (event: any) => {
     }
   }
 
+  if (!reactivated && tokenInviteEnabled && !oneTimeToken) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: "Failed to create secure invite token",
+      }),
+    };
+  }
+
   // Send invitation email (Token-Link, kein temporäres Passwort im E-Mail-Body)
   const emailHtml = reactivated
     ? `
@@ -545,15 +565,8 @@ export const handler = async (event: any) => {
       `
       : `
         <h2>Hallo ${nicknameRaw}!</h2>
-        <p>Du wurdest zu YogaSwap eingeladen.</p>
-        <p><a href="${link}">Klicke hier, um dein temporäres Passwort einzugeben und ein neues Passwort zu setzen</a></p>
-        <div style="margin-top:12px;">
-          <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
-          <div>
-            <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
-          </div>
-        </div>
-        <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
+        <p>Dein Zugang wird vorbereitet.</p>
+        <p>Bitte kontaktiere dein Studio, falls du keinen gueltigen Einladungslink erhalten hast.</p>
       `;
 
   let emailSent = false;

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -10,6 +10,11 @@ import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { GetItemCommand, PutItemCommand, QueryCommand, type AttributeValue } from "@aws-sdk/client-dynamodb";
 import crypto from "crypto";
 import { dynamoClient } from "../shared/dynamoClient";
+import {
+  buildInviteMail,
+  buildInvitePreparationMail,
+  buildReactivationMail,
+} from "../shared/templates/auth/authMailTemplates";
 
 const cognito = new CognitoIdentityProviderClient({});
 const ses = new SESClient({});
@@ -146,6 +151,7 @@ export const handler = async (event: any) => {
   const tenantId = getTenantId(event);
   const tokensTable = process.env.AUTH_TOKENS_TABLE;
   const tokenInviteEnabled = !!tokensTable;
+  const mailLocale = process.env.MAIL_LOCALE || "de";
 
   const emailNormalized = typeof email === "string" ? email.trim() : "";
   const hasEmail = emailNormalized.length > 0;
@@ -256,20 +262,19 @@ export const handler = async (event: any) => {
         const baseUrlEnv = process.env.BASE_URL || "";
         const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
         const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
-        const reactivatedHtml = `
-          <h2>Hallo ${nicknameRaw}!</h2>
-          <p>Dein Zugang zu YogaSwap wurde fuer dieses Studio reaktiviert.</p>
-          <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
-          <p><a href="${baseUrl}">Zur Anmeldung</a></p>
-        `;
+        const reactivationMail = buildReactivationMail({
+          locale: mailLocale,
+          nickname: nicknameRaw,
+          loginUrl: baseUrl,
+        });
         try {
           await ses.send(
             new SendEmailCommand({
               Source: sesSourceEmail,
               Destination: { ToAddresses: [existingEmail.trim()] },
               Message: {
-                Subject: { Data: "YogaSwap Reaktivierung" },
-                Body: { Html: { Data: reactivatedHtml } },
+                Subject: { Data: reactivationMail.subject },
+                Body: { Html: { Data: reactivationMail.html } },
               },
             }),
           );
@@ -549,25 +554,20 @@ export const handler = async (event: any) => {
   }
 
   // Send invitation email (Token-Link, kein temporäres Passwort im E-Mail-Body)
-  const emailHtml = reactivated
-    ? `
-      <h2>Hallo ${nicknameRaw}!</h2>
-      <p>Dein Zugang zu YogaSwap wurde für dieses Studio reaktiviert.</p>
-      <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
-      <p><a href="${baseUrl}">Zur Anmeldung</a></p>
-    `
-    : tokensTable && oneTimeToken
-      ? `
-        <h2>Hallo ${nicknameRaw}!</h2>
-        <p>Du wurdest zu YogaSwap eingeladen.</p>
-        <p><a href="${link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
-        <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
-      `
-      : `
-        <h2>Hallo ${nicknameRaw}!</h2>
-        <p>Dein Zugang wird vorbereitet.</p>
-        <p>Bitte kontaktiere dein Studio, falls du keinen gueltigen Einladungslink erhalten hast.</p>
-      `;
+  const reactivationMail = buildReactivationMail({
+    locale: mailLocale,
+    nickname: nicknameRaw,
+    loginUrl: baseUrl,
+  });
+  const inviteMail = buildInviteMail({
+    locale: mailLocale,
+    nickname: nicknameRaw,
+    link,
+  });
+  const fallbackMail = buildInvitePreparationMail({
+    locale: mailLocale,
+    nickname: nicknameRaw,
+  });
 
   let emailSent = false;
   try {
@@ -579,8 +579,18 @@ export const handler = async (event: any) => {
       Source: sesSourceEmail,
       Destination: { ToAddresses: [emailNormalized] },
       Message: {
-        Subject: { Data: reactivated ? "YogaSwap Reaktivierung" : "YogaSwap Einladung" },
-        Body: { Html: { Data: emailHtml } }
+        Subject: {
+          Data: reactivated
+            ? reactivationMail.subject
+            : (tokensTable && oneTimeToken ? inviteMail.subject : fallbackMail.subject),
+        },
+        Body: {
+          Html: {
+            Data: reactivated
+              ? reactivationMail.html
+              : (tokensTable && oneTimeToken ? inviteMail.html : fallbackMail.html),
+          },
+        }
       }
     }));
     emailSent = true;

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -7,7 +7,7 @@ import {
   AdminGetUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
-import { GetItemCommand, PutItemCommand, ScanCommand, type AttributeValue } from "@aws-sdk/client-dynamodb";
+import { GetItemCommand, PutItemCommand, QueryCommand, type AttributeValue } from "@aws-sdk/client-dynamodb";
 import crypto from "crypto";
 import { dynamoClient } from "../shared/dynamoClient";
 
@@ -16,6 +16,7 @@ const ses = new SESClient({});
 const dynamodb = dynamoClient;
 
 const DEFAULT_TENANT_ID = "default-tenant";
+const PARTICIPANTS_NORMALIZED_INDEX = "GSI_UserIdNormalized";
 
 function getTenantId(event: any): string {
   // Behandle baseEvent-Mock (event.headers ist in tests teils undefined, daher Fallback prüfen)
@@ -53,6 +54,7 @@ async function saveParticipantProfile(params: {
   let item: Record<string, AttributeValue> = {
     tenantId: { S: params.tenantId },
     userId: { S: params.userId },
+    userIdNormalized: { S: params.userId.toLowerCase() },
   };
 
   try {
@@ -71,6 +73,7 @@ async function saveParticipantProfile(params: {
         ...existing.Item,
         tenantId: { S: params.tenantId },
         userId: { S: params.userId },
+        userIdNormalized: { S: params.userId.toLowerCase() },
       };
     }
   } catch (err) {
@@ -181,18 +184,19 @@ export const handler = async (event: any) => {
         existingAuthUserId = lowerItem.authUserId?.S;
         existingEmail = lowerItem.email?.S;
       } else {
-        const scanResp = await dynamodb.send(
-          new ScanCommand({
+        const queryResp = await dynamodb.send(
+          new QueryCommand({
             TableName: process.env.PARTICIPANTS_TABLE,
-            FilterExpression: "tenantId = :tenantId",
-            ExpressionAttributeValues: { ":tenantId": { S: tenantId } },
-            ProjectionExpression: "userId, authUserId, cognitoUsername, email",
+            IndexName: PARTICIPANTS_NORMALIZED_INDEX,
+            KeyConditionExpression: "tenantId = :tenantId AND userIdNormalized = :userIdNormalized",
+            ExpressionAttributeValues: {
+              ":tenantId": { S: tenantId },
+              ":userIdNormalized": { S: nicknameNormalized },
+            },
+            Limit: 1,
           }),
         );
-        const matched = (scanResp.Items ?? []).find((item) => {
-          const id = item.userId?.S ?? "";
-          return id.toLowerCase() === nicknameNormalized;
-        });
+        const matched = queryResp.Items?.[0];
         if (matched?.userId?.S) {
           canonicalUserId = matched.userId.S;
           cognitoUsername = matched.cognitoUsername?.S || matched.userId.S;

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -1,6 +1,14 @@
-import { AdminCreateUserCommand, AdminAddUserToGroupCommand, CognitoIdentityProviderClient, AdminSetUserPasswordCommand} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AdminCreateUserCommand,
+  AdminAddUserToGroupCommand,
+  CognitoIdentityProviderClient,
+  AdminSetUserPasswordCommand,
+  AdminUpdateUserAttributesCommand,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { GetItemCommand, PutItemCommand, ScanCommand, type AttributeValue } from "@aws-sdk/client-dynamodb";
+import crypto from "crypto";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const cognito = new CognitoIdentityProviderClient({});
@@ -24,12 +32,18 @@ function generateSafeTempPassword(length = 10) {
   return pw;
 }
 
+function generateOneTimeToken(bytes = 32) {
+  // base64url => keine "/" oder "+" im Token (besser für URL-Parameter).
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
 async function saveParticipantProfile(params: {
   tenantId: string;
   userId: string;
   email?: string;
   inviteSentAt?: string;
   cognitoUsername?: string;
+  authUserId?: string;
 }) {
   if (!process.env.PARTICIPANTS_TABLE) {
     console.warn("PARTICIPANTS_TABLE environment variable not set, skipping participant profile write.");
@@ -72,6 +86,9 @@ async function saveParticipantProfile(params: {
   if (params.cognitoUsername && params.cognitoUsername.trim()) {
     item.cognitoUsername = { S: params.cognitoUsername.trim() };
   }
+  if (params.authUserId && params.authUserId.trim()) {
+    item.authUserId = { S: params.authUserId.trim() };
+  }
 
   await dynamodb.send(
     new PutItemCommand({
@@ -79,6 +96,34 @@ async function saveParticipantProfile(params: {
       Item: item,
     }),
   );
+}
+
+/** Cognito liefert den kanonischen Username + sub; beides kann von Dynamo (z. B. nach Altlasten) abweichen. */
+async function resolveCognitoUsernameAndSub(
+  userPoolId: string,
+  primaryUsername: string,
+  fallbackUsername: string,
+): Promise<{ username: string; sub?: string } | null> {
+  const candidates = [primaryUsername, fallbackUsername].filter(
+    (v, i, a) => v.trim() && a.indexOf(v) === i,
+  );
+  for (const candidate of candidates) {
+    try {
+      const resp = await cognito.send(
+        new AdminGetUserCommand({
+          UserPoolId: userPoolId,
+          Username: candidate,
+        }),
+      );
+      const canonical = resp.Username?.trim();
+      if (!canonical) continue;
+      const sub = resp.UserAttributes?.find((a) => a.Name === "sub")?.Value?.trim();
+      return { username: canonical, sub: sub || undefined };
+    } catch {
+      // nächster Kandidat (Groß-/Kleinschreibung, veralteter cognitoUsername in Dynamo)
+    }
+  }
+  return null;
 }
 
 export const handler = async (event: any) => {
@@ -96,6 +141,8 @@ export const handler = async (event: any) => {
   const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
   const { email, nickname, role } = body ?? {};
   const tenantId = getTenantId(event);
+  const tokensTable = process.env.AUTH_TOKENS_TABLE;
+  const tokenInviteEnabled = !!tokensTable;
 
   const emailNormalized = typeof email === "string" ? email.trim() : "";
   const hasEmail = emailNormalized.length > 0;
@@ -237,9 +284,10 @@ export const handler = async (event: any) => {
     };
   }
 
-  // raw temporary password (safe characters)
+  // Bootstrap password for Cognito admin operations.
+  // In token-based flow we keep it internal and then trigger the code flow from /invite.
   const rawPassword = generateSafeTempPassword(10) + "A1"; // ensure mix / length
-  // Do NOT put the password in the URL; include in the email body only.
+  // Do NOT put passwords in URLs.
 
   const userId = canonicalUserId;
 
@@ -258,6 +306,19 @@ export const handler = async (event: any) => {
       ],
       MessageAction: "SUPPRESS", // Keine automatische E-Mail
     }));
+
+    // Token-based invite flow relies on reset code endpoint (AdminResetUserPassword).
+    // For reliability, move newly created users to CONFIRMED with an internal password.
+    if (tokenInviteEnabled) {
+      await cognito.send(
+        new AdminSetUserPasswordCommand({
+          UserPoolId: process.env.USER_POOL_ID!,
+          Username: cognitoUsername,
+          Password: rawPassword,
+          Permanent: true,
+        }),
+      );
+    }
   } catch (err: any) {
     // If user exists, set a new temporary password (so admin can re-invite)
     if (err?.name === "UsernameExistsException") {
@@ -300,8 +361,31 @@ export const handler = async (event: any) => {
       }
 
       if (hasLoginProfile) {
-        reactivated = true;
-        console.log("Username exists with authUserId; reactivating without password reset.");
+        if (tokenInviteEnabled) {
+          // Bereits registriert: gleicher Token-/Invite-Link wie Neulinge (AdminResetUserPassword erst nach Klick).
+          // Ohne diesen Pfad: reactivated + kein Token → keine E-Mail mit Link, UI-Status oft „active“ → Einladen-Button aus.
+          reactivated = false;
+          console.log("Username exists with login; resending token-based invite (recovery).");
+          try {
+            await cognito.send(
+              new AdminUpdateUserAttributesCommand({
+                UserPoolId: process.env.USER_POOL_ID!,
+                Username: cognitoUsername,
+                UserAttributes: [
+                  { Name: "email", Value: emailNormalized },
+                  { Name: "email_verified", Value: "true" },
+                  { Name: "nickname", Value: nicknameRaw },
+                ],
+              }),
+            );
+          } catch (err2: any) {
+            console.error("AdminUpdateUserAttributes failed (registered user resend):", err2);
+            return { statusCode: 500, body: JSON.stringify({ error: "Failed to prepare existing user" }) };
+          }
+        } else {
+          reactivated = true;
+          console.log("Username exists with authUserId; reactivating without password reset.");
+        }
       } else {
         console.log("Username exists; setting a new temporary password via AdminSetUserPassword");
         try {
@@ -309,11 +393,24 @@ export const handler = async (event: any) => {
             UserPoolId: process.env.USER_POOL_ID!,
             Username: cognitoUsername,
             Password: rawPassword,
-            Permanent: false // user must change on next sign-in
+            // In token mode we need a CONFIRMED user so reset code can be issued reliably.
+            Permanent: tokenInviteEnabled,
           }));
+          // Ensure reset code can be delivered to the currently entered invite email.
+          await cognito.send(
+            new AdminUpdateUserAttributesCommand({
+              UserPoolId: process.env.USER_POOL_ID!,
+              Username: cognitoUsername,
+              UserAttributes: [
+                { Name: "email", Value: emailNormalized },
+                { Name: "email_verified", Value: "true" },
+                { Name: "nickname", Value: nicknameRaw },
+              ],
+            }),
+          );
         } catch (err2: any) {
-          console.error("AdminSetUserPassword failed:", err2);
-          return { statusCode: 500, body: JSON.stringify({ error: "Failed to reset password" }) };
+          console.error("AdminSetUserPassword/AdminUpdateUserAttributes failed:", err2);
+          return { statusCode: 500, body: JSON.stringify({ error: "Failed to prepare existing user" }) };
         }
       }
     } else {
@@ -354,12 +451,70 @@ export const handler = async (event: any) => {
     // aber wir loggen es deutlich.
   }
 
+  // Cognito-Username mit Dynamo abgleichen (kanonischer Username). authUserId nur nach abgeschlossener
+  // Einladung im Client (updateParticipant), nicht hier – sonst „registriert“ ohne echtes Onboarding.
+  const poolId = process.env.USER_POOL_ID;
+  if (poolId) {
+    const resolved = await resolveCognitoUsernameAndSub(poolId, cognitoUsername, userId);
+    if (resolved) {
+      cognitoUsername = resolved.username;
+      try {
+        await saveParticipantProfile({
+          tenantId,
+          userId,
+          email: emailNormalized,
+          cognitoUsername: resolved.username,
+        });
+      } catch (syncErr) {
+        console.warn("Could not persist Cognito sync to participant profile:", syncErr);
+      }
+    } else {
+      console.warn(
+        `AdminGetUser failed for invite user: tried cognitoUsername=${cognitoUsername}, userId=${userId}`,
+      );
+    }
+  }
+
   // Build link (only nickname in the URL)
   const baseUrlEnv = process.env.BASE_URL || "";
   const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
-  const link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
+  const tokenTtlSeconds = Number(process.env.AUTH_TOKEN_TTL_SECONDS || "3600");
+  const nowSeconds = Math.floor(Date.now() / 1000);
 
-  // Send invitation email (temp password shown in email body)
+  let oneTimeToken: string | undefined;
+  let link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
+
+  // Token nur für "echte Einladung" (nicht für Reaktivierung ohne Passwortreset).
+  if (!reactivated && tokensTable) {
+    oneTimeToken = generateOneTimeToken();
+    try {
+      await dynamodb.send(
+        new PutItemCommand({
+          TableName: tokensTable,
+          Item: {
+            tenantId: { S: tenantId },
+            token: { S: oneTimeToken },
+            cognitoUsername: { S: cognitoUsername },
+            userId: { S: userId },
+            purpose: { S: "invite-activation" },
+            createdAt: { N: String(nowSeconds) },
+            expiresAt: { N: String(nowSeconds + tokenTtlSeconds) },
+          },
+        }),
+      );
+    } catch (tokenErr) {
+      console.warn("Failed to store one-time token:", tokenErr);
+      oneTimeToken = undefined;
+    }
+
+    if (oneTimeToken) {
+      link = `${baseUrl}/invite?tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(
+        oneTimeToken,
+      )}&nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(emailNormalized)}`;
+    }
+  }
+
+  // Send invitation email (Token-Link, kein temporäres Passwort im E-Mail-Body)
   const emailHtml = reactivated
     ? `
       <h2>Hallo ${nicknameRaw}!</h2>
@@ -367,18 +522,25 @@ export const handler = async (event: any) => {
       <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
       <p><a href="${baseUrl}">Zur Anmeldung</a></p>
     `
-    : `
-      <h2>Hallo ${nicknameRaw}!</h2>
-      <p>Du wurdest zu YogaSwap eingeladen.</p>
-      <p><a href="${link}">Klicke hier, um dein temporäres Passwort einzugeben und ein neues Passwort zu setzen</a></p>
-      <div style="margin-top:12px;">
-        <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
-        <div>
-          <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
+    : tokensTable && oneTimeToken
+      ? `
+        <h2>Hallo ${nicknameRaw}!</h2>
+        <p>Du wurdest zu YogaSwap eingeladen.</p>
+        <p><a href="${link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
+        <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
+      `
+      : `
+        <h2>Hallo ${nicknameRaw}!</h2>
+        <p>Du wurdest zu YogaSwap eingeladen.</p>
+        <p><a href="${link}">Klicke hier, um dein temporäres Passwort einzugeben und ein neues Passwort zu setzen</a></p>
+        <div style="margin-top:12px;">
+          <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
+          <div>
+            <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
+          </div>
         </div>
-      </div>
-      <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
-    `;
+        <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
+      `;
 
   let emailSent = false;
   try {
@@ -399,14 +561,13 @@ export const handler = async (event: any) => {
   } catch (err: any) {
     console.warn("SES send warning:", err?.message || err);
     // do not fail user creation if SES can't send (depending on your policy)
-    // Falls E-Mail nicht versendet werden kann, logge das temporäre Passwort für den Admin
-    console.warn(`⚠️ E-Mail konnte nicht versendet werden. Temporäres Passwort für User '${userId}': ${rawPassword}`);
+    // In token-basierten Flows wird kein temporäres Passwort per E-Mail verschickt.
   }
 
   console.log("createParticipants: created/updated username=", userId);
   // Do NOT log passwords in production normally, but log if email failed
   if (!emailSent) {
-    console.warn(`⚠️ WICHTIG: E-Mail nicht versendet. User '${userId}' benötigt temporäres Passwort: ${rawPassword}`);
+    console.warn(`⚠️ WICHTIG: E-Mail nicht versendet. User '${userId}' benötigt den Einladungslink.`);
   }
 
   const inviteSentAt = new Date().toISOString();
@@ -430,10 +591,12 @@ export const handler = async (event: any) => {
       link,
       emailSent,
       reactivated,
-      // Nur wenn E-Mail nicht versendet wurde, Passwort zurückgeben (für Admin)
       ...(emailSent || reactivated
         ? {}
-        : { tempPassword: rawPassword, warning: "E-Mail konnte nicht versendet werden. Bitte Passwort manuell übermitteln." })
+        : { 
+            inviteToken: oneTimeToken,
+            warning: "E-Mail konnte nicht versendet werden. Bitte Einladungslink (oder Token) manuell übermitteln."
+          })
     }) 
   };
 };

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -382,8 +382,18 @@ export const handler = async (event: any) => {
                 ],
               }),
             );
+            // Einige Cognito-Zustände (z. B. nach Altflows) erlauben kein AdminResetUserPassword.
+            // Durch ein permanentes Passwort wird der User wieder in einen reset-fähigen Zustand gebracht.
+            await cognito.send(
+              new AdminSetUserPasswordCommand({
+                UserPoolId: process.env.USER_POOL_ID!,
+                Username: cognitoUsername,
+                Password: rawPassword,
+                Permanent: true,
+              }),
+            );
           } catch (err2: any) {
-            console.error("AdminUpdateUserAttributes failed (registered user resend):", err2);
+            console.error("AdminUpdateUserAttributes/AdminSetUserPassword failed (registered user resend):", err2);
             return { statusCode: 500, body: JSON.stringify({ error: "Failed to prepare existing user" }) };
           }
         } else {

--- a/backend/src/lambdas/deleteParticipant/index.test.ts
+++ b/backend/src/lambdas/deleteParticipant/index.test.ts
@@ -96,6 +96,18 @@ describe("deleteParticipant Lambda", () => {
       notificationEmailSent: true,
     });
     expect(sesMockSend).toHaveBeenCalledTimes(1);
+    expect(sesMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Message: expect.objectContaining({
+          Subject: { Data: "YogaSwap: Zugang im Studio entfernt" },
+          Body: expect.objectContaining({
+            Html: expect.objectContaining({
+              Data: expect.stringContaining("Accountname (Spitzname): alice"),
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   test("deletes only membership when participant has authUserId", async () => {

--- a/backend/src/lambdas/deleteParticipant/index.ts
+++ b/backend/src/lambdas/deleteParticipant/index.ts
@@ -9,6 +9,7 @@ import { unmarshall } from "@aws-sdk/util-dynamodb";
 import type { ParticipantProfile } from "@yogaswap/shared";
 import { dynamoClient } from "../shared/dynamoClient";
 import { canActorManageParticipants } from "../shared/participantAuthorization";
+import { buildStudioAccessRemovedMail } from "../shared/templates/auth/authMailTemplates";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
@@ -128,20 +129,21 @@ export const handler = async (
     // Optional notification email when participant has an email address.
     if (profile?.email) {
       const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+      const mailLocale = process.env.MAIL_LOCALE || "de";
+      const removedMail = buildStudioAccessRemovedMail({
+        locale: mailLocale,
+        nickname: profile.userId || userId,
+      });
       try {
         await ses.send(
           new SendEmailCommand({
             Source: sesSourceEmail,
             Destination: { ToAddresses: [profile.email] },
             Message: {
-              Subject: { Data: "YogaSwap: Zugang im Studio entfernt" },
+              Subject: { Data: removedMail.subject },
               Body: {
                 Html: {
-                  Data:
-                    "<p>Dein Zugang zu diesem YogaSwap-Studio wurde entfernt.</p>" +
-                    "<p>Dein Konto ist aktuell nur deaktiviert und noch nicht vollstaendig geloescht.</p>" +
-                    "<p>Wenn du eine vollstaendige Entfernung deines Kontos moechtest, schreibe bitte an support@yogaswap.de.</p>" +
-                    "<p>Falls das ein Versehen war, melde dich bitte beim Studio-Team.</p>",
+                  Data: removedMail.html,
                 },
               },
             },

--- a/backend/src/lambdas/resetParticipantPassword/index.test.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.test.ts
@@ -12,12 +12,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
 });
 
 jest.mock("@aws-sdk/client-cognito-identity-provider", () => {
-  const mockSend = jest.fn();
-  return {
-    CognitoIdentityProviderClient: jest.fn(() => ({ send: mockSend })),
-    AdminSetUserPasswordCommand: jest.fn((input) => input),
-    mockSend,
-  };
+  return {};
 });
 
 jest.mock("@aws-sdk/client-ses", () => {
@@ -30,7 +25,6 @@ jest.mock("@aws-sdk/client-ses", () => {
 });
 
 const { mockSend: dynamoMockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
-const { mockSend: cognitoMockSend } = jest.requireMock("@aws-sdk/client-cognito-identity-provider");
 const { mockSend: sesMockSend } = jest.requireMock("@aws-sdk/client-ses");
 
 describe("resetParticipantPassword Lambda", () => {
@@ -45,9 +39,9 @@ describe("resetParticipantPassword Lambda", () => {
       USER_POOL_ID: "test-user-pool-id",
       BASE_URL: "https://yogaswap.example.com",
       SES_SOURCE_EMAIL: "support@yogaswap.de",
+      AUTH_TOKENS_TABLE: "test-auth-tokens",
     };
     dynamoMockSend.mockReset();
-    cognitoMockSend.mockReset();
     sesMockSend.mockReset();
   });
 
@@ -113,8 +107,6 @@ describe("resetParticipantPassword Lambda", () => {
           cognitoUsername: { S: "Alice" },
         },
       })
-      .mockResolvedValueOnce({});
-    cognitoMockSend.mockResolvedValueOnce({});
     sesMockSend.mockResolvedValueOnce({});
 
     const result = await handler(makeEvent());
@@ -123,14 +115,6 @@ describe("resetParticipantPassword Lambda", () => {
     expect(body.success).toBe(true);
     expect(body.emailSent).toBe(true);
     expect(body.userId).toBe("alice");
-
-    expect(cognitoMockSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        UserPoolId: "test-user-pool-id",
-        Username: "Alice",
-        Permanent: false,
-      }),
-    );
     expect(sesMockSend).toHaveBeenCalledWith(
       expect.objectContaining({
         Destination: { ToAddresses: ["alice@example.com"] },

--- a/backend/src/lambdas/resetParticipantPassword/index.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.ts
@@ -94,7 +94,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }),
     );
 
-    const link = `${baseUrl}/invite?tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(oneTimeToken)}&nickname=${encodeURIComponent(
+    const link = `${baseUrl}/invite?mode=admin_reset&tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(oneTimeToken)}&nickname=${encodeURIComponent(
       cognitoUsername,
     )}&email=${encodeURIComponent(email)}`;
 

--- a/backend/src/lambdas/resetParticipantPassword/index.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.ts
@@ -1,32 +1,25 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { AdminSetUserPasswordCommand, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
+import crypto from "crypto";
 
-const cognito = new CognitoIdentityProviderClient({});
 const ses = new SESClient({});
 const dynamodb = dynamoClient;
-
-function generateSafeTempPassword(length = 10) {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*";
-  let pw = "";
-  for (let i = 0; i < length; i++) {
-    pw += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return pw;
+function generateOneTimeToken(bytes = 32) {
+  return crypto.randomBytes(bytes).toString("base64url");
 }
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const participantsTable = process.env.PARTICIPANTS_TABLE;
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
-  const userPoolId = process.env.USER_POOL_ID;
+  const authTokensTable = process.env.AUTH_TOKENS_TABLE;
   const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
   const baseUrlEnv = process.env.BASE_URL || "";
   const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
 
-  if (!participantsTable || !membershipsTable || !userPoolId) {
+  if (!participantsTable || !membershipsTable || !authTokensTable) {
     return {
       statusCode: 500,
       body: JSON.stringify({ error: "Missing required environment variables" }),
@@ -80,31 +73,31 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const cognitoUsername = participant.cognitoUsername?.S || participant.userId?.S || targetUserId;
-    const rawPassword = `${generateSafeTempPassword(10)}A1`;
 
-    await cognito.send(
-      new AdminSetUserPasswordCommand({
-        UserPoolId: userPoolId,
-        Username: cognitoUsername,
-        Password: rawPassword,
-        Permanent: false,
-      }),
-    );
+    // One-Time Token: Token-Link startet dann den Cognito-Code-Flow (ohne temporäres Passwort per E-Mail).
+    const tokenTtlSeconds = Number(process.env.AUTH_TOKEN_TTL_SECONDS || "3600");
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const oneTimeToken = generateOneTimeToken();
 
-    const inviteSentAt = new Date().toISOString();
     await dynamodb.send(
       new PutItemCommand({
-        TableName: participantsTable,
+        TableName: authTokensTable,
         Item: {
-          ...participant,
           tenantId: { S: tenantId },
+          token: { S: oneTimeToken },
+          cognitoUsername: { S: cognitoUsername },
           userId: { S: targetUserId },
-          inviteSentAt: { S: inviteSentAt },
+          purpose: { S: "admin-password-reset" },
+          createdAt: { N: String(nowSeconds) },
+          expiresAt: { N: String(nowSeconds + tokenTtlSeconds) },
         },
       }),
     );
 
-    const link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(email)}`;
+    const link = `${baseUrl}/invite?tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(oneTimeToken)}&nickname=${encodeURIComponent(
+      cognitoUsername,
+    )}&email=${encodeURIComponent(email)}`;
+
     let emailSent = false;
     try {
       await ses.send(
@@ -118,14 +111,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
                 Data: `
                 <h2>Hallo ${targetUserId}!</h2>
                 <p>Dein Passwort fuer YogaSwap wurde zurueckgesetzt.</p>
-                <p><a href="${link}">Klicke hier, um ein neues Passwort zu setzen</a></p>
-                <div style="margin-top:12px;">
-                  <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
-                  <div>
-                    <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
-                  </div>
-                </div>
-                <p>Tipp: Falls das Passwort beim Einfügen nicht funktioniert, achte auf keine Leerzeichen vor/nach dem Passwort.</p>
+                <p><a href="${link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
+                <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
               `,
               },
             },

--- a/backend/src/lambdas/resetParticipantPassword/index.ts
+++ b/backend/src/lambdas/resetParticipantPassword/index.ts
@@ -4,6 +4,7 @@ import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
 import crypto from "crypto";
+import { buildRecoveryMail } from "../shared/templates/auth/authMailTemplates";
 
 const ses = new SESClient({});
 const dynamodb = dynamoClient;
@@ -16,6 +17,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
   const authTokensTable = process.env.AUTH_TOKENS_TABLE;
   const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+  const mailLocale = process.env.MAIL_LOCALE || "de";
   const baseUrlEnv = process.env.BASE_URL || "";
   const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
 
@@ -100,20 +102,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     let emailSent = false;
     try {
+      const recoveryMail = buildRecoveryMail({
+        locale: mailLocale,
+        nickname: targetUserId,
+        link,
+      });
       await ses.send(
         new SendEmailCommand({
           Source: sesSourceEmail,
           Destination: { ToAddresses: [email] },
           Message: {
-            Subject: { Data: "YogaSwap Passwort zuruecksetzen" },
+            Subject: { Data: recoveryMail.subject },
             Body: {
               Html: {
-                Data: `
-                <h2>Hallo ${targetUserId}!</h2>
-                <p>Dein Passwort fuer YogaSwap wurde zurueckgesetzt.</p>
-                <p><a href="${link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
-                <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
-              `,
+                Data: recoveryMail.html,
               },
             },
           },

--- a/backend/src/lambdas/shared/participantStatus.ts
+++ b/backend/src/lambdas/shared/participantStatus.ts
@@ -2,13 +2,19 @@ import type { ParticipantProfile, ParticipantStatus } from "@yogaswap/shared";
 
 /**
  * Zentrale Ableitung des ParticipantStatus fuer Backend-Lambdas.
- * Wird von mehreren Endpunkten verwendet, damit die Statuslogik
- * nicht pro Lambda dupliziert wird.
+ * (Logik baugleich zu shared `getParticipantStatus` — hier dupliziert, damit Jest kein ESM aus `shared/dist` laedt.)
  */
 export function deriveParticipantStatus(
-  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt" | "inviteCompletedAt">,
 ): ParticipantStatus {
-  if (profile.authUserId) return "active";
-  if (profile.inviteSentAt) return "invited";
+  const auth = profile.authUserId?.trim();
+  const invitedFlag = profile.inviteSentAt?.trim();
+  const done = profile.inviteCompletedAt?.trim();
+  if (auth) {
+    if (done) return "active";
+    if (!invitedFlag) return "active";
+    return "invited";
+  }
+  if (invitedFlag) return "invited";
   return "no_login";
 }

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
@@ -1,0 +1,99 @@
+import {
+  buildInviteMail,
+  buildInvitePreparationMail,
+  buildRecoveryMail,
+  buildReactivationMail,
+} from "./authMailTemplates";
+
+describe("authMailTemplates", () => {
+  test("buildInviteMail returns german template with placeholders", () => {
+    const mail = buildInviteMail({
+      locale: "de",
+      nickname: "Karin",
+      link: "https://example.com/invite-token",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Einladung");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("https://example.com/invite-token");
+    expect(mail.html).toContain("eingeladen");
+  });
+
+  test("buildRecoveryMail returns german template with placeholders", () => {
+    const mail = buildRecoveryMail({
+      locale: "de",
+      nickname: "Karin",
+      link: "https://example.com/recovery-token",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Passwort zuruecksetzen");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("https://example.com/recovery-token");
+    expect(mail.html).toContain("Passwort fuer YogaSwap wurde zurueckgesetzt");
+  });
+
+  test("buildReactivationMail returns german template with placeholders", () => {
+    const mail = buildReactivationMail({
+      locale: "de",
+      nickname: "Karin",
+      loginUrl: "https://example.com/login",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Reaktivierung");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("https://example.com/login");
+    expect(mail.html).toContain("reaktiviert");
+  });
+
+  test("buildInvitePreparationMail returns german fallback template", () => {
+    const mail = buildInvitePreparationMail({
+      locale: "de",
+      nickname: "Karin",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Einladung");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Dein Zugang wird vorbereitet");
+  });
+
+  test("unknown locale falls back to german for all builders", () => {
+    const invite = buildInviteMail({
+      locale: "en",
+      nickname: "User",
+      link: "https://example.com/invite",
+    });
+    const recovery = buildRecoveryMail({
+      locale: "fr",
+      nickname: "User",
+      link: "https://example.com/recovery",
+    });
+    const reactivation = buildReactivationMail({
+      locale: "es",
+      nickname: "User",
+      loginUrl: "https://example.com/login",
+    });
+    const preparation = buildInvitePreparationMail({
+      locale: "it",
+      nickname: "User",
+    });
+
+    expect(invite.subject).toBe("YogaSwap Einladung");
+    expect(invite.html).toContain("eingeladen");
+    expect(recovery.subject).toBe("YogaSwap Passwort zuruecksetzen");
+    expect(recovery.html).toContain("zurueckgesetzt");
+    expect(reactivation.subject).toBe("YogaSwap Reaktivierung");
+    expect(reactivation.html).toContain("reaktiviert");
+    expect(preparation.subject).toBe("YogaSwap Einladung");
+    expect(preparation.html).toContain("wird vorbereitet");
+  });
+
+  test("missing locale defaults to german", () => {
+    const mail = buildInviteMail({
+      nickname: "Karin",
+      link: "https://example.com/invite",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Einladung");
+    expect(mail.html).toContain("Hallo Karin");
+  });
+});

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
@@ -3,6 +3,7 @@ import {
   buildInvitePreparationMail,
   buildRecoveryMail,
   buildReactivationMail,
+  buildStudioAccessRemovedMail,
 } from "./authMailTemplates";
 
 describe("authMailTemplates", () => {
@@ -15,6 +16,7 @@ describe("authMailTemplates", () => {
 
     expect(mail.subject).toBe("YogaSwap Einladung");
     expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
     expect(mail.html).toContain("https://example.com/invite-token");
     expect(mail.html).toContain("eingeladen");
   });
@@ -28,6 +30,7 @@ describe("authMailTemplates", () => {
 
     expect(mail.subject).toBe("YogaSwap Passwort zuruecksetzen");
     expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
     expect(mail.html).toContain("https://example.com/recovery-token");
     expect(mail.html).toContain("Passwort fuer YogaSwap wurde zurueckgesetzt");
   });
@@ -41,6 +44,7 @@ describe("authMailTemplates", () => {
 
     expect(mail.subject).toBe("YogaSwap Reaktivierung");
     expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
     expect(mail.html).toContain("https://example.com/login");
     expect(mail.html).toContain("reaktiviert");
   });
@@ -53,7 +57,19 @@ describe("authMailTemplates", () => {
 
     expect(mail.subject).toBe("YogaSwap Einladung");
     expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
     expect(mail.html).toContain("Dein Zugang wird vorbereitet");
+  });
+
+  test("buildStudioAccessRemovedMail returns german template with nickname", () => {
+    const mail = buildStudioAccessRemovedMail({
+      locale: "de",
+      nickname: "Karin",
+    });
+
+    expect(mail.subject).toBe("YogaSwap: Zugang im Studio entfernt");
+    expect(mail.html).toContain("Zugang zu diesem YogaSwap-Studio wurde entfernt");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
   });
 
   test("unknown locale falls back to german for all builders", () => {

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
@@ -36,6 +36,7 @@ export function buildInviteMail(input: InviteMailInput): MailTemplate {
       subject: "YogaSwap Einladung",
       html: `
         <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
         <p>Du wurdest zu YogaSwap eingeladen.</p>
         <p><a href="${input.link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
         <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
@@ -55,6 +56,7 @@ export function buildRecoveryMail(input: RecoveryMailInput): MailTemplate {
       subject: "YogaSwap Passwort zuruecksetzen",
       html: `
         <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
         <p>Dein Passwort fuer YogaSwap wurde zurueckgesetzt.</p>
         <p><a href="${input.link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
         <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
@@ -74,6 +76,7 @@ export function buildReactivationMail(input: ReactivationMailInput): MailTemplat
       subject: "YogaSwap Reaktivierung",
       html: `
         <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
         <p>Dein Zugang zu YogaSwap wurde fuer dieses Studio reaktiviert.</p>
         <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
         <p><a href="${input.loginUrl}">Zur Anmeldung</a></p>
@@ -98,6 +101,7 @@ export function buildInvitePreparationMail(input: InvitePreparationMailInput): M
       subject: "YogaSwap Einladung",
       html: `
         <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
         <p>Dein Zugang wird vorbereitet.</p>
         <p>Bitte kontaktiere dein Studio, falls du keinen gueltigen Einladungslink erhalten hast.</p>
       `,
@@ -105,6 +109,30 @@ export function buildInvitePreparationMail(input: InvitePreparationMailInput): M
   }
   return {
     subject: "YogaSwap Einladung",
+    html: "",
+  };
+}
+
+type StudioAccessRemovedMailInput = {
+  locale?: string;
+  nickname: string;
+};
+
+export function buildStudioAccessRemovedMail(input: StudioAccessRemovedMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap: Zugang im Studio entfernt",
+      html:
+        `<p>Dein Zugang zu diesem YogaSwap-Studio wurde entfernt.</p>` +
+        `<p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>` +
+        "<p>Dein Konto ist aktuell nur deaktiviert und noch nicht vollstaendig geloescht.</p>" +
+        "<p>Wenn du eine vollstaendige Entfernung deines Kontos moechtest, schreibe bitte an support@yogaswap.de.</p>" +
+        "<p>Falls das ein Versehen war, melde dich bitte beim Studio-Team.</p>",
+    };
+  }
+  return {
+    subject: "YogaSwap: Zugang im Studio entfernt",
     html: "",
   };
 }

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
@@ -1,0 +1,110 @@
+export type AuthMailLocale = "de";
+
+type InviteMailInput = {
+  locale?: string;
+  nickname: string;
+  link: string;
+};
+
+type RecoveryMailInput = {
+  locale?: string;
+  nickname: string;
+  link: string;
+};
+
+type ReactivationMailInput = {
+  locale?: string;
+  nickname: string;
+  loginUrl: string;
+};
+
+type MailTemplate = {
+  subject: string;
+  html: string;
+};
+
+function normalizeLocale(locale?: string): AuthMailLocale {
+  const raw = (locale || "de").trim().toLowerCase();
+  if (raw.startsWith("de")) return "de";
+  return "de";
+}
+
+export function buildInviteMail(input: InviteMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap Einladung",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p>Du wurdest zu YogaSwap eingeladen.</p>
+        <p><a href="${input.link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
+        <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap Einladung",
+    html: "",
+  };
+}
+
+export function buildRecoveryMail(input: RecoveryMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap Passwort zuruecksetzen",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p>Dein Passwort fuer YogaSwap wurde zurueckgesetzt.</p>
+        <p><a href="${input.link}">Klicke hier, um ein neues Passwort festzulegen</a></p>
+        <p>Danach erhältst du eine E-Mail mit einem Code zur Bestätigung.</p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap Passwort zuruecksetzen",
+    html: "",
+  };
+}
+
+export function buildReactivationMail(input: ReactivationMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap Reaktivierung",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p>Dein Zugang zu YogaSwap wurde fuer dieses Studio reaktiviert.</p>
+        <p>Du kannst dich mit deinem bestehenden Passwort wieder anmelden.</p>
+        <p><a href="${input.loginUrl}">Zur Anmeldung</a></p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap Reaktivierung",
+    html: "",
+  };
+}
+
+type InvitePreparationMailInput = {
+  locale?: string;
+  nickname: string;
+};
+
+export function buildInvitePreparationMail(input: InvitePreparationMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap Einladung",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p>Dein Zugang wird vorbereitet.</p>
+        <p>Bitte kontaktiere dein Studio, falls du keinen gueltigen Einladungslink erhalten hast.</p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap Einladung",
+    html: "",
+  };
+}

--- a/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
@@ -58,6 +58,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
         cognitoUsername: { S: "Alice" },
       },
@@ -81,6 +82,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) - 1) },
         cognitoUsername: { S: "Alice" },
       },
@@ -99,6 +101,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
         usedAt: { N: "1" },
         cognitoUsername: { S: "Alice" },
@@ -126,6 +129,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
         cognitoUsername: { S: "Alice" },
       },
@@ -149,6 +153,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
         cognitoUsername: { S: "Alice" },
       },
@@ -172,6 +177,7 @@ describe("startPasswordResetFromToken Lambda", () => {
       Item: {
         tenantId: { S: "tenant-1" },
         token: { S: "t1" },
+        purpose: { S: "invite-activation" },
         expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
         cognitoUsername: { S: "Alice" },
       },
@@ -185,6 +191,26 @@ describe("startPasswordResetFromToken Lambda", () => {
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).error).toMatch(/not allowed for this account state/i);
+  });
+
+  test("returns 400 for token with unsupported purpose", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        purpose: { S: "user-password-reset" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/purpose is invalid/i);
+    expect(cognitoMockSend).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
@@ -163,5 +163,28 @@ describe("startPasswordResetFromToken Lambda", () => {
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).error).toMatch(/cannot be delivered/i);
   });
+
+  test("returns 400 for NotAuthorizedException from Cognito", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+    dynamoMockSend.mockResolvedValueOnce({}); // UpdateItem
+
+    const notAuthorized = new Error("User password cannot be reset in the current state.");
+    (notAuthorized as any).name = "NotAuthorizedException";
+    cognitoMockSend.mockRejectedValueOnce(notAuthorized);
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/not allowed for this account state/i);
+  });
 });
 

--- a/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
@@ -193,6 +193,54 @@ describe("startPasswordResetFromToken Lambda", () => {
     expect(JSON.parse(result.body).error).toMatch(/not allowed for this account state/i);
   });
 
+  test("returns 400 for CodeDeliveryFailureException from Cognito", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        purpose: { S: "invite-activation" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+    dynamoMockSend.mockResolvedValueOnce({}); // UpdateItem
+
+    const deliveryError = new Error("Code delivery failed");
+    (deliveryError as any).name = "CodeDeliveryFailureException";
+    cognitoMockSend.mockRejectedValueOnce(deliveryError);
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/could not be delivered/i);
+  });
+
+  test("returns 429 for TooManyRequestsException from Cognito", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        purpose: { S: "invite-activation" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+    dynamoMockSend.mockResolvedValueOnce({}); // UpdateItem
+
+    const throttled = new Error("Too many requests");
+    (throttled as any).name = "TooManyRequestsException";
+    cognitoMockSend.mockRejectedValueOnce(throttled);
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(429);
+    expect(JSON.parse(result.body).error).toMatch(/too many reset attempts/i);
+  });
+
   test("returns 400 for token with unsupported purpose", async () => {
     const nowMs = Date.now();
     jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);

--- a/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.test.ts
@@ -1,0 +1,167 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    UpdateItemCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => {
+  const mockSend = jest.fn();
+  return {
+    CognitoIdentityProviderClient: jest.fn(() => ({ send: mockSend })),
+    AdminResetUserPasswordCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend: dynamoMockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+const { mockSend: cognitoMockSend } = jest.requireMock("@aws-sdk/client-cognito-identity-provider");
+
+describe("startPasswordResetFromToken Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      AUTH_TOKENS_TABLE: "test-auth-tokens",
+      USER_POOL_ID: "test-user-pool-id",
+    };
+
+    dynamoMockSend.mockReset();
+    cognitoMockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  const makeEvent = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent =>
+    ({
+      headers: {},
+      queryStringParameters: { token: "t1", tenantId: "tenant-1" },
+      ...overrides,
+    } as any);
+
+  test("returns 200 and triggers AdminResetUserPassword for valid unused token", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+
+    dynamoMockSend.mockResolvedValueOnce({}); // UpdateItem
+    cognitoMockSend.mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).username).toBe("Alice");
+    expect(cognitoMockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 400 for expired token", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) - 1) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Token expired/i);
+  });
+
+  test("returns 400 for already used token", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        usedAt: { N: "1" },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Token already used/i);
+  });
+
+  test("returns 404 for unknown token", async () => {
+    dynamoMockSend.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body).error).toBe("Token not found");
+  });
+
+  test("returns 400 when token is concurrently used/expired (ConditionalCheckFailed)", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+
+    const condErr = new Error("ConditionalCheckFailed");
+    (condErr as any).name = "ConditionalCheckFailedException";
+    dynamoMockSend.mockRejectedValueOnce(condErr); // UpdateItem
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/already used or expired/i);
+    expect(cognitoMockSend).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 for InvalidParameterException from Cognito", async () => {
+    const nowMs = Date.now();
+    jest.spyOn(Date, "now").mockReturnValueOnce(nowMs);
+
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: "tenant-1" },
+        token: { S: "t1" },
+        expiresAt: { N: String(Math.floor(nowMs / 1000) + 3600) },
+        cognitoUsername: { S: "Alice" },
+      },
+    }); // GetItem
+    dynamoMockSend.mockResolvedValueOnce({}); // UpdateItem
+
+    const invalidParamError = new Error("Cannot deliver code");
+    (invalidParamError as any).name = "InvalidParameterException";
+    cognitoMockSend.mockRejectedValueOnce(invalidParamError);
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/cannot be delivered/i);
+  });
+});
+

--- a/backend/src/lambdas/startPasswordResetFromToken/index.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.ts
@@ -8,6 +8,7 @@ import { dynamoClient } from "../shared/dynamoClient";
 
 const cognito = new CognitoIdentityProviderClient({});
 const ALLOWED_PURPOSES = new Set(["invite-activation", "admin-password-reset"]);
+const AUDIT_EVENT = "auth_token_password_reset";
 
 // Note: We deliberately re-use the lightweight shared dynamoClient pattern in other lambdas,
 // but for isolation (and easier test mocking) we instantiate here.
@@ -38,6 +39,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const nowSeconds = Math.floor(Date.now() / 1000);
 
   try {
+    console.info("AUDIT", {
+      event: AUDIT_EVENT,
+      stage: "trigger",
+      tenantId,
+      tokenProvided: true,
+    });
+
     const getResp = await dynamo.send(
       new GetItemCommand({
         TableName: tokensTable,
@@ -51,11 +59,24 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     const item = getResp.Item;
     if (!item) {
+      console.warn("AUDIT", {
+        event: AUDIT_EVENT,
+        stage: "reject",
+        tenantId,
+        reason: "token_not_found",
+      });
       return { statusCode: 404, body: JSON.stringify({ error: "Token not found" }) };
     }
 
     const purpose = item.purpose?.S?.trim();
     if (!purpose || !ALLOWED_PURPOSES.has(purpose)) {
+      console.warn("AUDIT", {
+        event: AUDIT_EVENT,
+        stage: "reject",
+        tenantId,
+        reason: "invalid_purpose",
+        purpose: purpose ?? null,
+      });
       return {
         statusCode: 400,
         body: JSON.stringify({ error: "Token purpose is invalid" }),
@@ -64,19 +85,42 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     const expiresAt = Number(item.expiresAt?.N ?? "0");
     if (!expiresAt || expiresAt <= nowSeconds) {
+      console.warn("AUDIT", {
+        event: AUDIT_EVENT,
+        stage: "reject",
+        tenantId,
+        reason: "token_expired",
+        purpose,
+      });
       return { statusCode: 400, body: JSON.stringify({ error: "Token expired" }) };
     }
 
     if (item.usedAt?.N) {
+      console.warn("AUDIT", {
+        event: AUDIT_EVENT,
+        stage: "reject",
+        tenantId,
+        reason: "token_already_used",
+        purpose,
+      });
       return { statusCode: 400, body: JSON.stringify({ error: "Token already used" }) };
     }
 
     const cognitoUsername = item.cognitoUsername?.S;
     if (!cognitoUsername) {
+      console.warn("AUDIT", {
+        event: AUDIT_EVENT,
+        stage: "reject",
+        tenantId,
+        reason: "missing_cognito_username",
+        purpose,
+      });
       return { statusCode: 400, body: JSON.stringify({ error: "Token is missing cognitoUsername" }) };
     }
 
-    // Consume token atomically so it can't be reused.
+    // Consume-before-trigger strategy:
+    // We intentionally mark usedAt BEFORE calling Cognito to prevent replay/race re-use.
+    // If Cognito fails afterwards, admin can issue a new token via re-invite/reset action.
     try {
       await dynamo.send(
         new UpdateItemCommand({
@@ -95,6 +139,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     } catch (e: unknown) {
       const name = (e as any)?.name as string | undefined;
       if (name === "ConditionalCheckFailedException") {
+        console.warn("AUDIT", {
+          event: AUDIT_EVENT,
+          stage: "reject",
+          tenantId,
+          reason: "token_used_or_expired_on_consume",
+          purpose,
+        });
         return {
           statusCode: 400,
           body: JSON.stringify({ error: "Token already used or expired" }),
@@ -102,6 +153,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }
       throw e;
     }
+
+    console.info("AUDIT", {
+      event: AUDIT_EVENT,
+      stage: "consume",
+      tenantId,
+      purpose,
+      cognitoUsername,
+      consumedAt: nowSeconds,
+    });
 
     await cognito.send(
       new AdminResetUserPasswordCommand({
@@ -119,6 +179,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     };
   } catch (err: unknown) {
     const name = (err as any)?.name as string | undefined;
+    console.warn("AUDIT", {
+      event: AUDIT_EVENT,
+      stage: "cognito_error",
+      tenantId,
+      reason: name || "unknown_error",
+    });
     if (name === "UserNotFoundException") {
       return { statusCode: 404, body: JSON.stringify({ error: "User not found" }) };
     }
@@ -136,6 +202,23 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         body: JSON.stringify({
           error:
             "Password reset is currently not allowed for this account state. Please ask admin to re-invite again.",
+        }),
+      };
+    }
+    if (name === "CodeDeliveryFailureException") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Reset code could not be delivered. Please ask admin to verify participant email and re-invite.",
+        }),
+      };
+    }
+    if (name === "TooManyRequestsException" || name === "LimitExceededException") {
+      return {
+        statusCode: 429,
+        body: JSON.stringify({
+          error: "Too many reset attempts. Please wait a moment and try again.",
         }),
       };
     }

--- a/backend/src/lambdas/startPasswordResetFromToken/index.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.ts
@@ -121,6 +121,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         }),
       };
     }
+    if (name === "NotAuthorizedException") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Password reset is currently not allowed for this account state. Please ask admin to re-invite again.",
+        }),
+      };
+    }
     console.error("Failed to start password reset from token", err);
     return {
       statusCode: 500,

--- a/backend/src/lambdas/startPasswordResetFromToken/index.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.ts
@@ -7,6 +7,7 @@ import { GetItemCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 
 const cognito = new CognitoIdentityProviderClient({});
+const ALLOWED_PURPOSES = new Set(["invite-activation", "admin-password-reset"]);
 
 // Note: We deliberately re-use the lightweight shared dynamoClient pattern in other lambdas,
 // but for isolation (and easier test mocking) we instantiate here.
@@ -51,6 +52,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const item = getResp.Item;
     if (!item) {
       return { statusCode: 404, body: JSON.stringify({ error: "Token not found" }) };
+    }
+
+    const purpose = item.purpose?.S?.trim();
+    if (!purpose || !ALLOWED_PURPOSES.has(purpose)) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: "Token purpose is invalid" }),
+      };
     }
 
     const expiresAt = Number(item.expiresAt?.N ?? "0");

--- a/backend/src/lambdas/startPasswordResetFromToken/index.ts
+++ b/backend/src/lambdas/startPasswordResetFromToken/index.ts
@@ -1,0 +1,131 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  AdminResetUserPasswordCommand,
+  CognitoIdentityProviderClient,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { GetItemCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/dynamoClient";
+
+const cognito = new CognitoIdentityProviderClient({});
+
+// Note: We deliberately re-use the lightweight shared dynamoClient pattern in other lambdas,
+// but for isolation (and easier test mocking) we instantiate here.
+const dynamo = dynamoClient;
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const tokensTable = process.env.AUTH_TOKENS_TABLE;
+  const userPoolId = process.env.USER_POOL_ID;
+
+  if (!tokensTable || !userPoolId) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing required environment variables" }),
+    };
+  }
+
+  const query = event.queryStringParameters ?? {};
+  const token = query.token ?? query.Token;
+  const tenantId = query.tenantId ?? query.TENANTID;
+
+  if (!token || !tenantId) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "Missing token or tenantId" }),
+    };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  try {
+    const getResp = await dynamo.send(
+      new GetItemCommand({
+        TableName: tokensTable,
+        Key: {
+          tenantId: { S: tenantId },
+          token: { S: token },
+        },
+        ConsistentRead: true,
+      }),
+    );
+
+    const item = getResp.Item;
+    if (!item) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Token not found" }) };
+    }
+
+    const expiresAt = Number(item.expiresAt?.N ?? "0");
+    if (!expiresAt || expiresAt <= nowSeconds) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Token expired" }) };
+    }
+
+    if (item.usedAt?.N) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Token already used" }) };
+    }
+
+    const cognitoUsername = item.cognitoUsername?.S;
+    if (!cognitoUsername) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Token is missing cognitoUsername" }) };
+    }
+
+    // Consume token atomically so it can't be reused.
+    try {
+      await dynamo.send(
+        new UpdateItemCommand({
+          TableName: tokensTable,
+          Key: {
+            tenantId: { S: tenantId },
+            token: { S: token },
+          },
+          UpdateExpression: "SET usedAt = :now",
+          ConditionExpression: "attribute_not_exists(usedAt) AND expiresAt > :now",
+          ExpressionAttributeValues: {
+            ":now": { N: String(nowSeconds) },
+          },
+        }),
+      );
+    } catch (e: unknown) {
+      const name = (e as any)?.name as string | undefined;
+      if (name === "ConditionalCheckFailedException") {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: "Token already used or expired" }),
+        };
+      }
+      throw e;
+    }
+
+    await cognito.send(
+      new AdminResetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: cognitoUsername,
+      }),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        success: true,
+        username: cognitoUsername,
+      }),
+    };
+  } catch (err: unknown) {
+    const name = (err as any)?.name as string | undefined;
+    if (name === "UserNotFoundException") {
+      return { statusCode: 404, body: JSON.stringify({ error: "User not found" }) };
+    }
+    if (name === "InvalidParameterException") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: "Password reset code cannot be delivered. Please ask admin to update participant email and re-invite.",
+        }),
+      };
+    }
+    console.error("Failed to start password reset from token", err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to start password reset" }),
+    };
+  }
+};
+

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -7,6 +7,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     GetItemCommand: jest.fn((input) => input),
     PutItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
     ScanCommand: jest.fn((input) => input),
     mockSend,
   };
@@ -225,6 +226,7 @@ describe("updateParticipant Lambda", () => {
         },
       })
       .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
       .mockResolvedValueOnce({ Items: [] });
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(404);

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -317,12 +317,45 @@ describe("updateParticipant Lambda", () => {
 
     const resultActive = await handler(
       makeEvent({
-        body: JSON.stringify({ authUserId: "cognito-sub-123" }),
+        body: JSON.stringify({
+          authUserId: "cognito-sub-123",
+          inviteCompletedAt: "2026-01-02T12:00:00.000Z",
+        }),
       }),
     );
 
     expect(resultActive.statusCode).toBe(200);
     expect(JSON.parse(resultActive.body).status).toBe("active");
+
+    mockSend.mockReset();
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "admin" },
+          role: { S: "admin" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const resultStuckSub = await handler(
+      makeEvent({
+        body: JSON.stringify({ authUserId: "cognito-sub-only" }),
+      }),
+    );
+
+    expect(resultStuckSub.statusCode).toBe(200);
+    expect(JSON.parse(resultStuckSub.body).status).toBe("invited");
   });
 
   test("returns 403 when membership is missing", async () => {

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -50,6 +50,8 @@ describe("updateParticipant Lambda", () => {
       USER_POOL_ID: "test-user-pool-id",
       BASE_URL: "https://yogaswap.example.com",
       SES_SOURCE_EMAIL: "support@yogaswap.de",
+      AUTH_TOKENS_TABLE: "test-auth-tokens",
+      AUTH_TOKEN_TTL_SECONDS: "3600",
     };
     mockSend.mockReset();
     cognitoMockSend.mockReset();

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -7,6 +7,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     GetItemCommand: jest.fn((input) => input),
     PutItemCommand: jest.fn((input) => input),
+    ScanCommand: jest.fn((input) => input),
     mockSend,
   };
 });
@@ -223,7 +224,8 @@ describe("updateParticipant Lambda", () => {
           role: { S: "admin" },
         },
       })
-      .mockResolvedValueOnce({ Item: undefined });
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] });
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(404);
     expect(JSON.parse(result.body).error).toBe("Participant not found");

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import {
   GetItemCommand,
   PutItemCommand,
+  ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   AdminSetUserPasswordCommand,
@@ -63,8 +64,8 @@ export const handler = async (
     };
   }
 
-  const userId = event.pathParameters?.userId?.trim();
-  if (!userId) {
+  const requestedUserId = event.pathParameters?.userId?.trim();
+  if (!requestedUserId) {
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "Missing userId in path" }),
@@ -109,7 +110,7 @@ export const handler = async (
     // Allow a participant to self-link their own Cognito `sub` once after sign-up.
     // This is required for participants created via invitation to move from "invited" -> "active".
     const isSelfAuthLink =
-      actorUserId?.toLowerCase() === userId.toLowerCase() &&
+      actorUserId?.toLowerCase() === requestedUserId.toLowerCase() &&
       hasAuthUserId &&
       !hasOtherMutationKeys;
 
@@ -160,26 +161,46 @@ export const handler = async (
       }
     }
 
+    let targetUserId = requestedUserId;
     const existingResp = await client.send(
       new GetItemCommand({
         TableName: tableName,
         Key: {
           tenantId: { S: tenantId },
-          userId: { S: userId },
+          userId: { S: targetUserId },
         },
         ConsistentRead: true,
       }),
     );
 
-    if (!existingResp.Item) {
+    let existingItem = existingResp.Item;
+    if (!existingItem) {
+      const scanResp = await client.send(
+        new ScanCommand({
+          TableName: tableName,
+          FilterExpression: "tenantId = :tenantId",
+          ExpressionAttributeValues: { ":tenantId": { S: tenantId } },
+        }),
+      );
+      const matched = (scanResp.Items ?? []).find((item) => {
+        const id = item.userId?.S ?? "";
+        return id.toLowerCase() === requestedUserId.toLowerCase();
+      });
+      if (matched?.userId?.S) {
+        targetUserId = matched.userId.S;
+        existingItem = matched;
+      }
+    }
+
+    if (!existingItem) {
       return {
         statusCode: 404,
         body: JSON.stringify({ error: "Participant not found" }),
       };
     }
 
-    const existing = unmarshall(existingResp.Item) as ParticipantProfile;
-    const existingCognitoUsername = existingResp.Item.cognitoUsername?.S;
+    const existing = unmarshall(existingItem) as ParticipantProfile;
+    const existingCognitoUsername = existingItem.cognitoUsername?.S;
     const existingStatus = deriveParticipantStatus(existing);
     if (requestsEmailChange) {
       const requestedEmail = typeof body.email === "string" ? body.email.trim() : body.email;
@@ -199,7 +220,7 @@ export const handler = async (
     const updated: ParticipantProfile = {
       ...existing,
       tenantId,
-      userId,
+      userId: targetUserId,
     };
 
     if (Object.prototype.hasOwnProperty.call(body, "email")) {
@@ -219,7 +240,7 @@ export const handler = async (
             };
           }
           try {
-            const cognitoUsername = existingCognitoUsername || userId;
+            const cognitoUsername = existingCognitoUsername || targetUserId;
             await cognito.send(
               new AdminUpdateUserAttributesCommand({
                 UserPoolId: userPoolId,
@@ -265,7 +286,7 @@ export const handler = async (
                       Body: {
                         Html: {
                           Data: `
-                            <h2>Hallo ${userId}!</h2>
+                            <h2>Hallo ${targetUserId}!</h2>
                             <p>Deine E-Mail-Adresse wurde aktualisiert. Bitte setze jetzt ein neues Passwort.</p>
                             <p><a href="${link}">Klicke hier, um ein neues Passwort zu setzen</a></p>
                             <div style="margin-top:12px;">
@@ -353,7 +374,7 @@ export const handler = async (
           TableName: membershipsTable,
           Item: marshall({
             tenantId,
-            userId,
+            userId: targetUserId,
             role: nextRole,
           }),
         }),

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -2,7 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import {
   GetItemCommand,
   PutItemCommand,
-  ScanCommand,
+  QueryCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   AdminSetUserPasswordCommand,
@@ -25,6 +25,7 @@ import { getTenantContext } from "../shared/tenantContext";
 const client = dynamoClient;
 const cognito = new CognitoIdentityProviderClient({});
 const ses = new SESClient({});
+const PARTICIPANTS_NORMALIZED_INDEX = "GSI_UserIdNormalized";
 
 function generateSafeTempPassword(length = 10) {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*";
@@ -175,20 +176,22 @@ export const handler = async (
 
     let existingItem = existingResp.Item;
     if (!existingItem) {
-      const scanResp = await client.send(
-        new ScanCommand({
+      const queryResp = await client.send(
+        new QueryCommand({
           TableName: tableName,
-          FilterExpression: "tenantId = :tenantId",
-          ExpressionAttributeValues: { ":tenantId": { S: tenantId } },
+          IndexName: PARTICIPANTS_NORMALIZED_INDEX,
+          KeyConditionExpression: "tenantId = :tenantId AND userIdNormalized = :userIdNormalized",
+          ExpressionAttributeValues: {
+            ":tenantId": { S: tenantId },
+            ":userIdNormalized": { S: requestedUserId.toLowerCase() },
+          },
+          Limit: 1,
         }),
       );
-      const matched = (scanResp.Items ?? []).find((item) => {
-        const id = item.userId?.S ?? "";
-        return id.toLowerCase() === requestedUserId.toLowerCase();
-      });
-      if (matched?.userId?.S) {
-        targetUserId = matched.userId.S;
-        existingItem = matched;
+      const queryMatched = queryResp.Items?.[0];
+      if (queryMatched?.userId?.S) {
+        targetUserId = queryMatched.userId.S;
+        existingItem = queryMatched;
       }
     }
 
@@ -221,6 +224,7 @@ export const handler = async (
       ...existing,
       tenantId,
       userId: targetUserId,
+      userIdNormalized: targetUserId.toLowerCase(),
     };
 
     if (Object.prototype.hasOwnProperty.call(body, "email")) {

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -5,13 +5,13 @@ import {
   QueryCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
-  AdminSetUserPasswordCommand,
   AdminUpdateUserAttributesCommand,
   AdminUserGlobalSignOutCommand,
   CognitoIdentityProviderClient,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import crypto from "crypto";
 import type {
   ParticipantProfile,
   ParticipantSettings,
@@ -21,19 +21,15 @@ import { dynamoClient } from "../shared/dynamoClient";
 import { canActorManageParticipants } from "../shared/participantAuthorization";
 import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
+import { buildRecoveryMail } from "../shared/templates/auth/authMailTemplates";
 
 const client = dynamoClient;
 const cognito = new CognitoIdentityProviderClient({});
 const ses = new SESClient({});
 const PARTICIPANTS_NORMALIZED_INDEX = "GSI_UserIdNormalized";
 
-function generateSafeTempPassword(length = 10) {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%&*";
-  let pw = "";
-  for (let i = 0; i < length; i++) {
-    pw += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return pw;
+function generateOneTimeToken(bytes = 32) {
+  return crypto.randomBytes(bytes).toString("base64url");
 }
 
 type UpdateParticipantBody = {
@@ -265,13 +261,29 @@ export const handler = async (
             }
 
             if (emailChanged && body.forcePasswordResetOnEmailChange) {
-              const rawPassword = `${generateSafeTempPassword(10)}A1`;
-              await cognito.send(
-                new AdminSetUserPasswordCommand({
-                  UserPoolId: userPoolId,
-                  Username: cognitoUsername,
-                  Password: rawPassword,
-                  Permanent: false,
+              const authTokensTable = process.env.AUTH_TOKENS_TABLE;
+              if (!authTokensTable) {
+                return {
+                  statusCode: 500,
+                  body: JSON.stringify({ error: "AUTH_TOKENS_TABLE env var is not set" }),
+                };
+              }
+
+              const tokenTtlSeconds = Number(process.env.AUTH_TOKEN_TTL_SECONDS || "3600");
+              const nowSeconds = Math.floor(Date.now() / 1000);
+              const oneTimeToken = generateOneTimeToken();
+              await client.send(
+                new PutItemCommand({
+                  TableName: authTokensTable,
+                  Item: {
+                    tenantId: { S: tenantId },
+                    token: { S: oneTimeToken },
+                    cognitoUsername: { S: cognitoUsername },
+                    userId: { S: targetUserId },
+                    purpose: { S: "admin-password-reset" },
+                    createdAt: { N: String(nowSeconds) },
+                    expiresAt: { N: String(nowSeconds + tokenTtlSeconds) },
+                  },
                 }),
               );
               passwordResetTriggered = true;
@@ -279,27 +291,23 @@ export const handler = async (
               const baseUrlEnv = process.env.BASE_URL || "";
               const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
               const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
-              const link = `${baseUrl}/invite?nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(email)}`;
+              const mailLocale = process.env.MAIL_LOCALE || "de";
+              const link = `${baseUrl}/invite?mode=admin_reset&tenantId=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(oneTimeToken)}&nickname=${encodeURIComponent(cognitoUsername)}&email=${encodeURIComponent(email)}`;
+              const recoveryMail = buildRecoveryMail({
+                locale: mailLocale,
+                nickname: targetUserId,
+                link,
+              });
               try {
                 await ses.send(
                   new SendEmailCommand({
                     Source: sesSourceEmail,
                     Destination: { ToAddresses: [email] },
                     Message: {
-                      Subject: { Data: "YogaSwap Passwort zuruecksetzen" },
+                      Subject: { Data: recoveryMail.subject },
                       Body: {
                         Html: {
-                          Data: `
-                            <h2>Hallo ${targetUserId}!</h2>
-                            <p>Deine E-Mail-Adresse wurde aktualisiert. Bitte setze jetzt ein neues Passwort.</p>
-                            <p><a href="${link}">Klicke hier, um ein neues Passwort zu setzen</a></p>
-                            <div style="margin-top:12px;">
-                              <p style="margin:0 0 6px 0;"><strong>Temporäres Passwort (bitte kopieren & einfügen):</strong></p>
-                              <div>
-                                <code style="display:inline-block;background:#f0f0f0;padding:8px 10px;border-radius:4px;line-height:1.4;font-family:monospace;">${rawPassword}</code>
-                              </div>
-                            </div>
-                          `,
+                          Data: recoveryMail.html,
                         },
                       },
                     },

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -38,6 +38,7 @@ type UpdateParticipantBody = {
   email?: string | null;
   settings?: ParticipantSettings;
   inviteSentAt?: string | null;
+  inviteCompletedAt?: string | null;
   authUserId?: string | null;
   role?: UserRole;
   forcePasswordResetOnEmailChange?: boolean;
@@ -102,6 +103,7 @@ export const handler = async (
       Object.prototype.hasOwnProperty.call(body, "email") ||
       Object.prototype.hasOwnProperty.call(body, "settings") ||
       Object.prototype.hasOwnProperty.call(body, "inviteSentAt") ||
+      Object.prototype.hasOwnProperty.call(body, "inviteCompletedAt") ||
       Object.prototype.hasOwnProperty.call(body, "role");
 
     // Allow a participant to self-link their own Cognito `sub` once after sign-up.
@@ -318,12 +320,24 @@ export const handler = async (
       }
     }
 
+    if (Object.prototype.hasOwnProperty.call(body, "inviteCompletedAt")) {
+      if (typeof body.inviteCompletedAt === "string" && body.inviteCompletedAt.trim()) {
+        updated.inviteCompletedAt = body.inviteCompletedAt;
+      } else {
+        delete updated.inviteCompletedAt;
+      }
+    }
+
     if (Object.prototype.hasOwnProperty.call(body, "authUserId")) {
       if (typeof body.authUserId === "string" && body.authUserId.trim()) {
         updated.authUserId = body.authUserId;
       } else {
         delete updated.authUserId;
       }
+    }
+
+    if (isSelfAuthLink && hasAuthUserId) {
+      updated.inviteCompletedAt = new Date().toISOString();
     }
 
     if (Object.prototype.hasOwnProperty.call(body, "role")) {

--- a/backend/src/scripts/backfill_participant_profiles.ts
+++ b/backend/src/scripts/backfill_participant_profiles.ts
@@ -22,6 +22,7 @@ async function run(): Promise<void> {
   let scanned = 0;
   let created = 0;
   let normalizedUpdated = 0;
+  let inviteCompletedUpdated = 0;
 
   do {
     const scanResp = await client.send(
@@ -90,7 +91,26 @@ async function run(): Promise<void> {
       if (!tenantId || !userId) continue;
       const normalized = userId.toLowerCase();
       const currentNormalized = item.userIdNormalized?.S;
-      if (currentNormalized === normalized) continue;
+      const authUserId = item.authUserId?.S?.trim();
+      const inviteCompletedAt = item.inviteCompletedAt?.S?.trim();
+      const inviteSentAt = item.inviteSentAt?.S?.trim();
+
+      const needsNormalized = currentNormalized !== normalized;
+      const needsInviteCompleted = !!authUserId && !inviteCompletedAt;
+
+      if (!needsNormalized && !needsInviteCompleted) continue;
+
+      const expressionParts: string[] = [];
+      const values: Record<string, AttributeValue> = {};
+      if (needsNormalized) {
+        expressionParts.push("userIdNormalized = :normalized");
+        values[":normalized"] = { S: normalized };
+      }
+      if (needsInviteCompleted) {
+        expressionParts.push("inviteCompletedAt = :inviteCompletedAt");
+        values[":inviteCompletedAt"] = { S: inviteSentAt || new Date().toISOString() };
+      }
+
       await client.send(
         new UpdateItemCommand({
           TableName: PARTICIPANTS_TABLE,
@@ -98,19 +118,19 @@ async function run(): Promise<void> {
             tenantId: { S: tenantId },
             userId: { S: userId },
           },
-          UpdateExpression: "SET userIdNormalized = :normalized",
-          ExpressionAttributeValues: {
-            ":normalized": { S: normalized },
-          },
+          UpdateExpression: `SET ${expressionParts.join(", ")}`,
+          ExpressionAttributeValues: values,
         }),
       );
-      normalizedUpdated += 1;
+
+      if (needsNormalized) normalizedUpdated += 1;
+      if (needsInviteCompleted) inviteCompletedUpdated += 1;
     }
     participantLastEvaluatedKey = participantScanResp.LastEvaluatedKey;
   } while (participantLastEvaluatedKey);
 
   console.log(
-    `Backfill done: scanned=${scanned}, attemptedCreates=${created}, normalizedUpdated=${normalizedUpdated}`,
+    `Backfill done: scanned=${scanned}, attemptedCreates=${created}, normalizedUpdated=${normalizedUpdated}, inviteCompletedUpdated=${inviteCompletedUpdated}`,
   );
 }
 

--- a/backend/src/scripts/backfill_participant_profiles.ts
+++ b/backend/src/scripts/backfill_participant_profiles.ts
@@ -1,6 +1,7 @@
 import {
   ScanCommand,
   PutItemCommand,
+  UpdateItemCommand,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../lambdas/shared/dynamoClient";
@@ -20,6 +21,7 @@ async function run(): Promise<void> {
   let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
   let scanned = 0;
   let created = 0;
+  let normalizedUpdated = 0;
 
   do {
     const scanResp = await client.send(
@@ -45,6 +47,7 @@ async function run(): Promise<void> {
             Item: {
               tenantId: { S: tenantId },
               userId: { S: userId },
+              userIdNormalized: { S: userId.toLowerCase() },
             },
             // Create only if missing; keeps existing profile fields untouched.
             ConditionExpression:
@@ -71,7 +74,44 @@ async function run(): Promise<void> {
     lastEvaluatedKey = scanResp.LastEvaluatedKey;
   } while (lastEvaluatedKey);
 
-  console.log(`Backfill done: scanned=${scanned}, attemptedCreates=${created}`);
+  // Existing participant profiles: ensure userIdNormalized is populated.
+  let participantLastEvaluatedKey: Record<string, AttributeValue> | undefined;
+  do {
+    const participantScanResp = await client.send(
+      new ScanCommand({
+        TableName: PARTICIPANTS_TABLE,
+        ExclusiveStartKey: participantLastEvaluatedKey,
+      }),
+    );
+    const items = participantScanResp.Items || [];
+    for (const item of items) {
+      const tenantId = item.tenantId?.S;
+      const userId = item.userId?.S;
+      if (!tenantId || !userId) continue;
+      const normalized = userId.toLowerCase();
+      const currentNormalized = item.userIdNormalized?.S;
+      if (currentNormalized === normalized) continue;
+      await client.send(
+        new UpdateItemCommand({
+          TableName: PARTICIPANTS_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: userId },
+          },
+          UpdateExpression: "SET userIdNormalized = :normalized",
+          ExpressionAttributeValues: {
+            ":normalized": { S: normalized },
+          },
+        }),
+      );
+      normalizedUpdated += 1;
+    }
+    participantLastEvaluatedKey = participantScanResp.LastEvaluatedKey;
+  } while (participantLastEvaluatedKey);
+
+  console.log(
+    `Backfill done: scanned=${scanned}, attemptedCreates=${created}, normalizedUpdated=${normalizedUpdated}`,
+  );
 }
 
 run().catch((error) => {

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -164,6 +164,31 @@ resource "aws_cloudfront_distribution" "spa" {
     compress = true
   }
 
+  # Public Auth Endpoint (token -> Cognito code)
+  ordered_cache_behavior {
+    path_pattern     = "/auth/password-reset/from-token*"
+    target_origin_id = "api-gateway-backend"
+    # CloudFront erlaubt hier nur vordefinierte Sets:
+    # - [HEAD, GET] oder [HEAD, GET, OPTIONS] oder das "Full"-Set inkl. POST/PUT/PATCH/DELETE.
+    allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods   = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "none"
+      }
+      headers = [
+        "Origin",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+      ]
+    }
+
+    compress = true
+  }
+
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]

--- a/projects/yogaswap/dynamodb.tf
+++ b/projects/yogaswap/dynamodb.tf
@@ -91,7 +91,16 @@ module "participants_table" {
   range_key = "userId"
   attributes = [
     { name = "tenantId", type = "S" },
-    { name = "userId", type = "S" }
+    { name = "userId", type = "S" },
+    { name = "userIdNormalized", type = "S" }
+  ]
+  global_secondary_index = [
+    {
+      name            = "GSI_UserIdNormalized"
+      hash_key        = "tenantId"
+      range_key       = "userIdNormalized"
+      projection_type = "ALL"
+    }
   ]
 }
 

--- a/projects/yogaswap/dynamodb.tf
+++ b/projects/yogaswap/dynamodb.tf
@@ -95,6 +95,19 @@ module "participants_table" {
   ]
 }
 
+# Auth Tokens (Invite/Recovery): PK = tenantId, SK = token
+# Speichert One-Time-Token inkl. Ablauf und usedAt (ohne TTL: wird serverseitig validiert).
+module "auth_tokens_table" {
+  source    = "../modules/dynamodb"
+  name      = "${var.project}-auth-tokens-table"
+  hash_key  = "tenantId"
+  range_key = "token"
+  attributes = [
+    { name = "tenantId", type = "S" },
+    { name = "token", type = "S" }
+  ]
+}
+
 output "table_names" {
   value = [
     module.swaps_table.table_name,
@@ -102,6 +115,7 @@ output "table_names" {
     module.courses_table.table_name,
     module.tenants_table.table_name,
     module.memberships_table.table_name,
-    module.participants_table.table_name
+    module.participants_table.table_name,
+    module.auth_tokens_table.table_name
   ]
 }

--- a/projects/yogaswap/lambda.tf
+++ b/projects/yogaswap/lambda.tf
@@ -29,7 +29,10 @@ resource "aws_iam_role_policy" "lambda_policy" {
       length(each.value.dynamodb_actions) > 0 ? [{
         Effect   = "Allow",
         Action   = each.value.dynamodb_actions,
-        Resource = each.value.table_arns
+        Resource = concat(
+          each.value.table_arns,
+          [for arn in each.value.table_arns : "${arn}/index/*"],
+        )
       }] : [],
       # S3-Berechtigungen, falls s3_actions nicht leer
       length(each.value.s3_actions) > 0 ? [{

--- a/projects/yogaswap/lambda.tf
+++ b/projects/yogaswap/lambda.tf
@@ -62,6 +62,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "${var.project}-${each.value.name}"
   handler       = "index.handler"
   runtime       = "nodejs18.x"
+  timeout       = try(each.value.timeout, 3)
   role          = aws_iam_role.lambda_role[each.key].arn
   filename      = "${path.module}/../../backend/zips/${each.value.file_name}"
   # Kombiniere Source Code Hash mit Environment Variables Hash, damit Lambda bei Environment-Änderungen neu deployed wird

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -210,6 +210,7 @@ locals {
     "create_participants" = {
       name             = "create-participants"
       file_name        = "createParticipants.zip"
+      timeout          = 15
       table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn, module.auth_tokens_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"]
       tables = {

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -154,7 +154,7 @@ locals {
       name             = "update-participant"
       file_name        = "updateParticipant.zip"
       table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
-      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Scan"]
       tables = {
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -210,11 +210,12 @@ locals {
     "create_participants" = {
       name             = "create-participants"
       file_name        = "createParticipants.zip"
-      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn]
+      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn, module.auth_tokens_table.table_arn]
       dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Scan"]
       tables = {
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
+        "AUTH_TOKENS_TABLE"   = module.auth_tokens_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -224,7 +225,9 @@ locals {
           Action = [
             "cognito-idp:AdminCreateUser",
             "cognito-idp:AdminAddUserToGroup",
-            "cognito-idp:AdminSetUserPassword"
+            "cognito-idp:AdminSetUserPassword",
+            "cognito-idp:AdminUpdateUserAttributes",
+            "cognito-idp:AdminGetUser"
           ]
           Resource = aws_cognito_user_pool.yogaswap.arn
         },
@@ -238,16 +241,18 @@ locals {
         USER_POOL_ID     = aws_cognito_user_pool.yogaswap.id
         BASE_URL         = length(var.cloudfront_aliases) > 0 ? "https://${var.cloudfront_aliases[0]}" : module.cloudfront_spa.distribution_url
         SES_SOURCE_EMAIL = var.ses_source_email # E-Mail-Adresse für SES-Absender (muss verifiziert sein)
+        AUTH_TOKENS_TABLE = module.auth_tokens_table.table_name
       }
     },
     "reset_participant_password" = {
       name             = "reset-participant-password"
       file_name        = "resetParticipantPassword.zip"
-      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn]
+      table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn, module.auth_tokens_table.table_arn]
       dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
       tables = {
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
+        "AUTH_TOKENS_TABLE"   = module.auth_tokens_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -269,6 +274,7 @@ locals {
         USER_POOL_ID     = aws_cognito_user_pool.yogaswap.id
         BASE_URL         = length(var.cloudfront_aliases) > 0 ? "https://${var.cloudfront_aliases[0]}" : module.cloudfront_spa.distribution_url
         SES_SOURCE_EMAIL = var.ses_source_email
+        AUTH_TOKENS_TABLE = module.auth_tokens_table.table_name
       }
     },
     "get_tenant_context" = {
@@ -287,6 +293,28 @@ locals {
       }
       s3_actions   = []
       s3_resources = []
+    }
+    "start_password_reset_from_token" = {
+      name             = "start-password-reset-from-token"
+      file_name        = "startPasswordResetFromToken.zip"
+      table_arns       = [module.auth_tokens_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:UpdateItem"]
+      tables = {
+        "AUTH_TOKENS_TABLE" = module.auth_tokens_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+      additional_policies = [
+        {
+          Effect = "Allow"
+          Action = ["cognito-idp:AdminResetUserPassword"]
+          Resource = aws_cognito_user_pool.yogaswap.arn
+        }
+      ]
+      environment = {
+        USER_POOL_ID      = aws_cognito_user_pool.yogaswap.id
+        AUTH_TOKENS_TABLE = module.auth_tokens_table.table_name
+      }
     }
   }
   # Map für Lambda-ARNs
@@ -308,6 +336,7 @@ locals {
     "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
     "POST /participants/{userId}/password-reset" = "reset_participant_password"
+    "POST /auth/password-reset/from-token"     = "start_password_reset_from_token"
     "PUT /participants/{userId}"                 = "update_participant"
     "DELETE /participants/{userId}"              = "delete_participant"
     "GET /tenant-context"                        = "get_tenant_context"

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -154,7 +154,7 @@ locals {
       name             = "update-participant"
       file_name        = "updateParticipant.zip"
       table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
-      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Scan"]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query"]
       tables = {
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
@@ -211,7 +211,7 @@ locals {
       name             = "create-participants"
       file_name        = "createParticipants.zip"
       table_arns       = [module.memberships_table.table_arn, module.participants_table.table_arn, module.auth_tokens_table.table_arn]
-      dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Scan"]
+      dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"]
       tables = {
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
         "PARTICIPANTS_TABLE" = module.participants_table.table_name

--- a/shared/src/lib/storage.ts
+++ b/shared/src/lib/storage.ts
@@ -1,19 +1,23 @@
 // shared/src/lib/storage.ts
 import type { User } from '..';
 
-const USER_KEY = "yogaswap_current_user";
+const USER_KEY = "currentUser";
+const LEGACY_USER_KEY = "yogaswap_current_user";
 
 export const saveCurrentUser = (user: User) => {
-  localStorage.setItem('currentUser', JSON.stringify(user));
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  // Cleanup legacy key to avoid stale user resurrection.
+  localStorage.removeItem(LEGACY_USER_KEY);
 };
 
 export const loadCurrentUser = (): User | null => {
-  const data = localStorage.getItem('currentUser');
+  const data = localStorage.getItem(USER_KEY) ?? localStorage.getItem(LEGACY_USER_KEY);
   return data ? JSON.parse(data) : null;
 };
 
 export const clearCurrentUser = () => {
   if (typeof window !== 'undefined') {
     localStorage.removeItem(USER_KEY);
+    localStorage.removeItem(LEGACY_USER_KEY);
   }
 };

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -130,6 +130,8 @@ export interface ParticipantProfile {
   tenantId: string;
   /** Aktuell: Nickname. Kann später auf eine stabile ID migriert werden. */
   userId: string;
+  /** Kanonische Lookup-ID für case-insensitive Suchen. */
+  userIdNormalized?: string;
 
   /** Optional: Kontakt-E-Mail (kann nachgetragen/aktualisiert werden). */
   email?: string;

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -140,6 +140,12 @@ export interface ParticipantProfile {
   /** Optional: Zeitpunkt der letzten Einladung (ISO timestamp). */
   inviteSentAt?: string;
 
+  /**
+   * Gesetzt, wenn die Einladung im Client abgeschlossen ist (z. B. nach Sign-In auf /invite).
+   * Ohne dieses Feld gilt ein nur serverseitig bekannter Cognito-Sub nicht als „registriert“.
+   */
+  inviteCompletedAt?: string;
+
   /** Optional: flexible, tenant-spezifische Teilnehmer-Einstellungen. */
   settings?: ParticipantSettings;
 }
@@ -176,9 +182,16 @@ export type ParticipantSettings = {
  * Ableitung des Teilnehmer-Status aus Profilfeldern (ohne eigenes Status-Feld).
  */
 export function getParticipantStatus(
-  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt">,
+  profile: Pick<ParticipantProfile, "authUserId" | "inviteSentAt" | "inviteCompletedAt">,
 ): ParticipantStatus {
-  if (profile.authUserId) return "active";
-  if (profile.inviteSentAt) return "invited";
+  const auth = profile.authUserId?.trim();
+  const invitedFlag = profile.inviteSentAt?.trim();
+  const done = profile.inviteCompletedAt?.trim();
+  if (auth) {
+    if (done) return "active";
+    if (!invitedFlag) return "active";
+    return "invited";
+  }
+  if (invitedFlag) return "invited";
   return "no_login";
 }


### PR DESCRIPTION
## Summary
- complete token-based invite/recovery flow without sending plaintext temporary passwords in emails, including update-on-email-change reset flow via one-time token
- unify frontend auth modes and copy for invite activation, password recovery, and admin reset; fix reset/login UX edge cases and clarify reactivation email behavior in AdminPanel
- harden token processing with purpose validation, explicit 4xx/429 mappings, standardized audit logs, and centralize auth-related email templates (including account nickname in mail content)

## Test plan
- [x] Backend: `npm run test --prefix backend -- createParticipants/index.test.ts resetParticipantPassword/index.test.ts startPasswordResetFromToken/index.test.ts shared/templates/auth/authMailTemplates.test.ts updateParticipant/index.test.ts deleteParticipant/index.test.ts`
- [x] Frontend: `npm test --prefix app -- --run Invite.test.tsx ForgotPassword.test.tsx Login.test.tsx AdminPanel.test.tsx`
- [ ] Manual E2E in demo: invite activation, admin reset, self-service forgot-password, invalid/expired/used token UX

Made with [Cursor](https://cursor.com)