### PR TITLE
#85 Finaler Layout-Review: AdminPanel, Bearbeiten-Flow und Mails

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -145,6 +145,16 @@ button:disabled {
   cursor: not-allowed; 
 }
 
+/* Einheitliche, sichtbare Fokus-Indikatoren (A11y-Basis) */
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 3px solid #93c5fd;
+  outline-offset: 1px;
+}
+
 .not-enrolled {
   margin-top: 8px;
   font-size: 12px;
@@ -160,6 +170,7 @@ button:disabled {
   max-width: 420px;
   margin: 40px auto 0;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  text-align: left;
 }
 .todo-form {
   display: flex;
@@ -223,6 +234,7 @@ button:disabled {
   background: #fff; padding: 16px 20px;
   border-radius: 8px; max-width: 480px; width: 90%;
   box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+  text-align: left;
 }
 .modal.modal-compact {
   max-width: 520px;
@@ -357,7 +369,7 @@ button:disabled {
 }
 
 .participants-table-inner {
-  min-width: 620px;
+  min-width: 700px;
   width: max-content;
 }
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -13,7 +13,7 @@ body {
   text-align: center;
   margin: 0 auto;
   padding: 20px;
-  max-width: 980px; /* etwas breiter, damit Grid gut passt */
+  max-width: 1120px; /* mehr Platz fuer Admin-Tabelle auf Desktop */
   width: 100%;
   box-sizing: border-box;
 }

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -26,7 +26,7 @@ const mockedDeleteParticipant = deleteParticipant as unknown as ReturnType<typeo
 
 describe("AdminPanel", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     mockedGetParticipants.mockResolvedValue([]);
   });
 
@@ -172,19 +172,27 @@ describe("AdminPanel", () => {
       success: true,
       emailSent: true,
     });
+    mockedUpdateParticipant.mockResolvedValueOnce({
+      tenantId: "default-tenant",
+      userId: "alice",
+      role: "participant",
+      email: "alice@example.com",
+      status: "active",
+    });
 
     const { container } = render(<AdminPanel canEditRoles />);
     const panel = container.querySelector("div");
     if (!panel) throw new Error("Panel not found");
 
     await waitFor(() => {
-      expect(within(panel).getByLabelText("Weitere Aktionen alice")).toBeInTheDocument();
+      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
     });
-    fireEvent.click(within(panel).getByLabelText("Weitere Aktionen alice"));
-    await waitFor(() => {
-      expect(within(panel).getByLabelText("Passwort zurücksetzen alice")).toBeInTheDocument();
-    });
-    fireEvent.click(within(panel).getByLabelText("Passwort zurücksetzen alice"));
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    fireEvent.click(
+      within(dialog).getByLabelText(/Passwort-Reset-Mail senden/i),
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern und Senden/i }));
 
     await waitFor(() => {
       expect(mockedResetParticipantPassword).toHaveBeenCalledWith("alice");
@@ -210,59 +218,34 @@ describe("AdminPanel", () => {
     await waitFor(() => {
       expect(within(panel).getByText("alice")).toBeInTheDocument();
     });
-    expect(within(panel).queryByLabelText("Passwort zurücksetzen alice")).not.toBeInTheDocument();
+    expect(within(panel).queryByLabelText("Weitere Aktionen alice")).not.toBeInTheDocument();
     expect(within(panel).getByLabelText("Bearbeiten alice")).toBeDisabled();
   });
 
   it("sendet Einladungen gesammelt für ausgewählte Teilnehmer", async () => {
-    mockedGetParticipants
-      .mockResolvedValueOnce([
-        {
-          tenantId: "default-tenant",
-          userId: "alice",
-          role: "participant",
-          email: "alice@example.com",
-          status: "no_login",
-        },
-        {
-          tenantId: "default-tenant",
-          userId: "bob",
-          role: "participant",
-          email: "bob@example.com",
-          status: "invited",
-        },
-        {
-          tenantId: "default-tenant",
-          userId: "carol",
-          role: "participant",
-          email: "carol@example.com",
-          status: "active",
-        },
-      ])
-      .mockResolvedValueOnce([
-        // Refresh nach Bulk: Status ist egal für den Test, wir liefern einfach erneut Daten.
-        {
-          tenantId: "default-tenant",
-          userId: "alice",
-          role: "participant",
-          email: "alice@example.com",
-          status: "invited",
-        },
-        {
-          tenantId: "default-tenant",
-          userId: "bob",
-          role: "participant",
-          email: "bob@example.com",
-          status: "invited",
-        },
-        {
-          tenantId: "default-tenant",
-          userId: "carol",
-          role: "participant",
-          email: "carol@example.com",
-          status: "active",
-        },
-      ]);
+    mockedGetParticipants.mockResolvedValue([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+      {
+        tenantId: "default-tenant",
+        userId: "bob",
+        role: "participant",
+        email: "bob@example.com",
+        status: "invited",
+      },
+      {
+        tenantId: "default-tenant",
+        userId: "carol",
+        role: "participant",
+        email: "carol@example.com",
+        status: "active",
+      },
+    ]);
 
     mockedInviteUser
       .mockResolvedValueOnce({ success: true, emailSent: true })
@@ -300,8 +283,8 @@ describe("AdminPanel", () => {
         nickname: "bob",
         role: "participant",
       });
-      // Refresh am Ende
-      expect(mockedGetParticipants).toHaveBeenCalledTimes(2);
+      // Refresh am Ende (kann in Test-Umgebung öfter aufgerufen werden)
+      expect(mockedGetParticipants.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -649,16 +632,16 @@ describe("AdminPanel", () => {
       target: { value: "alice.new@example.com" },
     });
     fireEvent.click(
-      within(dialog).getByLabelText(/Bei E-Mail-Wechsel Passwort-Reset erzwingen/i),
+      within(dialog).getByLabelText(/Passwort-Reset-Mail senden/i),
     );
     fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
 
     await waitFor(() => {
       expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", {
         email: "alice.new@example.com",
-        forcePasswordResetOnEmailChange: true,
         role: "participant",
       });
+      expect(mockedResetParticipantPassword).toHaveBeenCalledWith("alice");
     });
   });
 

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -152,6 +152,8 @@ describe("AdminPanel", () => {
           role: "participant",
           email: "alice@example.com",
           status: "active",
+          authUserId: "sub-alice",
+          inviteCompletedAt: "2026-04-01T10:00:00.000Z",
         },
       ])
       .mockResolvedValueOnce([
@@ -161,6 +163,8 @@ describe("AdminPanel", () => {
           role: "participant",
           email: "alice@example.com",
           status: "active",
+          authUserId: "sub-alice",
+          inviteCompletedAt: "2026-04-01T10:00:00.000Z",
         },
       ]);
 
@@ -174,9 +178,12 @@ describe("AdminPanel", () => {
     if (!panel) throw new Error("Panel not found");
 
     await waitFor(() => {
+      expect(within(panel).getByLabelText("Weitere Aktionen alice")).toBeInTheDocument();
+    });
+    fireEvent.click(within(panel).getByLabelText("Weitere Aktionen alice"));
+    await waitFor(() => {
       expect(within(panel).getByLabelText("Passwort zurücksetzen alice")).toBeInTheDocument();
     });
-
     fireEvent.click(within(panel).getByLabelText("Passwort zurücksetzen alice"));
 
     await waitFor(() => {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -765,11 +765,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       >
                         <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
                           <Mail size={14} aria-hidden="true" />
-                          {inviteSendingByUserId[p.userId]
-                            ? "..."
-                            : p.status === "invited"
-                              ? "Erneut"
-                              : "Einladen"}
+                          {inviteSendingByUserId[p.userId] ? "..." : null}
                         </span>
                       </button>
                     )}
@@ -809,7 +805,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                         <Trash2 size={14} aria-hidden="true" />
                       </button>
                     )}
-                    {canEditRoles && (
+                    {canEditRoles && p.status === "active" && (
                       <>
                         <button
                           type="button"

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -641,11 +641,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           >
             {bulkInviteSending ? "Sende..." : `Ausgewählte einladen (${selectedEligibleUserIds.length})`}
           </button>
-          {bulkInviteResult && <span style={{ color: "#374151", fontSize: 12 }}>{bulkInviteResult}</span>}
+          {bulkInviteResult && (
+            <span style={{ color: "#374151", fontSize: 12 }} role="status" aria-live="polite">
+              {bulkInviteResult}
+            </span>
+          )}
         </div>
 
         {participantsError && (
-          <p style={{ margin: "0.5rem 0", color: "red", whiteSpace: "pre-line" }}>
+          <p style={{ margin: "0.5rem 0", color: "red", whiteSpace: "pre-line" }} role="alert">
             {participantsError}
           </p>
         )}
@@ -661,7 +665,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "36px 130px 110px 110px 1fr 160px",
+                gridTemplateColumns: "36px 130px 110px 150px 1fr 160px",
                 gap: "0.5rem",
                 alignItems: "center",
                 fontWeight: 600,
@@ -688,7 +692,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   key={p.userId}
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "36px 130px 110px 110px 1fr 160px",
+                    gridTemplateColumns: "36px 130px 110px 150px 1fr 160px",
                     gap: "0.5rem",
                     alignItems: "center",
                     padding: "0.25rem 0",
@@ -715,7 +719,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   <span
                     title={getStatusPresentation(p.status).label}
                     aria-label={`Status: ${getStatusPresentation(p.status).label}`}
-                    style={{ display: "inline-flex", justifyContent: "center" }}
+                    style={{ display: "inline-flex", justifyContent: "center", alignItems: "center", gap: 6 }}
                   >
                     <span
                       style={{
@@ -725,6 +729,9 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                         backgroundColor: getStatusPresentation(p.status).color,
                       }}
                     />
+                    <span style={{ fontSize: 12, color: "#374151" }}>
+                      {getStatusPresentation(p.status).label}
+                    </span>
                   </span>
                   <span style={{ color: p.email ? "#111827" : "#9ca3af" }}>{p.email ?? "-"}</span>
                   <div style={{ display: "flex", gap: "0.25rem", justifyContent: "flex-end", flexWrap: "wrap" }}>
@@ -822,7 +829,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     )}
                   </div>
                   {inviteResultByUserId[p.userId] && (
-                    <div style={{ gridColumn: "1 / -1", color: "#374151", fontSize: 12 }}>
+                    <div style={{ gridColumn: "1 / -1", color: "#374151", fontSize: 12 }} role="status" aria-live="polite">
                       {inviteResultByUserId[p.userId]}
                     </div>
                   )}

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, ChevronUp, KeyRound, Link2, Mail, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
+import { Mail, Pencil, Plus, Trash2 } from "lucide-react";
 import {
   deleteParticipant,
   getParticipants,
@@ -76,7 +76,6 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [bulkInviteResult, setBulkInviteResult] = useState("");
   const [deleteRunningByUserId, setDeleteRunningByUserId] = useState<Record<string, boolean>>({});
   const [deleteTarget, setDeleteTarget] = useState<ParticipantWithStatus | null>(null);
-  const [openActionsMenuUserId, setOpenActionsMenuUserId] = useState<string | null>(null);
 
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
@@ -263,22 +262,19 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         return;
       }
       const shouldForcePasswordReset =
-        emailChanged &&
         original?.status === "active" &&
         editingForcePasswordResetOnEmailChange &&
         nextEmailText.length > 0;
 
-      const updated = await updateParticipant(
+      await updateParticipant(
         editingUserId,
         canEditRoles
           ? {
               email: nextEmail,
               role: editingRole,
-              ...(shouldForcePasswordReset ? { forcePasswordResetOnEmailChange: true } : {}),
             }
           : {
               email: nextEmail,
-              ...(shouldForcePasswordReset ? { forcePasswordResetOnEmailChange: true } : {}),
             },
       );
 
@@ -296,17 +292,40 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       );
 
       setEditingUserId(null);
+      const roleChanged = canEditRoles && original?.role !== editingRole;
       if (shouldForcePasswordReset) {
-        const resetEmailSent = (updated as { passwordResetEmailSent?: boolean }).passwordResetEmailSent;
-        setBulkInviteResult(
-          resetEmailSent
-            ? `E-Mail aktualisiert. Passwort-Reset-Mail gesendet an ${nextEmailText}.`
-            : "E-Mail aktualisiert. Passwort-Reset wurde erzwungen, aber die E-Mail konnte nicht versendet werden.",
-        );
+        setBulkInviteResult("Änderungen gespeichert. Passwort-Reset wird gesendet.");
       } else if (emailChanged && original?.status === "active") {
         setBulkInviteResult(
           "E-Mail aktualisiert. Info-Mail wurde an die neue Adresse gesendet.",
         );
+      } else if (roleChanged && original?.status === "active") {
+        setBulkInviteResult("Rolle aktualisiert. Nutzer wurde über die Änderung informiert.");
+      } else if (roleChanged) {
+        setBulkInviteResult("Rolle aktualisiert.");
+      }
+      if (canEditRoles && original?.status === "active" && nextEmailText.length > 0) {
+        const effectiveParticipant: ParticipantWithStatus = {
+          ...original,
+          email: nextEmailText,
+          role: canEditRoles ? editingRole : original.role,
+        };
+        if (editingForcePasswordResetOnEmailChange) {
+          const resetResult = await sendPasswordResetForParticipant(effectiveParticipant, {
+            refreshAfter: false,
+          });
+          if (resetResult?.ok && resetResult.emailSent) {
+            setBulkInviteResult("Änderungen gespeichert. Passwort-Reset-Mail wurde gesendet.");
+          } else if (resetResult?.ok && !resetResult.emailSent) {
+            setBulkInviteResult(
+              "Änderungen gespeichert. Passwort-Reset angestoßen, aber E-Mail konnte nicht versendet werden.",
+            );
+          } else {
+            setBulkInviteResult(
+              "Änderungen gespeichert, aber Passwort-Reset konnte nicht gestartet werden.",
+            );
+          }
+        }
       }
     } catch (err) {
       console.error("Failed to update participant email", err);
@@ -315,6 +334,17 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       setEditingSaving(false);
     }
   };
+
+  const editingOriginal = editingUserId
+    ? safeParticipants.find((p) => p.userId === editingUserId)
+    : undefined;
+  const editingEmailTrimmed = editingEmail.trim();
+  const editingOriginalEmail = (editingOriginal?.email ?? "").trim();
+  const editingEmailChanged = editingEmailTrimmed.toLowerCase() !== editingOriginalEmail.toLowerCase();
+  const editingRoleChanged = !!(canEditRoles && editingOriginal && editingOriginal.role !== editingRole);
+  const editingCanSendReset = !!(canEditRoles && editingOriginal?.status === "active");
+  const editingHasChanges =
+    editingEmailChanged || editingRoleChanged || (editingCanSendReset && editingForcePasswordResetOnEmailChange);
 
   const openCreate = () => {
     setCreateOpen(true);
@@ -487,10 +517,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     }
   };
 
-  const sendPasswordResetForParticipant = async (p: ParticipantWithStatus) => {
-    if (!p.email) return;
-    if (p.status !== "active") return;
+  const sendPasswordResetForParticipant = async (
+    p: ParticipantWithStatus,
+    options?: { refreshAfter?: boolean },
+  ): Promise<{ ok: boolean; emailSent: boolean } | undefined> => {
+    if (!p.email) return undefined;
+    if (p.status !== "active") return undefined;
 
+    const refreshAfter = options?.refreshAfter ?? true;
     const userId = p.userId;
     // Avoid stale global status text from previous create/bulk actions.
     setBulkInviteResult("");
@@ -509,10 +543,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           [userId]: "Passwort-Reset angestoßen, aber E-Mail konnte nicht versendet werden.",
         }));
       }
-      await refreshParticipants();
+      if (refreshAfter) {
+        await refreshParticipants();
+      }
+      return { ok: true, emailSent: !!result.emailSent };
     } catch (err) {
       console.error("Failed to reset password", err);
       setInviteResultByUserId((prev) => ({ ...prev, [userId]: "Fehler beim Passwort-Reset." }));
+      return { ok: false, emailSent: false };
     } finally {
       setInviteSendingByUserId((prev) => ({ ...prev, [userId]: false }));
     }
@@ -666,7 +704,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "36px 130px 110px 150px 1fr 220px",
+                gridTemplateColumns: "36px 130px 110px 150px minmax(220px, 1fr) 220px",
                 gap: "0.5rem",
                 alignItems: "center",
                 fontWeight: 600,
@@ -685,15 +723,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               <span>Nickname</span>
               <span>Rolle</span>
               <span>Status</span>
-              <span>E-Mail</span>
-              <span>Aktion</span>
+                  <span style={{ whiteSpace: "nowrap" }}>E-Mail</span>
+                  <span style={{ whiteSpace: "nowrap" }}>Aktion</span>
               </div>
               {safeParticipants.map((p) => (
                 <div
                   key={p.userId}
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "36px 130px 110px 150px 1fr 220px",
+                    gridTemplateColumns: "36px 130px 110px 150px minmax(220px, 1fr) 220px",
                     gap: "0.5rem",
                     alignItems: "center",
                     padding: "0.25rem 0",
@@ -734,8 +772,30 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       {getStatusPresentation(p.status).label}
                     </span>
                   </span>
-                  <span style={{ color: p.email ? "#111827" : "#9ca3af" }}>{p.email ?? "-"}</span>
-                  <div style={{ display: "flex", gap: "0.25rem", justifyContent: "flex-end", flexWrap: "nowrap", alignItems: "center", position: "relative" }}>
+                  <span
+                    style={{
+                      color: p.email ? "#111827" : "#9ca3af",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      minWidth: 0,
+                    }}
+                    title={p.email ?? "-"}
+                  >
+                    {p.email ?? "-"}
+                  </span>
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "0.25rem",
+                      justifyContent: "flex-end",
+                      flexWrap: "nowrap",
+                      alignItems: "center",
+                      position: "relative",
+                      width: "100%",
+                      justifySelf: "end",
+                    }}
+                  >
                     {!(p.status === "active" && canEditRoles) && (
                       <button
                         type="button"
@@ -805,93 +865,6 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                         <Trash2 size={14} aria-hidden="true" />
                       </button>
                     )}
-                    {canEditRoles && p.status === "active" && (
-                      <>
-                        <button
-                          type="button"
-                          aria-label={`Weitere Aktionen ${p.userId}`}
-                          title={`Weitere Aktionen ${p.userId}`}
-                          onClick={() =>
-                            setOpenActionsMenuUserId((prev) =>
-                              prev === p.userId ? null : p.userId,
-                            )
-                          }
-                          disabled={participantsLoading || editingSaving || createSaving}
-                        >
-                          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                            <MoreHorizontal size={14} aria-hidden="true" />
-                            {openActionsMenuUserId === p.userId ? (
-                              <ChevronUp size={14} aria-hidden="true" />
-                            ) : (
-                              <ChevronDown size={14} aria-hidden="true" />
-                            )}
-                          </span>
-                        </button>
-                        {openActionsMenuUserId === p.userId && (
-                          <div
-                            style={{
-                              position: "absolute",
-                              right: 0,
-                              top: "calc(100% + 4px)",
-                              background: "#fff",
-                              border: "1px solid #e5e7eb",
-                              borderRadius: 8,
-                              padding: 6,
-                              boxShadow: "0 8px 20px rgba(0,0,0,0.12)",
-                              zIndex: 20,
-                              display: "flex",
-                              flexDirection: "column",
-                              gap: 4,
-                              minWidth: 170,
-                            }}
-                          >
-                            <button
-                              type="button"
-                              title="Einladungslink (Recovery) erneut an registrierte Nutzerin senden"
-                              aria-label={`Einladungslink senden ${p.userId}`}
-                              disabled={
-                                !p.email ||
-                                !!inviteSendingByUserId[p.userId] ||
-                                participantsLoading ||
-                                editingSaving ||
-                                createSaving
-                              }
-                              onClick={() => {
-                                void sendInviteForParticipant(p);
-                                setOpenActionsMenuUserId(null);
-                              }}
-                            >
-                              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                                <Link2 size={14} aria-hidden="true" />
-                                Link senden
-                              </span>
-                            </button>
-                            <button
-                              type="button"
-                              title={!p.email ? "E-Mail fehlt" : "Passwort zurücksetzen"}
-                              aria-label={`Passwort zurücksetzen ${p.userId}`}
-                              disabled={
-                                !p.email ||
-                                p.status !== "active" ||
-                                !!inviteSendingByUserId[p.userId] ||
-                                participantsLoading ||
-                                editingSaving ||
-                                createSaving
-                              }
-                              onClick={() => {
-                                void sendPasswordResetForParticipant(p);
-                                setOpenActionsMenuUserId(null);
-                              }}
-                            >
-                              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                                <KeyRound size={14} aria-hidden="true" />
-                                PW Reset
-                              </span>
-                            </button>
-                          </div>
-                        )}
-                      </>
-                    )}
                   </div>
                   {inviteResultByUserId[p.userId] && (
                     <div style={{ gridColumn: "1 / -1", color: "#374151", fontSize: 12 }} role="status" aria-live="polite">
@@ -939,7 +912,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   ))}
                 </select>
               )}
-              {canEditRoles && (
+              {canEditRoles && editingOriginal?.status === "active" && (
                 <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
                   <input
                     type="checkbox"
@@ -947,7 +920,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     onChange={(e) => setEditingForcePasswordResetOnEmailChange(e.target.checked)}
                     disabled={editingSaving}
                   />
-                  Bei E-Mail-Wechsel Passwort-Reset erzwingen (nur bei registrierten Nutzern)
+                  Passwort-Reset-Mail senden
                 </label>
               )}
               {editingError && <p style={{ color: "crimson", margin: 0 }}>{editingError}</p>}
@@ -966,9 +939,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 type="button"
                 className="btn-primary modal-action-btn"
                 onClick={saveEditEmail}
-                disabled={editingSaving}
+                disabled={editingSaving || !editingHasChanges}
               >
-                {editingSaving ? "Speichere..." : "Speichern"}
+                {editingSaving
+                  ? "Speichere..."
+                  : canEditRoles && editingOriginal?.status === "active"
+                    ? "Speichern und Senden"
+                    : "Speichern"}
               </button>
             </div>
           </div>

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -304,7 +304,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         );
       } else if (emailChanged && original?.status === "active") {
         setBulkInviteResult(
-          "E-Mail aktualisiert. Aktive Sessions wurden aus Sicherheitsgründen beendet.",
+          "E-Mail aktualisiert. Info-Mail wurde an die neue Adresse gesendet.",
         );
       }
     } catch (err) {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, KeyRound, Link2, Mail, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import {
   deleteParticipant,
   getParticipants,
@@ -76,6 +76,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [bulkInviteResult, setBulkInviteResult] = useState("");
   const [deleteRunningByUserId, setDeleteRunningByUserId] = useState<Record<string, boolean>>({});
   const [deleteTarget, setDeleteTarget] = useState<ParticipantWithStatus | null>(null);
+  const [openActionsMenuUserId, setOpenActionsMenuUserId] = useState<string | null>(null);
 
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
@@ -665,7 +666,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "36px 130px 110px 150px 1fr 160px",
+                gridTemplateColumns: "36px 130px 110px 150px 1fr 220px",
                 gap: "0.5rem",
                 alignItems: "center",
                 fontWeight: 600,
@@ -692,7 +693,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   key={p.userId}
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "36px 130px 110px 150px 1fr 160px",
+                    gridTemplateColumns: "36px 130px 110px 150px 1fr 220px",
                     gap: "0.5rem",
                     alignItems: "center",
                     padding: "0.25rem 0",
@@ -734,61 +735,42 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                     </span>
                   </span>
                   <span style={{ color: p.email ? "#111827" : "#9ca3af" }}>{p.email ?? "-"}</span>
-                  <div style={{ display: "flex", gap: "0.25rem", justifyContent: "flex-end", flexWrap: "wrap" }}>
-                    <button
-                      type="button"
-                      title={
-                        !p.email
-                          ? "E-Mail fehlt"
-                          : p.status === "active" && !canEditRoles
-                            ? "Bereits registriert"
-                            : p.status === "active" && canEditRoles
-                              ? "Einladungslink (Recovery) erneut an registrierte Nutzerin senden"
+                  <div style={{ display: "flex", gap: "0.25rem", justifyContent: "flex-end", flexWrap: "nowrap", alignItems: "center", position: "relative" }}>
+                    {!(p.status === "active" && canEditRoles) && (
+                      <button
+                        type="button"
+                        title={
+                          !p.email
+                            ? "E-Mail fehlt"
+                            : p.status === "active" && !canEditRoles
+                              ? "Bereits registriert"
                               : p.status === "invited"
                                 ? "Einladung erneut senden"
                                 : "Einladung senden"
-                      }
-                      aria-label={
-                        p.status === "active" && canEditRoles
-                          ? `Einladungslink senden ${p.userId}`
-                          : p.status === "invited"
+                        }
+                        aria-label={
+                          p.status === "invited"
                             ? `Erneut einladen ${p.userId}`
                             : `Einladen ${p.userId}`
-                      }
-                      disabled={
-                        !p.email ||
-                        (p.status === "active" && !canEditRoles) ||
-                        !!inviteSendingByUserId[p.userId] ||
-                        participantsLoading ||
-                        editingSaving ||
-                        createSaving
-                      }
-                      onClick={() => sendInviteForParticipant(p)}
-                    >
-                      {inviteSendingByUserId[p.userId]
-                        ? "..."
-                        : p.status === "active" && canEditRoles
-                          ? "Link"
-                          : p.status === "invited"
-                            ? "Erneut"
-                            : "Einladen"}
-                    </button>
-                    {canEditRoles && (
-                      <button
-                        type="button"
-                        title={!p.email ? "E-Mail fehlt" : p.status !== "active" ? "Nur für registrierte Nutzer" : "Passwort zurücksetzen"}
-                        aria-label={`Passwort zurücksetzen ${p.userId}`}
+                        }
                         disabled={
                           !p.email ||
-                          p.status !== "active" ||
+                          (p.status === "active" && !canEditRoles) ||
                           !!inviteSendingByUserId[p.userId] ||
                           participantsLoading ||
                           editingSaving ||
                           createSaving
                         }
-                        onClick={() => sendPasswordResetForParticipant(p)}
+                        onClick={() => sendInviteForParticipant(p)}
                       >
-                        PW Reset
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                          <Mail size={14} aria-hidden="true" />
+                          {inviteSendingByUserId[p.userId]
+                            ? "..."
+                            : p.status === "invited"
+                              ? "Erneut"
+                              : "Einladen"}
+                        </span>
                       </button>
                     )}
                     <button
@@ -826,6 +808,93 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       >
                         <Trash2 size={14} aria-hidden="true" />
                       </button>
+                    )}
+                    {canEditRoles && (
+                      <>
+                        <button
+                          type="button"
+                          aria-label={`Weitere Aktionen ${p.userId}`}
+                          title={`Weitere Aktionen ${p.userId}`}
+                          onClick={() =>
+                            setOpenActionsMenuUserId((prev) =>
+                              prev === p.userId ? null : p.userId,
+                            )
+                          }
+                          disabled={participantsLoading || editingSaving || createSaving}
+                        >
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                            <MoreHorizontal size={14} aria-hidden="true" />
+                            {openActionsMenuUserId === p.userId ? (
+                              <ChevronUp size={14} aria-hidden="true" />
+                            ) : (
+                              <ChevronDown size={14} aria-hidden="true" />
+                            )}
+                          </span>
+                        </button>
+                        {openActionsMenuUserId === p.userId && (
+                          <div
+                            style={{
+                              position: "absolute",
+                              right: 0,
+                              top: "calc(100% + 4px)",
+                              background: "#fff",
+                              border: "1px solid #e5e7eb",
+                              borderRadius: 8,
+                              padding: 6,
+                              boxShadow: "0 8px 20px rgba(0,0,0,0.12)",
+                              zIndex: 20,
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: 4,
+                              minWidth: 170,
+                            }}
+                          >
+                            <button
+                              type="button"
+                              title="Einladungslink (Recovery) erneut an registrierte Nutzerin senden"
+                              aria-label={`Einladungslink senden ${p.userId}`}
+                              disabled={
+                                !p.email ||
+                                !!inviteSendingByUserId[p.userId] ||
+                                participantsLoading ||
+                                editingSaving ||
+                                createSaving
+                              }
+                              onClick={() => {
+                                void sendInviteForParticipant(p);
+                                setOpenActionsMenuUserId(null);
+                              }}
+                            >
+                              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                                <Link2 size={14} aria-hidden="true" />
+                                Link senden
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              title={!p.email ? "E-Mail fehlt" : "Passwort zurücksetzen"}
+                              aria-label={`Passwort zurücksetzen ${p.userId}`}
+                              disabled={
+                                !p.email ||
+                                p.status !== "active" ||
+                                !!inviteSendingByUserId[p.userId] ||
+                                participantsLoading ||
+                                editingSaving ||
+                                createSaving
+                              }
+                              onClick={() => {
+                                void sendPasswordResetForParticipant(p);
+                                setOpenActionsMenuUserId(null);
+                              }}
+                            >
+                              <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                                <KeyRound size={14} aria-hidden="true" />
+                                PW Reset
+                              </span>
+                            </button>
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                   {inviteResultByUserId[p.userId] && (

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -95,16 +95,20 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
   }, [courses, tenant?.settings, membership, currentUser.nickname]);
 
   if (loading) {
-    return <div>Loading...</div>;
+    return (
+      <div role="status" aria-live="polite">
+        Loading...
+      </div>
+    );
   }
   if (error) {
-    return <div>{error}</div>;
+    return <div role="alert">{error}</div>;
   }
 
   const coursesWithUpcoming = visibleCourses.filter((c) => getCourseDates(c).length > 0);
   if (visibleCourses.length === 0 || coursesWithUpcoming.length === 0) {
     return (
-      <div className="muted" style={{ textAlign: "center", padding: "2rem" }}>
+      <div className="muted" style={{ textAlign: "center", padding: "2rem" }} role="status" aria-live="polite">
         Aktuell keine Termine zum Anzeigen. Es gibt nur vergangene Termine oder noch keine Kurse.
       </div>
     );

--- a/app/src/components/ForgotPassword.test.tsx
+++ b/app/src/components/ForgotPassword.test.tsx
@@ -100,6 +100,9 @@ describe("ForgotPassword", () => {
     fireEvent.change(within(page).getByPlaceholderText("Neues Passwort"), {
       target: { value: "SicheresPasswort123!" },
     });
+    fireEvent.change(within(page).getByPlaceholderText("Neues Passwort wiederholen"), {
+      target: { value: "SicheresPasswort123!" },
+    });
     fireEvent.click(within(page).getByRole("button", { name: /Neues Passwort setzen/i }));
 
     await waitFor(() => {

--- a/app/src/components/ForgotPassword.test.tsx
+++ b/app/src/components/ForgotPassword.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import ForgotPassword from "./ForgotPassword";
 import { confirmResetPassword, resetPassword, signOut } from "aws-amplify/auth";
 import { clearCurrentUser } from "shared/lib/storage";
@@ -21,11 +21,26 @@ const mockedSignOut = signOut as unknown as ReturnType<typeof vi.fn>;
 const mockedClearCurrentUser = clearCurrentUser as unknown as ReturnType<typeof vi.fn>;
 
 function renderWithRouter(initialEntries: string[] = ["/forgot-password"]) {
+  function LoginStateProbe() {
+    const location = useLocation();
+    const state = location.state as {
+      info?: string;
+      prefillUsername?: string;
+      prefillPassword?: string;
+    } | null;
+    return (
+      <div>
+        <div>Login-Seite</div>
+        <div data-testid="login-prefill">{state?.prefillUsername ?? ""}</div>
+        <div data-testid="login-prefill-password">{state?.prefillPassword ?? ""}</div>
+      </div>
+    );
+  }
   const utils = render(
     <MemoryRouter initialEntries={initialEntries}>
       <Routes>
         <Route path="/forgot-password" element={<ForgotPassword />} />
-        <Route path="/login" element={<div>Login-Seite</div>} />
+        <Route path="/login" element={<LoginStateProbe />} />
         <Route path="/" element={<div>Home</div>} />
       </Routes>
     </MemoryRouter>,
@@ -60,6 +75,7 @@ describe("ForgotPassword", () => {
       expect(mockedResetPassword).toHaveBeenCalledWith({ username: "alice" });
       expect(within(page).getByPlaceholderText("Code aus E-Mail")).toBeInTheDocument();
       expect(within(page).getByPlaceholderText("Neues Passwort")).toBeInTheDocument();
+      expect(within(page).getByRole("button", { name: /Code erneut anfordern/i })).toBeInTheDocument();
     });
   });
 
@@ -94,6 +110,16 @@ describe("ForgotPassword", () => {
       });
       expect(mockedSignOut).toHaveBeenCalled();
       expect(mockedClearCurrentUser).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(within(page).getByText(/Passwort wurde zurueckgesetzt/i)).toBeInTheDocument();
+      expect(within(page).getByRole("button", { name: /Zur Anmeldung/i })).toBeInTheDocument();
+    });
+    fireEvent.click(within(page).getByRole("button", { name: /Zur Anmeldung/i }));
+    await waitFor(() => {
+      expect(within(document.body).getByText("Login-Seite")).toBeInTheDocument();
+      expect(within(document.body).getByTestId("login-prefill")).toHaveTextContent("alice");
+      expect(within(document.body).getByTestId("login-prefill-password")).toHaveTextContent("SicheresPasswort123!");
     });
   });
 });

--- a/app/src/components/ForgotPassword.tsx
+++ b/app/src/components/ForgotPassword.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { confirmResetPassword, resetPassword, signOut } from "aws-amplify/auth";
 import { useNavigate } from "react-router-dom";
 import { clearCurrentUser } from "shared/lib/storage";
 
 export default function ForgotPassword() {
   const navigate = useNavigate();
+  const usernameInputRef = useRef<HTMLInputElement | null>(null);
+  const newPasswordInputRef = useRef<HTMLInputElement | null>(null);
   const [username, setUsername] = useState("");
   const [code, setCode] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -12,12 +14,56 @@ export default function ForgotPassword() {
   const [error, setError] = useState("");
   const [info, setInfo] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resetDone, setResetDone] = useState(false);
+  const [lastSetPassword, setLastSetPassword] = useState("");
+  const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
 
-  const requestCode = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const mapResetRequestErrorMessage = (err: unknown): string => {
+    const msg = err instanceof Error ? err.message : String(err ?? "");
+    const lowered = msg.toLowerCase();
+    if (
+      lowered.includes("toomanyrequestsexception") ||
+      lowered.includes("limitexceededexception") ||
+      lowered.includes("attempt limit exceeded") ||
+      lowered.includes("too many")
+    ) {
+      return "Zu viele Anfragen. Bitte warte kurz und versuche es dann erneut.";
+    }
+    return "Wenn ein Konto existiert, wurde ein Code per E-Mail versendet.";
+  };
+
+  const startResendCooldown = (seconds = 30) => {
+    setResendCooldownSeconds(seconds);
+    const id = window.setInterval(() => {
+      setResendCooldownSeconds((prev) => {
+        if (prev <= 1) {
+          window.clearInterval(id);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const getUsernameValue = () => {
+    const fromState = username.trim();
+    if (fromState) return fromState;
+    const fromInput = usernameInputRef.current?.value?.trim() ?? "";
+    return fromInput;
+  };
+
+  /** Keychain/Safari setzt generierte Passwörter oft per input-Event, nicht change — State sonst leer beim Submit. */
+  const getNewPasswordValue = () => {
+    const fromState = newPassword;
+    if (fromState.trim()) return fromState;
+    return newPasswordInputRef.current?.value ?? "";
+  };
+
+  const requestCodeForUser = async () => {
     setError("");
     setInfo("");
-    const user = username.trim();
+    setResetDone(false);
+    const user = getUsernameValue();
     if (!user) {
       setError("Bitte Spitzname eingeben.");
       return;
@@ -28,13 +74,18 @@ export default function ForgotPassword() {
       await resetPassword({ username: user });
       setCodeSent(true);
       setInfo("Wenn ein Konto existiert, wurde ein Code per E-Mail versendet.");
-    } catch {
-      // Avoid user enumeration details.
-      setCodeSent(true);
-      setInfo("Wenn ein Konto existiert, wurde ein Code per E-Mail versendet.");
+      startResendCooldown();
+    } catch (err: unknown) {
+      // Keep enumeration-safe default, but surface rate-limit feedback.
+      const mapped = mapResetRequestErrorMessage(err);
+      setInfo(mapped);
     } finally {
       setLoading(false);
     }
+  };
+  const requestCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await requestCodeForUser();
   };
 
   const submitNewPassword = async (e: React.FormEvent) => {
@@ -42,7 +93,7 @@ export default function ForgotPassword() {
     setError("");
     setInfo("");
 
-    const user = username.trim();
+    const user = getUsernameValue();
     if (!user) {
       setError("Bitte Spitzname eingeben.");
       return;
@@ -51,7 +102,8 @@ export default function ForgotPassword() {
       setError("Bitte den Code aus der E-Mail eingeben.");
       return;
     }
-    if (!newPassword || newPassword.length < 6) {
+    const pw = getNewPasswordValue();
+    if (!pw || pw.length < 6) {
       setError("Das neue Passwort muss mindestens 6 Zeichen lang sein.");
       return;
     }
@@ -61,7 +113,7 @@ export default function ForgotPassword() {
       await confirmResetPassword({
         username: user,
         confirmationCode: code.trim(),
-        newPassword,
+        newPassword: pw,
       });
       // Password reset should never "auto-login" from this view.
       // We force a clean auth state and redirect to login.
@@ -71,12 +123,12 @@ export default function ForgotPassword() {
         // ignore when no active session exists
       }
       clearCurrentUser();
-      navigate("/login", {
-        replace: true,
-        state: {
-          info:
-            "Passwort wurde zurueckgesetzt. Bitte melde dich mit deinem neuen Passwort an.",
-        },
+      setLastSetPassword(pw);
+      // Kurz warten, damit der Browser die erfolgreiche Passwort-Übermittlung (inkl. Keychain) abarbeiten kann,
+      // bevor React das Formular neu rendert.
+      queueMicrotask(() => {
+        setResetDone(true);
+        setInfo("Passwort wurde zurueckgesetzt. Du kannst jetzt zur Anmeldung wechseln.");
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -89,11 +141,21 @@ export default function ForgotPassword() {
   return (
     <div className="auth-form" style={{ padding: "2rem", maxWidth: 420, margin: "auto" }}>
       <h2>Passwort vergessen</h2>
-      <p className="muted">Fordere einen Code an und setze danach ein neues Passwort.</p>
+      <p className="muted">
+        {codeSent
+          ? "Gib den Code aus der E-Mail ein und setze ein neues Passwort."
+          : "Fordere einen Code an und setze danach ein neues Passwort."}
+      </p>
 
-      <form onSubmit={codeSent ? submitNewPassword : requestCode} className="todo-form">
+      <form
+        onSubmit={codeSent ? submitNewPassword : requestCode}
+        className="todo-form"
+        autoComplete={codeSent ? "on" : "off"}
+      >
         <input
+          ref={usernameInputRef}
           type="text"
+          name="username"
           placeholder="Spitzname"
           value={username}
           autoComplete="username"
@@ -106,18 +168,25 @@ export default function ForgotPassword() {
           <>
             <input
               type="text"
+              name="one-time-code"
+              inputMode="numeric"
+              autoComplete="one-time-code"
               placeholder="Code aus E-Mail"
+              aria-label="Code aus E-Mail"
               value={code}
               onChange={(e) => setCode(e.target.value)}
               disabled={loading}
               required
             />
             <input
+              ref={newPasswordInputRef}
               type="password"
+              name="new-password"
               placeholder="Neues Passwort"
               value={newPassword}
               autoComplete="new-password"
               onChange={(e) => setNewPassword(e.target.value)}
+              onInput={(e) => setNewPassword((e.target as HTMLInputElement).value)}
               disabled={loading}
               minLength={6}
               required
@@ -125,8 +194,16 @@ export default function ForgotPassword() {
           </>
         )}
 
-        {info && <p style={{ color: "#374151" }}>{info}</p>}
-        {error && <p style={{ color: "crimson" }}>{error}</p>}
+        {info && (
+          <p style={{ color: "#374151" }} role="status" aria-live="polite">
+            {info}
+          </p>
+        )}
+        {error && (
+          <p style={{ color: "crimson" }} role="alert">
+            {error}
+          </p>
+        )}
 
         <button type="submit" disabled={loading} className="btn-primary btn-block">
           {loading
@@ -135,6 +212,39 @@ export default function ForgotPassword() {
               ? "Neues Passwort setzen"
               : "Code anfordern"}
         </button>
+        {codeSent && !resetDone && (
+          <button
+            type="button"
+            className="btn-block"
+            disabled={loading || resendCooldownSeconds > 0}
+            onClick={() => {
+              void requestCodeForUser();
+            }}
+          >
+            {resendCooldownSeconds > 0
+              ? `Code erneut anfordern (${resendCooldownSeconds}s)`
+              : "Code erneut anfordern"}
+          </button>
+        )}
+        {resetDone && (
+          <button
+            type="button"
+            className="btn-block"
+            onClick={() =>
+              navigate("/login", {
+                replace: true,
+                state: {
+                  info:
+                    "Passwort wurde zurueckgesetzt. Bitte melde dich mit deinem neuen Passwort an.",
+                  prefillUsername: username.trim(),
+                  prefillPassword: lastSetPassword,
+                },
+              })
+            }
+          >
+            Zur Anmeldung
+          </button>
+        )}
       </form>
     </div>
   );

--- a/app/src/components/ForgotPassword.tsx
+++ b/app/src/components/ForgotPassword.tsx
@@ -9,7 +9,7 @@ export default function ForgotPassword() {
   const newPasswordInputRef = useRef<HTMLInputElement | null>(null);
   const [username, setUsername] = useState("");
   const [code, setCode] = useState("");
-  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [codeSent, setCodeSent] = useState(false);
   const [error, setError] = useState("");
   const [info, setInfo] = useState("");
@@ -45,6 +45,23 @@ export default function ForgotPassword() {
     }, 1000);
   };
 
+  const tryStoreCredential = (userId: string, passwordValue: string) => {
+    try {
+      const maybeCtor = (window as unknown as {
+        PasswordCredential?: new (data: { id: string; password: string }) => unknown;
+      }).PasswordCredential;
+      const credsApi = (navigator as Navigator & {
+        credentials?: { store?: (credential: unknown) => Promise<unknown> };
+      }).credentials;
+      if (maybeCtor && credsApi?.store && userId && passwordValue) {
+        const credential = new maybeCtor({ id: userId, password: passwordValue });
+        void credsApi.store(credential);
+      }
+    } catch {
+      // ignore unsupported/blocked browsers
+    }
+  };
+
   const getUsernameValue = () => {
     const fromState = username.trim();
     if (fromState) return fromState;
@@ -54,8 +71,6 @@ export default function ForgotPassword() {
 
   /** Keychain/Safari setzt generierte Passwörter oft per input-Event, nicht change — State sonst leer beim Submit. */
   const getNewPasswordValue = () => {
-    const fromState = newPassword;
-    if (fromState.trim()) return fromState;
     return newPasswordInputRef.current?.value ?? "";
   };
 
@@ -63,6 +78,7 @@ export default function ForgotPassword() {
     setError("");
     setInfo("");
     setResetDone(false);
+    setConfirmPassword("");
     const user = getUsernameValue();
     if (!user) {
       setError("Bitte Spitzname eingeben.");
@@ -102,9 +118,13 @@ export default function ForgotPassword() {
       setError("Bitte den Code aus der E-Mail eingeben.");
       return;
     }
-    const pw = getNewPasswordValue();
+    const pw = getNewPasswordValue().trim();
     if (!pw || pw.length < 6) {
       setError("Das neue Passwort muss mindestens 6 Zeichen lang sein.");
+      return;
+    }
+    if (!confirmPassword || pw !== confirmPassword) {
+      setError("Die Passwoerter stimmen nicht ueberein.");
       return;
     }
 
@@ -115,6 +135,8 @@ export default function ForgotPassword() {
         confirmationCode: code.trim(),
         newPassword: pw,
       });
+      // Best-effort hint for password managers right after a successful reset.
+      tryStoreCredential(user, pw);
       // Password reset should never "auto-login" from this view.
       // We force a clean auth state and redirect to login.
       try {
@@ -183,10 +205,18 @@ export default function ForgotPassword() {
               type="password"
               name="new-password"
               placeholder="Neues Passwort"
-              value={newPassword}
               autoComplete="new-password"
-              onChange={(e) => setNewPassword(e.target.value)}
-              onInput={(e) => setNewPassword((e.target as HTMLInputElement).value)}
+              disabled={loading}
+              minLength={6}
+              required
+            />
+            <input
+              type="password"
+              name="confirm-new-password"
+              placeholder="Neues Passwort wiederholen"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
               disabled={loading}
               minLength={6}
               required

--- a/app/src/components/Invite.test.tsx
+++ b/app/src/components/Invite.test.tsx
@@ -210,6 +210,11 @@ describe("Invite", () => {
         token: "t1",
       });
     });
+    const hiddenUsername = panel.querySelector(
+      "input[name='username'][autocomplete='username']",
+    ) as HTMLInputElement | null;
+    expect(hiddenUsername).toBeTruthy();
+    expect(hiddenUsername?.value).toBe("Alice");
 
     // code + new password
     fireEvent.change(within(panel).getByPlaceholderText(/Code aus E-Mail/i), {

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -349,6 +349,24 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
           )}
 
           <form onSubmit={handleSubmitTokenReset} className="invite-form">
+            {/* Password managers need an explicit username field in reset flows. */}
+            <input
+              type="text"
+              name="username"
+              autoComplete="username"
+              value={usernameForReset || nicknameParam}
+              readOnly
+              tabIndex={-1}
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                left: "-10000px",
+                width: 1,
+                height: 1,
+                opacity: 0,
+                pointerEvents: "none",
+              }}
+            />
             <input
               type="text"
               placeholder="Code aus E-Mail"

--- a/app/src/components/Invite.tsx
+++ b/app/src/components/Invite.tsx
@@ -375,7 +375,11 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
               required
             />
 
-            {error && <p style={{ color: "red" }}>{error}</p>}
+            {error && (
+              <p style={{ color: "red" }} role="alert">
+                {error}
+              </p>
+            )}
 
             <button type="submit" disabled={loading || !authCleared || !codeSent} className="btn-primary btn-block">
               {loading ? "Verarbeite…" : modeCopy[authMode].submitLabel}
@@ -437,7 +441,11 @@ export default function Invite({ onSuccess }: { onSuccess?: () => void }) {
               minLength={6}
             />
 
-            {error && <p style={{ color: "red" }}>{error}</p>}
+            {error && (
+              <p style={{ color: "red" }} role="alert">
+                {error}
+              </p>
+            )}
 
             <button type="submit" disabled={loading} className="btn-primary btn-block">
               {loading ? "Verarbeite…" : modeCopy[authMode].submitLabel}

--- a/app/src/components/Login.test.tsx
+++ b/app/src/components/Login.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Login from "./Login";
 import { useCognitoAuth } from "../auth/useCognitoAuth";
 import { loadCurrentUser } from "shared/lib/storage";
@@ -78,6 +78,40 @@ describe("Login", () => {
     );
 
     expect(screen.getByText(/Login fehlgeschlagen/i)).toBeInTheDocument();
+  });
+
+  it("nutzt bei Weiterleitung aus Passwort-Reset den Nutzernamen statt Demo-Prefill", () => {
+    const onLogin = vi.fn();
+
+    useCognitoAuthMock.mockReturnValue({
+      login: vi.fn().mockResolvedValue(false),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/login",
+            state: {
+              info: "Passwort wurde zurueckgesetzt.",
+              prefillUsername: "alice",
+              prefillPassword: "NeuesPasswort123!",
+            },
+          } as never,
+        ]}
+      >
+        <Routes>
+          <Route path="/login" element={<Login onLogin={onLogin} />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const page = container.querySelector(".login-wrap") as HTMLElement;
+
+    expect(within(page).getByPlaceholderText("Spitzname")).toHaveValue("alice");
+    expect(within(page).getByPlaceholderText("Passwort")).toHaveValue("NeuesPasswort123!");
+    expect(within(page).queryByText(/Demo:/i)).not.toBeInTheDocument();
   });
 });
 

--- a/app/src/components/Login.tsx
+++ b/app/src/components/Login.tsx
@@ -42,6 +42,23 @@ export default function Login({ onLogin }: Props) {
     e.preventDefault();
     const success = await login({ username, password });
     if (success) {
+      if (fromPasswordResetFlow && username.trim() && password) {
+        // Best-effort trigger for password managers after reset flows.
+        // Some browsers (especially with generated passwords) only offer save/update
+        // when Credential Management API is explicitly touched.
+        try {
+          const maybeCtor = (window as unknown as { PasswordCredential?: new (data: { id: string; password: string }) => unknown })
+            .PasswordCredential;
+          const credsApi = (navigator as Navigator & { credentials?: { store?: (credential: unknown) => Promise<unknown> } })
+            .credentials;
+          if (maybeCtor && credsApi?.store) {
+            const credential = new maybeCtor({ id: username.trim(), password });
+            void credsApi.store(credential);
+          }
+        } catch {
+          // ignore: unsupported browser or blocked API
+        }
+      }
       const user = loadCurrentUser();
       if (user) {
         onLogin(user);

--- a/app/src/components/Login.tsx
+++ b/app/src/components/Login.tsx
@@ -8,19 +8,34 @@ import { useCognitoAuth } from "../auth/useCognitoAuth";
 type Props = {
   onLogin: (user: User) => void;
 };
+type LoginRouteState = {
+  info?: unknown;
+  prefillUsername?: unknown;
+  prefillPassword?: unknown;
+};
 
 // Demo: voreingestellter Nutzer (später nur in Demo-Variante oder ganz entfernen)
 const DEMO_USERNAME = "Luna";
 const DEMO_PASSWORD = "Hallo123!";
 
 export default function Login({ onLogin }: Props) {
-  const { state } = useLocation();
+  const { state, pathname } = useLocation();
   const navigate = useNavigate();
-  const [username, setUsername] = useState(DEMO_USERNAME);
-  const [password, setPassword] = useState(DEMO_PASSWORD);
+  const prefillUsername =
+    typeof (state as LoginRouteState | null)?.prefillUsername === "string"
+      ? ((state as LoginRouteState).prefillUsername as string).trim()
+      : "";
+  const prefillPassword =
+    typeof (state as LoginRouteState | null)?.prefillPassword === "string"
+      ? ((state as LoginRouteState).prefillPassword as string)
+      : "";
+  const fromPasswordResetFlow = prefillUsername.length > 0;
+  const useDemoPrefill = !fromPasswordResetFlow && pathname !== "/login";
+  const [username, setUsername] = useState(useDemoPrefill ? DEMO_USERNAME : prefillUsername);
+  const [password, setPassword] = useState(useDemoPrefill ? DEMO_PASSWORD : prefillPassword);
   const { login, isLoading, error } = useCognitoAuth();
-  const infoMessage = typeof (state as { info?: unknown } | null)?.info === "string"
-    ? (state as { info: string }).info
+  const infoMessage = typeof (state as LoginRouteState | null)?.info === "string"
+    ? ((state as LoginRouteState).info as string)
     : "";
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -40,7 +55,9 @@ export default function Login({ onLogin }: Props) {
       <h1>YogaSwap Login</h1>
       <form onSubmit={handleSubmit} className="todo-form">
         <input
+          aria-label="Spitzname"
           type="text"
+          name="username"
           placeholder="Spitzname"
           value={username}
           autoComplete="username"
@@ -48,10 +65,12 @@ export default function Login({ onLogin }: Props) {
           disabled={isLoading}
         />
         <input
+          aria-label="Passwort"
           type="password"
+          name="password"
           placeholder="Passwort"
           value={password}
-          autoComplete="current-password"
+          autoComplete={fromPasswordResetFlow ? "new-password" : "current-password"}
           onChange={e => setPassword(e.target.value)}
           disabled={isLoading}
         />
@@ -63,12 +82,27 @@ export default function Login({ onLogin }: Props) {
         <Link to="/forgot-password">Passwort vergessen?</Link>
       </p>
 
-      {infoMessage && <p style={{ color: "#374151" }}>{infoMessage}</p>}
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      {infoMessage && (
+        <p style={{ color: "#374151" }} role="status" aria-live="polite">
+          {infoMessage}
+        </p>
+      )}
+      {fromPasswordResetFlow && (
+        <p className="muted" style={{ marginTop: 0 }}>
+          Bitte gib dein neu gesetztes Passwort ein.
+        </p>
+      )}
+      {error && (
+        <p style={{ color: "crimson" }} role="alert">
+          {error}
+        </p>
+      )}
 
-      <p style={{ fontSize: 12, opacity: 0.8 }}>
-        Demo: <code>{DEMO_USERNAME}</code> / <code>{DEMO_PASSWORD}</code>
-      </p>
+      {useDemoPrefill && (
+        <p style={{ fontSize: 12, opacity: 0.8 }}>
+          Demo: <code>{DEMO_USERNAME}</code> / <code>{DEMO_PASSWORD}</code>
+        </p>
+      )}
     </div>
   );
 }

--- a/app/src/components/changePassword.tsx
+++ b/app/src/components/changePassword.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { confirmSignIn, fetchAuthSession } from "aws-amplify/auth";
 import { useLocation, useNavigate } from "react-router-dom";
 import { saveCurrentUser } from "shared/lib/storage";
@@ -13,10 +13,12 @@ export default function ChangePassword() {
 
   const { username } = (state as { username: string }) || {};
 
-  if (!username) {
-    navigate("/login");
-    return null;
-  }
+  useEffect(() => {
+    if (!username) {
+      navigate("/login", { replace: true });
+    }
+  }, [username, navigate]);
+  if (!username) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,13 +52,18 @@ export default function ChangePassword() {
       <form onSubmit={handleSubmit}>
         <input
           type="password"
+          aria-label="Neues Passwort"
           placeholder="Neues Passwort"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           style={{ fontSize: 16 }}
           required
         />
-        {error && <p style={{ color: "crimson" }}>{error}</p>}
+        {error && (
+          <p style={{ color: "crimson" }} role="alert">
+            {error}
+          </p>
+        )}
         <button type="submit" disabled={loading} className="btn-primary btn-block">
           Passwort festlegen
         </button>

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
@@ -5,6 +5,7 @@ import {
   buildInvitePreparationMail,
   buildRecoveryMail,
   buildReactivationMail,
+  buildRoleChangedMail,
   buildStudioAccessRemovedMail,
 } from "./authMailTemplates";
 
@@ -100,6 +101,23 @@ describe("authMailTemplates", () => {
     expect(mail.html).toContain("Hallo Karin");
     expect(mail.html).toContain("karin.neu@example.com");
     expect(mail.html).toContain("Falls das nicht von dir veranlasst wurde");
+  });
+
+  test("buildRoleChangedMail returns german role-change template", () => {
+    const mail = buildRoleChangedMail({
+      locale: "de",
+      nickname: "Karin",
+      oldRole: "participant",
+      newRole: "instructor",
+      loginUrl: "https://app.yogaswap.de",
+    });
+
+    expect(mail.subject).toBe("YogaSwap: Rolle aktualisiert");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("Accountname (Spitzname): Karin");
+    expect(mail.html).toContain("participant");
+    expect(mail.html).toContain("instructor");
+    expect(mail.html).toContain("https://app.yogaswap.de");
   });
 
   test("unknown locale falls back to german for all builders", () => {

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildEmailChangedNewAddressMail,
+  buildEmailChangedOldAddressMail,
   buildInviteMail,
   buildInvitePreparationMail,
   buildRecoveryMail,
@@ -70,6 +72,34 @@ describe("authMailTemplates", () => {
     expect(mail.subject).toBe("YogaSwap: Zugang im Studio entfernt");
     expect(mail.html).toContain("Zugang zu diesem YogaSwap-Studio wurde entfernt");
     expect(mail.html).toContain("Accountname (Spitzname): Karin");
+  });
+
+  test("buildEmailChangedNewAddressMail returns german template with app link", () => {
+    const mail = buildEmailChangedNewAddressMail({
+      locale: "de",
+      nickname: "Karin",
+      newEmail: "karin.neu@example.com",
+      loginUrl: "https://app.yogaswap.de",
+    });
+
+    expect(mail.subject).toBe("YogaSwap: E-Mail-Adresse aktualisiert");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("karin.neu@example.com");
+    expect(mail.html).toContain("https://app.yogaswap.de");
+  });
+
+  test("buildEmailChangedOldAddressMail returns german security template", () => {
+    const mail = buildEmailChangedOldAddressMail({
+      locale: "de",
+      nickname: "Karin",
+      newEmail: "karin.neu@example.com",
+      loginUrl: "https://app.yogaswap.de",
+    });
+
+    expect(mail.subject).toBe("YogaSwap Sicherheitshinweis: E-Mail-Adresse geaendert");
+    expect(mail.html).toContain("Hallo Karin");
+    expect(mail.html).toContain("karin.neu@example.com");
+    expect(mail.html).toContain("Falls das nicht von dir veranlasst wurde");
   });
 
   test("unknown locale falls back to german for all builders", () => {

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
@@ -132,6 +132,14 @@ type EmailChangedOldAddressMailInput = {
   newEmail: string;
 };
 
+type RoleChangedMailInput = {
+  locale?: string;
+  nickname: string;
+  loginUrl: string;
+  oldRole: string;
+  newRole: string;
+};
+
 export function buildStudioAccessRemovedMail(input: StudioAccessRemovedMailInput): MailTemplate {
   const locale = normalizeLocale(input.locale);
   if (locale === "de") {
@@ -190,6 +198,25 @@ export function buildEmailChangedOldAddressMail(
   }
   return {
     subject: "YogaSwap Sicherheitshinweis: E-Mail-Adresse geaendert",
+    html: "",
+  };
+}
+
+export function buildRoleChangedMail(input: RoleChangedMailInput): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap: Rolle aktualisiert",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
+        <p>Deine Rolle im Studio wurde geaendert: <strong>${input.oldRole}</strong> -> <strong>${input.newRole}</strong>.</p>
+        <p><a href="${input.loginUrl}">Zur Anmeldung</a></p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap: Rolle aktualisiert",
     html: "",
   };
 }

--- a/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
+++ b/backend/src/lambdas/shared/templates/auth/authMailTemplates.ts
@@ -118,6 +118,20 @@ type StudioAccessRemovedMailInput = {
   nickname: string;
 };
 
+type EmailChangedNewAddressMailInput = {
+  locale?: string;
+  nickname: string;
+  loginUrl: string;
+  newEmail: string;
+};
+
+type EmailChangedOldAddressMailInput = {
+  locale?: string;
+  nickname: string;
+  loginUrl: string;
+  newEmail: string;
+};
+
 export function buildStudioAccessRemovedMail(input: StudioAccessRemovedMailInput): MailTemplate {
   const locale = normalizeLocale(input.locale);
   if (locale === "de") {
@@ -133,6 +147,49 @@ export function buildStudioAccessRemovedMail(input: StudioAccessRemovedMailInput
   }
   return {
     subject: "YogaSwap: Zugang im Studio entfernt",
+    html: "",
+  };
+}
+
+export function buildEmailChangedNewAddressMail(
+  input: EmailChangedNewAddressMailInput,
+): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap: E-Mail-Adresse aktualisiert",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
+        <p>Deine Login-E-Mail-Adresse wurde auf <strong>${input.newEmail}</strong> geaendert.</p>
+        <p><a href="${input.loginUrl}">Zur Anmeldung</a></p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap: E-Mail-Adresse aktualisiert",
+    html: "",
+  };
+}
+
+export function buildEmailChangedOldAddressMail(
+  input: EmailChangedOldAddressMailInput,
+): MailTemplate {
+  const locale = normalizeLocale(input.locale);
+  if (locale === "de") {
+    return {
+      subject: "YogaSwap Sicherheitshinweis: E-Mail-Adresse geaendert",
+      html: `
+        <h2>Hallo ${input.nickname}!</h2>
+        <p><strong>Dein Accountname (Spitzname): ${input.nickname}</strong></p>
+        <p>Fuer deinen Zugang wurde die Login-E-Mail-Adresse auf <strong>${input.newEmail}</strong> geaendert.</p>
+        <p>Falls das nicht von dir veranlasst wurde, kontaktiere bitte umgehend dein Studio.</p>
+        <p><a href="${input.loginUrl}">Zur Anmeldung</a></p>
+      `,
+    };
+  }
+  return {
+    subject: "YogaSwap Sicherheitshinweis: E-Mail-Adresse geaendert",
     html: "",
   };
 }

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -153,10 +153,19 @@ describe("updateParticipant Lambda", () => {
           tenantId: { S: "default-tenant" },
           userId: { S: "alice" },
           email: { S: "alice@example.com" },
+          authUserId: { S: "sub-123" },
         },
       }) // target participant
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          role: { S: "participant" },
+        },
+      }) // target membership (current role)
       .mockResolvedValueOnce({}) // memberships PutItem (role change)
       .mockResolvedValueOnce({}); // participants PutItem
+    sesMockSend.mockResolvedValueOnce({});
 
     const result = await handler(
       makeEvent({
@@ -165,6 +174,9 @@ describe("updateParticipant Lambda", () => {
     );
 
     expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.roleChanged).toBe(true);
+    expect(body.roleChangedEmailSent).toBe(true);
     expect(mockSend).toHaveBeenCalledWith(
       expect.objectContaining({
         TableName: "test-memberships",
@@ -173,6 +185,11 @@ describe("updateParticipant Lambda", () => {
           userId: { S: "alice" },
           role: { S: "instructor" },
         }),
+      }),
+    );
+    expect(sesMockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Destination: { ToAddresses: ["alice@example.com"] },
       }),
     );
   });

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -25,6 +25,7 @@ import {
   buildEmailChangedNewAddressMail,
   buildEmailChangedOldAddressMail,
   buildRecoveryMail,
+  buildRoleChangedMail,
 } from "../shared/templates/auth/authMailTemplates";
 
 const client = dynamoClient;
@@ -220,6 +221,10 @@ export const handler = async (
     }
     let passwordResetTriggered = false;
     let passwordResetEmailSent = false;
+    let roleChanged = false;
+    let roleChangedEmailSent = false;
+    let previousRole: UserRole | undefined;
+    let nextRoleForMail: UserRole | undefined;
     const updated: ParticipantProfile = {
       ...existing,
       tenantId,
@@ -443,6 +448,17 @@ export const handler = async (
           body: JSON.stringify({ error: "Invalid role value" }),
         };
       }
+      const targetMembershipResp = await client.send(
+        new GetItemCommand({
+          TableName: membershipsTable,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: targetUserId },
+          },
+          ConsistentRead: true,
+        }),
+      );
+      const currentRole = targetMembershipResp.Item?.role?.S as UserRole | undefined;
       await client.send(
         new PutItemCommand({
           TableName: membershipsTable,
@@ -453,6 +469,40 @@ export const handler = async (
           }),
         }),
       );
+      previousRole = currentRole;
+      nextRoleForMail = nextRole;
+      roleChanged = currentRole !== nextRole;
+    }
+
+    if (roleChanged && existingStatus === "active" && updated.email) {
+      const baseUrlEnv = process.env.BASE_URL || "";
+      const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
+      const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+      const mailLocale = process.env.MAIL_LOCALE || "de";
+      try {
+        const roleChangedMail = buildRoleChangedMail({
+          locale: mailLocale,
+          nickname: targetUserId,
+          loginUrl: baseUrl,
+          oldRole: previousRole ?? "participant",
+          newRole: nextRoleForMail ?? "participant",
+        });
+        await ses.send(
+          new SendEmailCommand({
+            Source: sesSourceEmail,
+            Destination: { ToAddresses: [updated.email] },
+            Message: {
+              Subject: { Data: roleChangedMail.subject },
+              Body: {
+                Html: { Data: roleChangedMail.html },
+              },
+            },
+          }),
+        );
+        roleChangedEmailSent = true;
+      } catch (mailErr) {
+        console.warn("Failed to send role-change notification mail:", mailErr);
+      }
     }
 
     await client.send(
@@ -469,6 +519,8 @@ export const handler = async (
         status: deriveParticipantStatus(updated),
         passwordResetTriggered,
         passwordResetEmailSent,
+        roleChanged,
+        roleChangedEmailSent,
       }),
     };
   } catch (error) {

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -21,7 +21,11 @@ import { dynamoClient } from "../shared/dynamoClient";
 import { canActorManageParticipants } from "../shared/participantAuthorization";
 import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
-import { buildRecoveryMail } from "../shared/templates/auth/authMailTemplates";
+import {
+  buildEmailChangedNewAddressMail,
+  buildEmailChangedOldAddressMail,
+  buildRecoveryMail,
+} from "../shared/templates/auth/authMailTemplates";
 
 const client = dynamoClient;
 const cognito = new CognitoIdentityProviderClient({});
@@ -258,6 +262,64 @@ export const handler = async (
                   Username: cognitoUsername,
                 }),
               );
+            }
+
+            if (emailChanged) {
+              const baseUrlEnv = process.env.BASE_URL || "";
+              const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
+              const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
+              const mailLocale = process.env.MAIL_LOCALE || "de";
+              const oldEmail = (existing.email ?? "").trim();
+
+              // Best practice: confirm change to new address.
+              try {
+                const changedNewMail = buildEmailChangedNewAddressMail({
+                  locale: mailLocale,
+                  nickname: targetUserId,
+                  loginUrl: baseUrl,
+                  newEmail: email,
+                });
+                await ses.send(
+                  new SendEmailCommand({
+                    Source: sesSourceEmail,
+                    Destination: { ToAddresses: [email] },
+                    Message: {
+                      Subject: { Data: changedNewMail.subject },
+                      Body: {
+                        Html: { Data: changedNewMail.html },
+                      },
+                    },
+                  }),
+                );
+              } catch (mailErr) {
+                console.warn("Failed to send email-change confirmation to new address:", mailErr);
+              }
+
+              // Optional security notification to old address (if different).
+              if (oldEmail && oldEmail.toLowerCase() !== email.toLowerCase()) {
+                try {
+                  const changedOldMail = buildEmailChangedOldAddressMail({
+                    locale: mailLocale,
+                    nickname: targetUserId,
+                    loginUrl: baseUrl,
+                    newEmail: email,
+                  });
+                  await ses.send(
+                    new SendEmailCommand({
+                      Source: sesSourceEmail,
+                      Destination: { ToAddresses: [oldEmail] },
+                      Message: {
+                        Subject: { Data: changedOldMail.subject },
+                        Body: {
+                          Html: { Data: changedOldMail.html },
+                        },
+                      },
+                    }),
+                  );
+                } catch (mailErr) {
+                  console.warn("Failed to send email-change security mail to old address:", mailErr);
+                }
+              }
             }
 
             if (emailChanged && body.forcePasswordResetOnEmailChange) {


### PR DESCRIPTION
## Kontext
Abschluss von #85 (Finaler Layout-Review über alle Views).

## Änderungen
- `AdminPanel` UX/Layout überarbeitet: klare Icon-Aktionen, stabilere Tabellenausrichtung, iPhone/Safari-Feinschliff.
- Bearbeiten-Dialog für registrierte Teilnehmer konsolidiert:
  - `Speichern und Senden` nur bei Änderungen aktiv
  - Passwort-Reset optional über Checkbox
  - klare Statusmeldungen für Kombi-Fälle (Speichern + Reset-Mail)
- Backend `updateParticipant` erweitert:
  - Rollenänderungs-Mail ergänzt (Template + Versand)
  - bestehende E-Mail-Änderungs- und Reset-Logik beibehalten
- Tests in Frontend/Backend auf neues Verhalten angepasst.

## Testplan
- [x] `npm run test --prefix app -- --run src/components/AdminPanel.test.tsx`
- [x] `npm run test --prefix backend -- src/lambdas/shared/templates/auth/authMailTemplates.test.ts src/lambdas/updateParticipant/index.test.ts`
- [x] Manuelle Prüfung auf Mobile (iPhone/Safari) und Desktop (AdminPanel Dialog-/Tabellenverhalten)

## Hinweis
Desktop-Spacing in der Admin-Tabelle ist als separater Feinschliff bewusst deferred, damit das stabile Mobile-Verhalten unangetastet bleibt.