### PR TITLE
#111 AdminPanel: invited-Dialog und Trainer-Regeln schärfen

### DIFF
--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -613,6 +613,81 @@ describe("AdminPanel", () => {
     });
   });
 
+  it("fokussiert bei Reaktivierung per Tab zuerst die Reaktivierungs-Checkbox", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: undefined,
+        email: "alice@example.com",
+        status: "active",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    const nicknameInput = within(dialog).getByPlaceholderText("Spitzname") as HTMLInputElement;
+    fireEvent.change(nicknameInput, { target: { value: "alice" } });
+    nicknameInput.focus();
+    fireEvent.keyDown(nicknameInput, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        within(dialog).getByRole("checkbox", { name: /E-Mail fuer Reaktivierung bearbeiten/i }),
+      );
+    });
+  });
+
+  it("setzt Reaktivierungs-Eingaben beim erneuten Blur ohne Nickname-Änderung nicht zurück", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: undefined,
+        email: "alice@example.com",
+        status: "active",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    const nicknameInput = within(dialog).getByPlaceholderText("Spitzname") as HTMLInputElement;
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+
+    fireEvent.change(nicknameInput, { target: { value: "alice" } });
+    fireEvent.blur(nicknameInput);
+    let reactivationCheckbox: HTMLInputElement;
+    await waitFor(() => {
+      reactivationCheckbox = within(dialog).getByRole("checkbox", {
+        name: /E-Mail fuer Reaktivierung bearbeiten/i,
+      }) as HTMLInputElement;
+      expect(reactivationCheckbox.checked).toBe(false);
+      expect(emailInput.disabled).toBe(true);
+    });
+
+    fireEvent.click(reactivationCheckbox!);
+    fireEvent.change(emailInput, { target: { value: "alice.new@example.com" } });
+    expect(reactivationCheckbox!.checked).toBe(true);
+    expect(emailInput.value).toBe("alice.new@example.com");
+
+    fireEvent.focus(nicknameInput);
+    fireEvent.blur(nicknameInput);
+
+    await waitFor(() => {
+      expect(reactivationCheckbox!.checked).toBe(true);
+      expect(emailInput.disabled).toBe(false);
+      expect(emailInput.value).toBe("alice.new@example.com");
+    });
+  });
+
   it("Kursleitung sieht Reaktivierungs-E-Mail nur read-only und ohne Checkbox", async () => {
     mockedGetParticipants.mockResolvedValueOnce([
       {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -289,17 +289,7 @@ describe("AdminPanel", () => {
   });
 
   it("legt einen Teilnehmer über + Neu an (Nickname Pflicht, E-Mail optional)", async () => {
-    mockedGetParticipants
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          tenantId: "default-tenant",
-          userId: "alice",
-          role: "participant",
-          email: "alice@example.com",
-          status: "no_login",
-        },
-      ]);
+    mockedGetParticipants.mockResolvedValue([]);
 
     mockedInviteUser.mockResolvedValueOnce({
       success: true,
@@ -324,6 +314,10 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
       target: { value: "alice" },
     });
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
+    await waitFor(() => {
+      expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).disabled).toBe(false);
+    });
     fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
       target: { value: "alice@example.com" },
     });
@@ -333,13 +327,41 @@ describe("AdminPanel", () => {
     await waitFor(() => {
       expect(mockedInviteUser).toHaveBeenCalledWith({ nickname: "alice", role: "participant" });
       expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice@example.com" });
-      expect(within(panel).getByText("alice")).toBeInTheDocument();
-      expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
+    });
+  });
+
+  it("hält E-Mail ohne validierten Nickname deaktiviert", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([]);
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    const nicknameInput = within(dialog).getByPlaceholderText("Spitzname");
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+
+    expect(emailInput.disabled).toBe(true);
+
+    fireEvent.change(nicknameInput, { target: { value: "al" } });
+    fireEvent.blur(nicknameInput);
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/Nickname-Prüfung startet ab 3 Zeichen/i)).toBeInTheDocument();
+      expect(emailInput.disabled).toBe(true);
     });
   });
 
   it("ueberschreibt E-Mail bei Reaktivierung standardmaessig nicht", async () => {
-    mockedGetParticipants.mockResolvedValueOnce([]);
+    mockedGetParticipants.mockResolvedValue([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: undefined,
+        email: "alice@example.com",
+        status: "active",
+      },
+    ]);
     mockedInviteUser.mockResolvedValueOnce({
       success: true,
       emailSent: true,
@@ -356,11 +378,15 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
       target: { value: "alice" },
     });
-    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
-      target: { value: "alice.new@example.com" },
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
+    await waitFor(() => {
+      expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).value).toBe(
+        "alice@example.com",
+      );
+      expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).disabled).toBe(true);
     });
 
-    fireEvent.click(within(dialog).getByRole("button", { name: /^Anlegen$/i }));
+    fireEvent.click(within(dialog).getByRole("button", { name: /^(Reaktivieren|Anlegen)$/i }));
 
     await waitFor(() => {
       expect(mockedInviteUser).toHaveBeenCalledWith({ nickname: "alice", role: "participant" });
@@ -376,9 +402,9 @@ describe("AdminPanel", () => {
       {
         tenantId: "default-tenant",
         userId: "alice",
-        role: "participant",
+        role: undefined,
         email: "alice@example.com",
-        status: "invited",
+        status: "active",
       },
     ]);
     mockedInviteUser.mockResolvedValueOnce({
@@ -390,9 +416,9 @@ describe("AdminPanel", () => {
     mockedUpdateParticipant.mockResolvedValueOnce({
       tenantId: "default-tenant",
       userId: "alice",
-      role: "participant",
+      role: undefined,
       email: "alice.new@example.com",
-      status: "invited",
+      status: "active",
     });
 
     const { container } = render(<AdminPanel canEditRoles />);
@@ -408,9 +434,7 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
       target: { value: "alice" },
     });
-    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
-      target: { value: "alice.new@example.com" },
-    });
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
     await waitFor(() => {
       expect(
         within(dialog).getByText(/Reaktivierung erkannt fuer bestehenden Teilnehmer: alice/i),
@@ -418,10 +442,30 @@ describe("AdminPanel", () => {
     });
     fireEvent.click(
       within(dialog).getByRole("checkbox", {
-        name: /Eingegebene E-Mail fuer Reaktivierung uebernehmen/i,
+        name: /E-Mail fuer Reaktivierung bearbeiten/i,
       }),
     );
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice.new@example.com" },
+    });
     expect(within(dialog).getByText(/Mail geht an: alice\.new@example\.com/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      within(dialog).getByRole("checkbox", {
+        name: /E-Mail fuer Reaktivierung bearbeiten/i,
+      }),
+    );
+    expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).disabled).toBe(true);
+    expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).value).toBe("alice@example.com");
+
+    fireEvent.click(
+      within(dialog).getByRole("checkbox", {
+        name: /E-Mail fuer Reaktivierung bearbeiten/i,
+      }),
+    );
+    fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
+      target: { value: "alice.new@example.com" },
+    });
 
     fireEvent.click(within(dialog).getByRole("button", { name: /^(Reaktivieren|Anlegen)$/i }));
 
@@ -444,9 +488,9 @@ describe("AdminPanel", () => {
       {
         tenantId: "default-tenant",
         userId: "alice",
-        role: "participant",
+        role: undefined,
         email: "alice@example.com",
-        status: "invited",
+        status: "active",
       },
     ]);
 
@@ -463,6 +507,7 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
       target: { value: "alice" },
     });
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
 
     await waitFor(() => {
       expect(
@@ -475,7 +520,7 @@ describe("AdminPanel", () => {
     expect(emailInput.value).toBe("alice@example.com");
     expect(
       within(dialog).queryByRole("checkbox", {
-        name: /Eingegebene E-Mail fuer Reaktivierung uebernehmen/i,
+        name: /E-Mail fuer Reaktivierung bearbeiten/i,
       }),
     ).not.toBeInTheDocument();
   });
@@ -487,9 +532,9 @@ describe("AdminPanel", () => {
         {
           tenantId: "default-tenant",
           userId: "alice",
-          role: "participant",
+          role: undefined,
           email: "alice@example.com",
-          status: "invited",
+          status: "active",
         },
       ]);
 
@@ -519,15 +564,12 @@ describe("AdminPanel", () => {
       expect(
         within(dialog).getByText(/Reaktivierung erkannt fuer bestehenden Teilnehmer: alice/i),
       ).toBeInTheDocument();
-      expect(
-        within(dialog).getByText(/Spitzname existiert bereits \(case-insensitiv\)/i),
-      ).toBeInTheDocument();
       expect(within(dialog).getByRole("button", { name: /^Reaktivieren$/i })).toBeInTheDocument();
     });
   });
 
   it("blockt aktive Nicknames und bietet Vorschlag mit Suffix", async () => {
-    mockedGetParticipants.mockResolvedValueOnce([
+    mockedGetParticipants.mockResolvedValue([
       {
         tenantId: "default-tenant",
         userId: "Kai",
@@ -547,6 +589,7 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
       target: { value: "kai" },
     });
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
 
     await waitFor(() => {
       expect(
@@ -558,6 +601,44 @@ describe("AdminPanel", () => {
 
     fireEvent.click(within(dialog).getByRole("button", { name: /Uebernehmen/i }));
     expect((within(dialog).getByPlaceholderText("Spitzname") as HTMLInputElement).value).toBe("kai1");
+    expect(within(dialog).queryByText(/bereits aktiv/i)).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /^Anlegen$/i })).not.toBeDisabled();
+  });
+
+  it("erkennt eingeladenen Studio-Teilnehmer nicht als Reaktivierung", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "invited",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+    fireEvent.blur(within(dialog).getByPlaceholderText("Spitzname"));
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText(/Teilnehmer existiert bereits im Studio/i),
+      ).toBeInTheDocument();
+      expect(
+        within(dialog).queryByText(/Reaktivierung erkannt fuer bestehenden Teilnehmer/i),
+      ).not.toBeInTheDocument();
+      expect(
+        within(dialog).queryByRole("checkbox", { name: /E-Mail fuer Reaktivierung bearbeiten/i }),
+      ).not.toBeInTheDocument();
+      expect(within(dialog).getByRole("button", { name: /^Anlegen$/i })).toBeDisabled();
+    });
   });
 
   it("bearbeitet E-Mail eines Teilnehmers über den Stift", async () => {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -88,6 +88,9 @@ describe("AdminPanel", () => {
 
     fireEvent.click(within(panel).getByLabelText("Löschen alice"));
     const deleteDialog = within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i });
+    expect(
+      within(deleteDialog).getByText(/vollständig entfernt, ohne Info-Mail/i),
+    ).toBeInTheDocument();
     fireEvent.click(within(deleteDialog).getByRole("button", { name: /^Löschen$/i }));
 
     await waitFor(() => {
@@ -95,6 +98,34 @@ describe("AdminPanel", () => {
       expect(within(panel).getByText(/Profil-Cleanup/i)).toBeInTheDocument();
       expect(within(panel).getByText(/Info-Mail gesendet an alice@example.com/i)).toBeInTheDocument();
     });
+  });
+
+  it("zeigt im Löschdialog für registrierte Nutzer den Hinweis auf Info-Mail", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "active",
+        authUserId: "sub-123",
+        inviteCompletedAt: "2026-04-10T10:00:00.000Z",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByLabelText("Löschen alice"));
+    const deleteDialog = within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i });
+    expect(
+      within(deleteDialog).getByText(/Profil bleibt erhalten und es wird eine Info-Mail versendet/i),
+    ).toBeInTheDocument();
   });
 
   it("schließt den Anlegen-Dialog per Escape", async () => {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -577,6 +577,10 @@ describe("AdminPanel", () => {
       email: "alice@example.com",
       status: "invited",
     });
+    mockedInviteUser.mockResolvedValueOnce({
+      success: true,
+      emailSent: true,
+    });
 
     const { container } = render(<AdminPanel />);
     const panel = container.querySelector("div");
@@ -591,11 +595,68 @@ describe("AdminPanel", () => {
     fireEvent.change(within(dialog).getByPlaceholderText("E-Mail"), {
       target: { value: "alice@example.com" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern/i }));
+    fireEvent.click(within(dialog).getByRole("button", { name: /Speichern und Senden/i }));
 
     await waitFor(() => {
       expect(mockedUpdateParticipant).toHaveBeenCalledWith("alice", { email: "alice@example.com" });
+      expect(mockedInviteUser).toHaveBeenCalledWith({
+        email: "alice@example.com",
+        nickname: "alice",
+        role: "participant",
+      });
     });
+  });
+
+  it("Trainer kann Admins/Trainer nicht bearbeiten oder einladen", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "admin1",
+        role: "admin",
+        email: "admin@example.com",
+        status: "invited",
+      },
+      {
+        tenantId: "default-tenant",
+        userId: "trainer1",
+        role: "instructor",
+        email: "trainer@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("admin1")).toBeInTheDocument();
+      expect(within(panel).getByText("trainer1")).toBeInTheDocument();
+    });
+
+    expect(within(panel).getByLabelText("Bearbeiten admin1")).toBeDisabled();
+    expect(within(panel).getByLabelText("Bearbeiten trainer1")).toBeDisabled();
+    expect(within(panel).getByLabelText("Erneut einladen admin1")).toBeDisabled();
+    expect(within(panel).getByLabelText("Einladen trainer1")).toBeDisabled();
+  });
+
+  it("zeigt Rollenauswahl im Anlegen-Dialog nur für Admin", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([]);
+
+    const { container, rerender } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByLabelText("Neuer Teilnehmer"));
+    let dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    expect(within(dialog).queryByLabelText("Rolle")).not.toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /Abbrechen/i }));
+
+    rerender(<AdminPanel canEditRoles />);
+    fireEvent.click(within(panel).getByLabelText("Neuer Teilnehmer"));
+    dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    expect(within(dialog).getByLabelText("Rolle")).toBeInTheDocument();
   });
 
   it("erzwingt optional Passwort-Reset beim E-Mail-Wechsel", async () => {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -395,7 +395,7 @@ describe("AdminPanel", () => {
       status: "invited",
     });
 
-    const { container } = render(<AdminPanel />);
+    const { container } = render(<AdminPanel canEditRoles />);
     const panel = container.querySelector("div");
     if (!panel) throw new Error("Panel not found");
 
@@ -437,6 +437,47 @@ describe("AdminPanel", () => {
         within(panel).getByText(/Reaktivierung: Info-Mail gesendet an alice\.new@example\.com\./i),
       ).toBeInTheDocument();
     });
+  });
+
+  it("Kursleitung sieht Reaktivierungs-E-Mail nur read-only und ohne Checkbox", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "invited",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    fireEvent.change(within(dialog).getByPlaceholderText("Spitzname"), {
+      target: { value: "alice" },
+    });
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText(/Reaktivierung erkannt fuer bestehenden Teilnehmer: alice/i),
+      ).toBeInTheDocument();
+    });
+
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+    expect(emailInput).toBeDisabled();
+    expect(emailInput.value).toBe("alice@example.com");
+    expect(
+      within(dialog).queryByRole("checkbox", {
+        name: /Eingegebene E-Mail fuer Reaktivierung uebernehmen/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("uebernimmt E-Mail in Create-Form anhand des Nicknames", async () => {

--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -97,6 +97,105 @@ describe("AdminPanel", () => {
     });
   });
 
+  it("schließt den Anlegen-Dialog per Escape", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([]);
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(within(panel).queryByRole("dialog", { name: /Teilnehmer anlegen/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("schließt den Bearbeiten-Dialog per Escape", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+    fireEvent.click(within(panel).getByLabelText("Bearbeiten alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i });
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(within(panel).queryByRole("dialog", { name: /Teilnehmer E-Mail bearbeiten/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("schließt den Lösch-Dialog nicht per Escape während Löschen läuft", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+    let resolveDelete!: (value: {
+      success: boolean;
+      membershipDeleted: boolean;
+      profileDeleted: boolean;
+      notificationEmail: string;
+      notificationEmailSent: boolean;
+    }) => void;
+    const pendingDelete = new Promise<{
+      success: boolean;
+      membershipDeleted: boolean;
+      profileDeleted: boolean;
+      notificationEmail: string;
+      notificationEmailSent: boolean;
+    }>((resolve) => {
+      resolveDelete = resolve;
+    });
+    mockedDeleteParticipant.mockImplementationOnce(() => pendingDelete);
+
+    const { container } = render(<AdminPanel canEditRoles />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+    fireEvent.click(within(panel).getByLabelText("Löschen alice"));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Löschen$/i }));
+
+    await waitFor(() => {
+      expect(within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i })).toBeInTheDocument();
+    });
+    fireEvent.keyDown(within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i }), { key: "Escape" });
+    expect(within(panel).getByRole("dialog", { name: /Teilnehmer löschen/i })).toBeInTheDocument();
+
+    resolveDelete({
+      success: true,
+      membershipDeleted: true,
+      profileDeleted: true,
+      notificationEmail: "alice@example.com",
+      notificationEmailSent: true,
+    });
+    await waitFor(() => {
+      expect(within(panel).queryByRole("dialog", { name: /Teilnehmer löschen/i })).not.toBeInTheDocument();
+    });
+  });
+
   it("sendet Einladung aus der Teilnehmerliste", async () => {
     mockedGetParticipants
       .mockResolvedValueOnce([
@@ -602,7 +701,31 @@ describe("AdminPanel", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /Uebernehmen/i }));
     expect((within(dialog).getByPlaceholderText("Spitzname") as HTMLInputElement).value).toBe("kai1");
     expect(within(dialog).queryByText(/bereits aktiv/i)).not.toBeInTheDocument();
-    expect(within(dialog).getByRole("button", { name: /^Anlegen$/i })).not.toBeDisabled();
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: /^Anlegen$/i })).not.toBeDisabled();
+      expect((within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement).disabled).toBe(false);
+    });
+  });
+
+  it("fokussiert E-Mail direkt bei Tab nach neuer Nickname-Prüfung", async () => {
+    mockedGetParticipants.mockResolvedValue([]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector("div");
+    if (!panel) throw new Error("Panel not found");
+
+    fireEvent.click(within(panel).getByRole("button", { name: "Neuer Teilnehmer" }));
+    const dialog = within(panel).getByRole("dialog", { name: /Teilnehmer anlegen/i });
+    const nicknameInput = within(dialog).getByPlaceholderText("Spitzname") as HTMLInputElement;
+    const emailInput = within(dialog).getByPlaceholderText("E-Mail") as HTMLInputElement;
+
+    fireEvent.change(nicknameInput, { target: { value: "mira" } });
+    nicknameInput.focus();
+    fireEvent.keyDown(nicknameInput, { key: "Tab" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(emailInput);
+    });
   });
 
   it("erkennt eingeladenen Studio-Teilnehmer nicht als Reaktivierung", async () => {

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -474,6 +474,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const createEmailEditable =
     createNicknameCheckState === "new" ||
     (createCanUnlockReactivationEmail && createOverwriteEmailOnReactivate);
+  const deleteTargetHasLoginHistory = !!(
+    deleteTarget &&
+    (deleteTarget.authUserId || deleteTarget.inviteCompletedAt || deleteTarget.status === "active")
+  );
   const resetCreateNicknameResolution = () => {
     setCreateNicknameCheckState("idle");
     setCreateMatchedParticipant(null);
@@ -1462,8 +1466,9 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               Teilnehmer <strong>{deleteTarget.userId}</strong> aus diesem Studio entfernen?
             </p>
             <p style={{ marginTop: 0, color: "#6b7280", fontSize: 14 }}>
-              Mit Login bleibt das globale Profil erhalten. Ohne Login kann zusätzlich das Profil
-              gelöscht werden, falls keine weitere Studio-Zuordnung existiert.
+              {deleteTargetHasLoginHistory
+                ? "Dieser Zugang wird nur aus diesem Studio entfernt. Das Profil bleibt erhalten und es wird eine Info-Mail versendet."
+                : "Dieser Nutzer hat sich noch nicht registriert. Der Eintrag wird (falls keine weitere Studio-Zuordnung existiert) vollständig entfernt, ohne Info-Mail."}
             </p>
             <div className="modal-actions">
               <button

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -70,11 +70,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [createError, setCreateError] = useState("");
   const [createEmailAutoFilled, setCreateEmailAutoFilled] = useState(false);
   const [createOverwriteEmailOnReactivate, setCreateOverwriteEmailOnReactivate] = useState(false);
+  const [createReactivationCheckboxFocused, setCreateReactivationCheckboxFocused] = useState(false);
   const [createReactivationUserId, setCreateReactivationUserId] = useState<string | null>(null);
   const [createNicknameCheckState, setCreateNicknameCheckState] =
     useState<CreateNicknameCheckState>("idle");
   const [createMatchedParticipant, setCreateMatchedParticipant] =
     useState<ParticipantWithStatus | null>(null);
+  const [createLastResolvedNickname, setCreateLastResolvedNickname] = useState<string | null>(null);
 
   const [inviteSendingByUserId, setInviteSendingByUserId] = useState<Record<string, boolean>>(
     {},
@@ -94,6 +96,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const createEmailInputRef = useRef<HTMLInputElement | null>(null);
   const createRoleSelectRef = useRef<HTMLSelectElement | null>(null);
   const createCancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const createReactivationCheckboxRef = useRef<HTMLInputElement | null>(null);
 
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
@@ -186,6 +189,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       setCreateOverwriteEmailOnReactivate(false);
       setCreateMatchedParticipant(null);
       setCreateNicknameCheckState("idle");
+      setCreateLastResolvedNickname(null);
       return { state: "idle" as const, match: null as ParticipantWithStatus | null };
     }
     if (normalized.length < 3) {
@@ -193,7 +197,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       setCreateOverwriteEmailOnReactivate(false);
       setCreateMatchedParticipant(null);
       setCreateNicknameCheckState("too_short");
+      setCreateLastResolvedNickname(null);
       return { state: "too_short" as const, match: null as ParticipantWithStatus | null };
+    }
+    if (normalized === createLastResolvedNickname && createNicknameCheckState !== "idle") {
+      return {
+        state: createNicknameCheckState,
+        match: createMatchedParticipant,
+      } as const;
     }
 
     const applyMatch = (match: ParticipantWithStatus) => {
@@ -232,6 +243,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     const localMatch = getKnownParticipantByNickname(normalized);
     if (localMatch) {
       applyMatch(localMatch);
+      setCreateLastResolvedNickname(normalized);
       const hasTenantMembership = !!localMatch.role;
       if (hasTenantMembership && localMatch.status === "active") {
         return { state: "active_conflict" as const, match: localMatch };
@@ -249,6 +261,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       );
       if (remoteMatch) {
         applyMatch(remoteMatch);
+        setCreateLastResolvedNickname(normalized);
         const hasTenantMembership = !!remoteMatch.role;
         if (hasTenantMembership && remoteMatch.status === "active") {
           return { state: "active_conflict" as const, match: remoteMatch };
@@ -259,12 +272,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         return { state: "reactivation" as const, match: remoteMatch };
       }
       applyNew();
+      setCreateLastResolvedNickname(normalized);
       return { state: "new" as const, match: null as ParticipantWithStatus | null };
     } catch {
       applyNew();
+      setCreateLastResolvedNickname(normalized);
       return { state: "new" as const, match: null as ParticipantWithStatus | null };
     }
-  }, [getKnownParticipantByNickname]);
+  }, [createLastResolvedNickname, createMatchedParticipant, createNicknameCheckState, getKnownParticipantByNickname]);
   const canTrainerManageTarget = useCallback(
     (p: ParticipantWithStatus) => p.role === "participant",
     [],
@@ -483,8 +498,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setCreateMatchedParticipant(null);
     setCreateReactivationUserId(null);
     setCreateOverwriteEmailOnReactivate(false);
+    setCreateReactivationCheckboxFocused(false);
     setCreateEmail("");
     setCreateEmailAutoFilled(false);
+    setCreateLastResolvedNickname(null);
   };
 
   const openCreate = () => {
@@ -497,8 +514,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setCreateSaving(false);
     setCreateOverwriteEmailOnReactivate(false);
     setCreateReactivationUserId(null);
+    setCreateReactivationCheckboxFocused(false);
     setCreateNicknameCheckState("idle");
     setCreateMatchedParticipant(null);
+    setCreateLastResolvedNickname(null);
   };
   useEffect(() => {
     if (editingUserId) {
@@ -607,6 +626,19 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         setTimeout(() => focusEmailWhenEnabled(attempt + 1), 0);
       };
       focusEmailWhenEnabled();
+      return;
+    }
+    if (resolved.state === "reactivation" && canEditRoles) {
+      const focusCheckboxWhenAvailable = (attempt = 0) => {
+        const checkboxEl = createReactivationCheckboxRef.current;
+        if (checkboxEl) {
+          checkboxEl.focus();
+          return;
+        }
+        if (attempt >= 6) return;
+        setTimeout(() => focusCheckboxWhenAvailable(attempt + 1), 0);
+      };
+      focusCheckboxWhenAvailable();
       return;
     }
     const fallbackTarget = canEditRoles
@@ -1295,6 +1327,75 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 className="dialog-field"
               />
 
+              {createIsReactivation && (
+                <>
+                  <p style={{ margin: "0.25rem 0 0", color: "#92400e", fontSize: 12 }}>
+                    Reaktivierung erkannt fuer bestehenden Teilnehmer: {createReactivationUserId ?? "-"}
+                  </p>
+                  {createCanUnlockReactivationEmail ? (
+                    <>
+                      <label
+                        style={{
+                          display: "flex",
+                          gap: 8,
+                          alignItems: "center",
+                          borderRadius: 6,
+                          padding: "2px 4px",
+                          outline: createReactivationCheckboxFocused ? "2px solid #2563eb" : "none",
+                          outlineOffset: 2,
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          ref={createReactivationCheckboxRef}
+                          checked={createOverwriteEmailOnReactivate}
+                          onChange={(e) => {
+                            const nextChecked = e.target.checked;
+                            setCreateOverwriteEmailOnReactivate(nextChecked);
+                            if (!nextChecked) {
+                              const fallbackEmail = createMatchedParticipant?.email ?? "";
+                              setCreateEmail(fallbackEmail);
+                              setCreateEmailAutoFilled(!!fallbackEmail);
+                            }
+                          }}
+                          onFocus={() => setCreateReactivationCheckboxFocused(true)}
+                          onBlur={() => setCreateReactivationCheckboxFocused(false)}
+                          disabled={createSaving}
+                          style={{ accentColor: "#2563eb" }}
+                        />
+                        E-Mail fuer Reaktivierung bearbeiten
+                        <strong style={{ color: createOverwriteEmailOnReactivate ? "#166534" : "#6b7280" }}>
+                          {createOverwriteEmailOnReactivate ? "(aktiv)" : "(inaktiv)"}
+                        </strong>
+                      </label>
+                      <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                        {createOverwriteEmailOnReactivate
+                          ? "Bearbeitung aktiv: E-Mail-Feld ist freigegeben."
+                          : "Bearbeitung inaktiv: E-Mail-Feld bleibt gesperrt."}
+                      </p>
+                      <p
+                        role="status"
+                        aria-live="polite"
+                        style={{ margin: 0, fontSize: 11, color: "#6b7280" }}
+                      >
+                        {createOverwriteEmailOnReactivate
+                          ? "Status: E-Mail-Bearbeitung aktiviert."
+                          : "Status: E-Mail-Bearbeitung deaktiviert."}
+                      </p>
+                    </>
+                  ) : (
+                    <p style={{ margin: "0.15rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                      Bei Reaktivierung bleibt die bestehende E-Mail unverändert.
+                    </p>
+                  )}
+                  <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                    {createOverwriteEmailOnReactivate && createEmail.trim()
+                      ? `Mail geht an: ${createEmail.trim()}`
+                      : "Mail geht an: bestehende Profil-E-Mail"}
+                  </p>
+                </>
+              )}
+
               <input
                 type="email"
                 aria-label="E-Mail"
@@ -1323,41 +1424,6 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 <p style={{ margin: "0.25rem 0 0", color: "#4b5563", fontSize: 12 }}>
                   E-Mail aus bestehendem Profil uebernommen.
                 </p>
-              )}
-              {createIsReactivation && (
-                <>
-                  <p style={{ margin: "0.25rem 0 0", color: "#92400e", fontSize: 12 }}>
-                    Reaktivierung erkannt fuer bestehenden Teilnehmer: {createReactivationUserId ?? "-"}
-                  </p>
-                  {createCanUnlockReactivationEmail ? (
-                    <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                      <input
-                        type="checkbox"
-                        checked={createOverwriteEmailOnReactivate}
-                        onChange={(e) => {
-                          const nextChecked = e.target.checked;
-                          setCreateOverwriteEmailOnReactivate(nextChecked);
-                          if (!nextChecked) {
-                            const fallbackEmail = createMatchedParticipant?.email ?? "";
-                            setCreateEmail(fallbackEmail);
-                            setCreateEmailAutoFilled(!!fallbackEmail);
-                          }
-                        }}
-                        disabled={createSaving}
-                      />
-                      E-Mail fuer Reaktivierung bearbeiten
-                    </label>
-                  ) : (
-                    <p style={{ margin: "0.15rem 0 0", color: "#4b5563", fontSize: 12 }}>
-                      Bei Reaktivierung bleibt die bestehende E-Mail unverändert.
-                    </p>
-                  )}
-                  <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
-                    {createOverwriteEmailOnReactivate && createEmail.trim()
-                      ? `Mail geht an: ${createEmail.trim()}`
-                      : "Mail geht an: bestehende Profil-E-Mail"}
-                  </p>
-                </>
               )}
               {createActiveConflict && (
                 <div style={{ margin: "0.25rem 0 0", color: "#991b1b", fontSize: 12 }}>

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Mail, Pencil, Plus, Trash2 } from "lucide-react";
 import {
   deleteParticipant,
@@ -204,10 +204,20 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       setCreateEmailAutoFilled(false);
     }
   };
-  const isInviteEligible = (p: ParticipantWithStatus) => !!p.email && p.status !== "active";
+  const canTrainerManageTarget = useCallback(
+    (p: ParticipantWithStatus) => p.role === "participant",
+    [],
+  );
+  const isInviteEligible = useCallback(
+    (p: ParticipantWithStatus) =>
+      !!p.email &&
+      p.status !== "active" &&
+      (canEditRoles || canTrainerManageTarget(p)),
+    [canEditRoles, canTrainerManageTarget],
+  );
   const inviteEligibleUserIds = useMemo(
     () => safeParticipants.filter(isInviteEligible).map((p) => p.userId),
-    [safeParticipants],
+    [safeParticipants, isInviteEligible],
   );
   const selectedEligibleUserIds = inviteEligibleUserIds.filter((id) => !!selectedInviteUserIds[id]);
   const allEligibleSelected =
@@ -238,7 +248,13 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setEditingSaving(false);
   };
   const canEditEmailForParticipant = (p: ParticipantWithStatus): boolean =>
-    canEditRoles || (p.status !== "active" && !p.authUserId);
+    canEditRoles ||
+    (
+      canTrainerManageTarget(p) &&
+      p.status !== "active" &&
+      !p.authUserId &&
+      !p.inviteCompletedAt
+    );
 
   const saveEditEmail = async () => {
     if (!editingUserId) return;
@@ -293,12 +309,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
 
       setEditingUserId(null);
       const roleChanged = canEditRoles && original?.role !== editingRole;
+      const wasInvited = original?.status === "invited";
       if (shouldForcePasswordReset) {
         setBulkInviteResult("Änderungen gespeichert. Passwort-Reset wird gesendet.");
       } else if (emailChanged && original?.status === "active") {
         setBulkInviteResult(
           "E-Mail aktualisiert. Info-Mail wurde an die neue Adresse gesendet.",
         );
+      } else if (wasInvited) {
+        setBulkInviteResult("Änderungen gespeichert. Einladung wird erneut gesendet.");
       } else if (roleChanged && original?.status === "active") {
         setBulkInviteResult("Rolle aktualisiert. Nutzer wurde über die Änderung informiert.");
       } else if (roleChanged) {
@@ -327,6 +346,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           }
         }
       }
+      if (wasInvited && nextEmailText.length > 0) {
+        const effectiveParticipant: ParticipantWithStatus = {
+          ...original,
+          email: nextEmailText,
+          role: canEditRoles ? editingRole : original.role,
+          status: "invited",
+        };
+        await sendInviteForParticipant(effectiveParticipant, { refreshAfter: false });
+      }
     } catch (err) {
       console.error("Failed to update participant email", err);
       setEditingError("E-Mail konnte nicht gespeichert werden.");
@@ -343,6 +371,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const editingEmailChanged = editingEmailTrimmed.toLowerCase() !== editingOriginalEmail.toLowerCase();
   const editingRoleChanged = !!(canEditRoles && editingOriginal && editingOriginal.role !== editingRole);
   const editingCanSendReset = !!(canEditRoles && editingOriginal?.status === "active");
+  const editingSendsInvite = editingOriginal?.status === "invited";
   const editingHasChanges =
     editingEmailChanged || editingRoleChanged || (editingCanSendReset && editingForcePasswordResetOnEmailChange);
 
@@ -392,7 +421,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
 
       // #67: Teilnehmer anlegen ohne Einladung (kein Cognito/SES).
       // Wir legen zunächst ohne E-Mail an, speichern E-Mail (falls vorhanden) danach separat im Profil.
-      const result = await inviteUser({ nickname: nicknameValue, role: createRole });
+      const result = await inviteUser({
+        nickname: nicknameValue,
+        role: canEditRoles ? createRole : "participant",
+      });
       if (result.error === "Nickname already exists") {
         setCreateError("Dieser Spitzname ist bereits vergeben.");
         return;
@@ -452,6 +484,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     options?: { refreshAfter?: boolean },
   ) => {
     if (!p.email) return;
+    if (!canEditRoles && !canTrainerManageTarget(p)) return;
     if (p.status === "active" && !canEditRoles) return;
 
     const refreshAfter = options?.refreshAfter ?? true;
@@ -796,39 +829,36 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       justifySelf: "end",
                     }}
                   >
-                    {!(p.status === "active" && canEditRoles) && (
-                      <button
-                        type="button"
-                        title={
-                          !p.email
-                            ? "E-Mail fehlt"
-                            : p.status === "active" && !canEditRoles
-                              ? "Bereits registriert"
-                              : p.status === "invited"
-                                ? "Einladung erneut senden"
-                                : "Einladung senden"
-                        }
-                        aria-label={
-                          p.status === "invited"
-                            ? `Erneut einladen ${p.userId}`
-                            : `Einladen ${p.userId}`
-                        }
-                        disabled={
-                          !p.email ||
-                          (p.status === "active" && !canEditRoles) ||
-                          !!inviteSendingByUserId[p.userId] ||
-                          participantsLoading ||
-                          editingSaving ||
-                          createSaving
-                        }
-                        onClick={() => sendInviteForParticipant(p)}
-                      >
-                        <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                          <Mail size={14} aria-hidden="true" />
-                          {inviteSendingByUserId[p.userId] ? "..." : null}
-                        </span>
-                      </button>
-                    )}
+                    <button
+                      type="button"
+                      title={
+                        !p.email
+                          ? "E-Mail fehlt"
+                          : !isInviteEligible(p)
+                            ? "Einladen nicht möglich"
+                            : p.status === "invited"
+                              ? "Einladung erneut senden"
+                              : "Einladung senden"
+                      }
+                      aria-label={
+                        p.status === "invited"
+                          ? `Erneut einladen ${p.userId}`
+                          : `Einladen ${p.userId}`
+                      }
+                      disabled={
+                        !isInviteEligible(p) ||
+                        !!inviteSendingByUserId[p.userId] ||
+                        participantsLoading ||
+                        editingSaving ||
+                        createSaving
+                      }
+                      onClick={() => sendInviteForParticipant(p)}
+                    >
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                        <Mail size={14} aria-hidden="true" />
+                        {inviteSendingByUserId[p.userId] ? "..." : null}
+                      </span>
+                    </button>
                     <button
                       type="button"
                       title={
@@ -943,7 +973,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               >
                 {editingSaving
                   ? "Speichere..."
-                  : canEditRoles && editingOriginal?.status === "active"
+                  : editingSendsInvite || (canEditRoles && editingOriginal?.status === "active")
                     ? "Speichern und Senden"
                     : "Speichern"}
               </button>
@@ -1051,21 +1081,23 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 </div>
               )}
 
-              <select
-                aria-label="Rolle"
-                value={createRole}
-                onChange={(e) =>
-                  setCreateRole(e.target.value as "participant" | "instructor" | "admin")
-                }
-                disabled={createSaving}
-                className="dialog-field"
-              >
-                {ROLE_OPTIONS.map((role) => (
-                  <option key={role} value={role}>
-                    {ROLE_LABELS_DE[role]}
-                  </option>
-                ))}
-              </select>
+              {canEditRoles && (
+                <select
+                  aria-label="Rolle"
+                  value={createRole}
+                  onChange={(e) =>
+                    setCreateRole(e.target.value as "participant" | "instructor" | "admin")
+                  }
+                  disabled={createSaving}
+                  className="dialog-field"
+                >
+                  {ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {ROLE_LABELS_DE[role]}
+                    </option>
+                  ))}
+                </select>
+              )}
 
               {createError && <p style={{ color: "crimson", margin: 0 }}>{createError}</p>}
             </div>

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Mail, Pencil, Plus, Trash2 } from "lucide-react";
 import {
   deleteParticipant,
@@ -38,6 +38,13 @@ function getStatusPresentation(status: ParticipantWithStatus["status"]): {
 type AdminPanelProps = {
   canEditRoles?: boolean;
 };
+type CreateNicknameCheckState =
+  | "idle"
+  | "too_short"
+  | "new"
+  | "reactivation"
+  | "active_conflict"
+  | "exists_in_tenant";
 
 export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [participants, setParticipants] = useState<ParticipantWithStatus[]>([]);
@@ -64,6 +71,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [createEmailAutoFilled, setCreateEmailAutoFilled] = useState(false);
   const [createOverwriteEmailOnReactivate, setCreateOverwriteEmailOnReactivate] = useState(false);
   const [createReactivationUserId, setCreateReactivationUserId] = useState<string | null>(null);
+  const [createNicknameCheckState, setCreateNicknameCheckState] =
+    useState<CreateNicknameCheckState>("idle");
+  const [createMatchedParticipant, setCreateMatchedParticipant] =
+    useState<ParticipantWithStatus | null>(null);
 
   const [inviteSendingByUserId, setInviteSendingByUserId] = useState<Record<string, boolean>>(
     {},
@@ -76,6 +87,9 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const [bulkInviteResult, setBulkInviteResult] = useState("");
   const [deleteRunningByUserId, setDeleteRunningByUserId] = useState<Record<string, boolean>>({});
   const [deleteTarget, setDeleteTarget] = useState<ParticipantWithStatus | null>(null);
+  const editingModalRef = useRef<HTMLDivElement | null>(null);
+  const createModalRef = useRef<HTMLDivElement | null>(null);
+  const deleteModalRef = useRef<HTMLDivElement | null>(null);
 
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
@@ -139,21 +153,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     () => (Array.isArray(participants) ? participants : []),
     [participants],
   );
-  const getKnownEmailByNickname = (nicknameValue: string): string => {
-    const normalized = nicknameValue.trim().toLowerCase();
-    if (!normalized) return "";
-    const match = safeParticipants.find(
-      (p) => (p.userId || "").trim().toLowerCase() === normalized && !!p.email,
-    );
-    return match?.email ?? "";
-  };
-  const getKnownParticipantByNickname = (nicknameValue: string): ParticipantWithStatus | undefined => {
-    const normalized = nicknameValue.trim().toLowerCase();
-    if (!normalized) return undefined;
-    return safeParticipants.find((p) => (p.userId || "").trim().toLowerCase() === normalized);
-  };
-  const createMatch = getKnownParticipantByNickname(createNickname);
-  const createActiveConflict = !!createMatch && createMatch.status === "active";
+  const getKnownParticipantByNickname = useCallback(
+    (nicknameValue: string): ParticipantWithStatus | undefined => {
+      const normalized = nicknameValue.trim().toLowerCase();
+      if (!normalized) return undefined;
+      return safeParticipants.find((p) => (p.userId || "").trim().toLowerCase() === normalized);
+    },
+    [safeParticipants],
+  );
+  const createActiveConflict = createNicknameCheckState === "active_conflict";
   const createSuggestedNickname = useMemo(() => {
     if (!createActiveConflict) return "";
     const base = createNickname.trim();
@@ -167,21 +175,67 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     }
     return candidate;
   }, [createActiveConflict, createNickname, safeParticipants]);
-  const prefillCreateEmailByNickname = async (nicknameValue: string) => {
-    if (createEmail.trim()) return;
+  const resolveCreateNicknameContext = useCallback(async (nicknameValue: string) => {
     const normalized = nicknameValue.trim().toLowerCase();
     if (!normalized) {
       setCreateReactivationUserId(null);
-      return;
+      setCreateOverwriteEmailOnReactivate(false);
+      setCreateMatchedParticipant(null);
+      setCreateNicknameCheckState("idle");
+      return { state: "idle" as const, match: null as ParticipantWithStatus | null };
+    }
+    if (normalized.length < 3) {
+      setCreateReactivationUserId(null);
+      setCreateOverwriteEmailOnReactivate(false);
+      setCreateMatchedParticipant(null);
+      setCreateNicknameCheckState("too_short");
+      return { state: "too_short" as const, match: null as ParticipantWithStatus | null };
     }
 
+    const applyMatch = (match: ParticipantWithStatus) => {
+      setCreateMatchedParticipant(match);
+      const hasTenantMembership = !!match.role;
+      if (hasTenantMembership && match.status === "active") {
+        setCreateNicknameCheckState("active_conflict");
+        setCreateReactivationUserId(null);
+        setCreateOverwriteEmailOnReactivate(false);
+        setCreateEmail("");
+        setCreateEmailAutoFilled(false);
+        return;
+      }
+      if (hasTenantMembership) {
+        setCreateNicknameCheckState("exists_in_tenant");
+        setCreateReactivationUserId(null);
+        setCreateOverwriteEmailOnReactivate(false);
+        setCreateEmail(match.email ?? "");
+        setCreateEmailAutoFilled(!!match.email);
+        return;
+      }
+      setCreateNicknameCheckState("reactivation");
+      setCreateReactivationUserId(match.userId);
+      setCreateOverwriteEmailOnReactivate(false);
+      setCreateEmail(match.email ?? "");
+      setCreateEmailAutoFilled(!!match.email);
+    };
+    const applyNew = () => {
+      setCreateNicknameCheckState("new");
+      setCreateMatchedParticipant(null);
+      setCreateReactivationUserId(null);
+      setCreateOverwriteEmailOnReactivate(false);
+      setCreateEmailAutoFilled(false);
+    };
+
     const localMatch = getKnownParticipantByNickname(normalized);
-    setCreateReactivationUserId(localMatch && localMatch.status !== "active" ? localMatch.userId : null);
-    const localEmail = localMatch?.email ?? "";
-    if (localEmail) {
-      setCreateEmail(localEmail);
-      setCreateEmailAutoFilled(true);
-      return;
+    if (localMatch) {
+      applyMatch(localMatch);
+      const hasTenantMembership = !!localMatch.role;
+      if (hasTenantMembership && localMatch.status === "active") {
+        return { state: "active_conflict" as const, match: localMatch };
+      }
+      if (hasTenantMembership) {
+        return { state: "exists_in_tenant" as const, match: localMatch };
+      }
+      return { state: "reactivation" as const, match: localMatch };
     }
 
     try {
@@ -189,29 +243,50 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       const remoteMatch = remoteList.find(
         (p) => (p.userId || "").trim().toLowerCase() === normalized,
       );
-      setCreateReactivationUserId(
-        remoteMatch && (!remoteMatch.role || remoteMatch.status !== "active")
-          ? remoteMatch.userId
-          : null,
-      );
-      if (!canEditRoles && remoteMatch && remoteMatch.status !== "active") {
-        setCreateEmail(remoteMatch.email ?? "");
-        setCreateEmailAutoFilled(!!remoteMatch.email);
-        return;
+      if (remoteMatch) {
+        applyMatch(remoteMatch);
+        const hasTenantMembership = !!remoteMatch.role;
+        if (hasTenantMembership && remoteMatch.status === "active") {
+          return { state: "active_conflict" as const, match: remoteMatch };
+        }
+        if (hasTenantMembership) {
+          return { state: "exists_in_tenant" as const, match: remoteMatch };
+        }
+        return { state: "reactivation" as const, match: remoteMatch };
       }
-      if (remoteMatch?.email) {
-        setCreateEmail((prev) => (prev.trim() ? prev : remoteMatch.email ?? ""));
-        setCreateEmailAutoFilled(true);
-      } else {
-        setCreateEmailAutoFilled(false);
-      }
+      applyNew();
+      return { state: "new" as const, match: null as ParticipantWithStatus | null };
     } catch {
-      setCreateEmailAutoFilled(false);
+      applyNew();
+      return { state: "new" as const, match: null as ParticipantWithStatus | null };
     }
-  };
+  }, [getKnownParticipantByNickname]);
   const canTrainerManageTarget = useCallback(
     (p: ParticipantWithStatus) => p.role === "participant",
     [],
+  );
+  const getFocusableElements = useCallback(
+    (container: HTMLElement): HTMLElement[] =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+        ),
+      ),
+    [],
+  );
+  const focusFirstInModal = useCallback(
+    (modalEl: HTMLDivElement | null) => {
+      if (!modalEl) return;
+      const focusable = getFocusableElements(modalEl);
+      const preferredInput =
+        focusable.find((el) => el.tagName === "INPUT" || el.tagName === "SELECT") ?? focusable[0];
+      if (preferredInput) {
+        preferredInput.focus();
+        return;
+      }
+      modalEl.focus();
+    },
+    [getFocusableElements],
   );
   const isInviteEligible = useCallback(
     (p: ParticipantWithStatus) =>
@@ -379,7 +454,19 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const editingSendsInvite = editingOriginal?.status === "invited";
   const editingHasChanges =
     editingEmailChanged || editingRoleChanged || (editingCanSendReset && editingForcePasswordResetOnEmailChange);
-  const createIsTrainerReactivationReadonly = !canEditRoles && !!createReactivationUserId;
+  const createIsReactivation = createNicknameCheckState === "reactivation";
+  const createCanUnlockReactivationEmail = canEditRoles && createIsReactivation;
+  const createEmailEditable =
+    createNicknameCheckState === "new" ||
+    (createCanUnlockReactivationEmail && createOverwriteEmailOnReactivate);
+  const resetCreateNicknameResolution = () => {
+    setCreateNicknameCheckState("idle");
+    setCreateMatchedParticipant(null);
+    setCreateReactivationUserId(null);
+    setCreateOverwriteEmailOnReactivate(false);
+    setCreateEmail("");
+    setCreateEmailAutoFilled(false);
+  };
 
   const openCreate = () => {
     setCreateOpen(true);
@@ -391,27 +478,102 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setCreateSaving(false);
     setCreateOverwriteEmailOnReactivate(false);
     setCreateReactivationUserId(null);
+    setCreateNicknameCheckState("idle");
+    setCreateMatchedParticipant(null);
   };
+  useEffect(() => {
+    if (editingUserId) {
+      queueMicrotask(() => focusFirstInModal(editingModalRef.current));
+    }
+  }, [editingUserId, focusFirstInModal]);
+  useEffect(() => {
+    if (createOpen) {
+      queueMicrotask(() => focusFirstInModal(createModalRef.current));
+    }
+  }, [createOpen, focusFirstInModal]);
+  useEffect(() => {
+    if (deleteTarget) {
+      queueMicrotask(() => focusFirstInModal(deleteModalRef.current));
+    }
+  }, [deleteTarget, focusFirstInModal]);
+  useEffect(() => {
+    const anyModalOpen = !!editingUserId || createOpen || !!deleteTarget;
+    if (!anyModalOpen) return;
+
+    const onDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const activeModal =
+        (editingUserId && editingModalRef.current) ||
+        (createOpen && createModalRef.current) ||
+        (deleteTarget && deleteModalRef.current) ||
+        null;
+      if (!activeModal) return;
+
+      const focusable = getFocusableElements(activeModal);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        activeModal.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      const isInsideModal = !!active && activeModal.contains(active);
+
+      if (event.shiftKey) {
+        if (!isInsideModal || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (!isInsideModal || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onDocumentKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onDocumentKeyDown, true);
+    };
+  }, [editingUserId, createOpen, deleteTarget, getFocusableElements]);
 
   const saveCreate = async () => {
     const nicknameValue = createNickname.trim();
-    const emailValue = createEmail.trim();
     if (!nicknameValue) {
       setCreateError("Bitte einen Nickname eingeben.");
       return;
     }
-    const isValidEmailOrEmpty =
-      emailValue.length === 0 || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue);
-    if (!isValidEmailOrEmpty) {
-      setCreateError("Bitte eine gültige E-Mail-Adresse eingeben (oder leer lassen).");
+    if (nicknameValue.length < 3) {
+      setCreateNicknameCheckState("too_short");
+      setCreateError("Bitte mindestens 3 Zeichen für den Nickname eingeben.");
       return;
     }
-    if (createActiveConflict) {
+    const resolved = await resolveCreateNicknameContext(nicknameValue);
+    if (resolved.state === "active_conflict") {
       setCreateError(
         createSuggestedNickname
           ? `Dieser Spitzname ist im Tenant bereits aktiv. Vorschlag: ${createSuggestedNickname}`
           : "Dieser Spitzname ist im Tenant bereits aktiv.",
       );
+      return;
+    }
+    if (resolved.state === "exists_in_tenant") {
+      setCreateError("Dieser Teilnehmer existiert bereits im Studio. Bitte bearbeiten oder erneut einladen.");
+      return;
+    }
+
+    const isReactivationFlow = resolved.state === "reactivation";
+    const reactivationUserId = isReactivationFlow ? resolved.match?.userId ?? null : null;
+    const emailValue = (isReactivationFlow && !(canEditRoles && createOverwriteEmailOnReactivate))
+      ? (resolved.match?.email ?? "").trim()
+      : createEmail.trim();
+    const isValidEmailOrEmpty =
+      emailValue.length === 0 || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue);
+    if (!isValidEmailOrEmpty) {
+      setCreateError("Bitte eine gültige E-Mail-Adresse eingeben (oder leer lassen).");
       return;
     }
 
@@ -420,12 +582,12 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     try {
       const shouldPreUpdateEmailForReactivation =
         canEditRoles &&
-        !!createReactivationUserId &&
+        !!reactivationUserId &&
         createOverwriteEmailOnReactivate &&
         emailValue.length > 0;
 
       if (shouldPreUpdateEmailForReactivation) {
-        await updateParticipant(createReactivationUserId, { email: emailValue });
+        await updateParticipant(reactivationUserId, { email: emailValue });
       }
 
       // #67: Teilnehmer anlegen ohne Einladung (kein Cognito/SES).
@@ -451,7 +613,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         await updateParticipant(result.username ?? nicknameValue.toLowerCase(), { email: emailValue });
       } else if (emailValue.length > 0 && result.reactivated && (!canEditRoles || !createOverwriteEmailOnReactivate)) {
         setBulkInviteResult(
-          "Reaktivierung: bestehende E-Mail blieb unverändert (kein Überschreiben).",
+          "Reaktivierung: bestehende E-Mail bleibt unverändert.",
         );
       }
 
@@ -919,7 +1081,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       </div>
 
       {editingUserId && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Teilnehmer E-Mail bearbeiten">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Teilnehmer E-Mail bearbeiten"
+          ref={editingModalRef}
+          tabIndex={-1}
+        >
           <div className="modal modal-compact">
             <h4>Teilnehmer bearbeiten</h4>
             <p style={{ marginTop: 0, color: "#4b5563" }}>
@@ -992,7 +1161,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       )}
 
       {createOpen && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Teilnehmer anlegen">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Teilnehmer anlegen"
+          ref={createModalRef}
+          tabIndex={-1}
+        >
           <div className="modal modal-compact">
             <h4>Teilnehmer anlegen</h4>
 
@@ -1005,25 +1181,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 onChange={(e) => {
                   const nextNickname = e.target.value;
                   setCreateNickname(nextNickname);
-                  const localMatch = getKnownParticipantByNickname(nextNickname);
-                  setCreateReactivationUserId(
-                    localMatch && localMatch.status !== "active" ? localMatch.userId : null,
-                  );
-                  if (localMatch?.status === "active") {
-                    setCreateOverwriteEmailOnReactivate(false);
-                  }
-                  if (!canEditRoles && localMatch && localMatch.status !== "active") {
-                    setCreateEmail(localMatch.email ?? "");
-                    setCreateEmailAutoFilled(!!localMatch.email);
-                    return;
-                  }
-                  if (createEmail.trim()) return;
-                  const suggestedEmail = getKnownEmailByNickname(nextNickname);
-                  if (suggestedEmail) setCreateEmail(suggestedEmail);
-                  setCreateEmailAutoFilled(!!suggestedEmail);
+                  resetCreateNicknameResolution();
                 }}
                 onBlur={() => {
-                  void prefillCreateEmailByNickname(createNickname);
+                  void resolveCreateNicknameContext(createNickname);
                 }}
                 disabled={createSaving}
                 className="dialog-field"
@@ -1035,44 +1196,55 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 placeholder="E-Mail"
                 value={createEmail}
                 onChange={(e) => {
-                  if (createIsTrainerReactivationReadonly) return;
+                  if (!createEmailEditable) return;
                   setCreateEmail(e.target.value);
                   setCreateEmailAutoFilled(false);
                 }}
-                disabled={createSaving || createIsTrainerReactivationReadonly}
+                disabled={createSaving || !createEmailEditable}
                 className="dialog-field"
               />
+              {createNicknameCheckState === "too_short" && (
+                <p style={{ margin: "0.25rem 0 0", color: "#92400e", fontSize: 12 }}>
+                  Nickname-Prüfung startet ab 3 Zeichen.
+                </p>
+              )}
+              {createNicknameCheckState === "exists_in_tenant" && (
+                <p style={{ margin: "0.25rem 0 0", color: "#92400e", fontSize: 12 }}>
+                  Teilnehmer existiert bereits im Studio. Bitte bearbeiten oder erneut einladen.
+                </p>
+              )}
               {createEmailAutoFilled && (
                 <p style={{ margin: "0.25rem 0 0", color: "#4b5563", fontSize: 12 }}>
                   E-Mail aus bestehendem Profil uebernommen.
                 </p>
               )}
-              <p style={{ margin: "0.25rem 0 0", color: "#4b5563", fontSize: 12 }}>
-                Bei Reaktivierung bleibt die bestehende E-Mail standardmaessig unveraendert.
-              </p>
-              {createReactivationUserId && (
+              {createIsReactivation && (
                 <>
                   <p style={{ margin: "0.25rem 0 0", color: "#92400e", fontSize: 12 }}>
-                    Reaktivierung erkannt fuer bestehenden Teilnehmer: {createReactivationUserId}
+                    Reaktivierung erkannt fuer bestehenden Teilnehmer: {createReactivationUserId ?? "-"}
                   </p>
-                  <p style={{ margin: "0.15rem 0 0", color: "#92400e", fontSize: 12 }}>
-                    Spitzname existiert bereits (case-insensitiv). Es wird kein neuer User angelegt.
-                  </p>
-                  {!canEditRoles && (
-                    <p style={{ margin: "0.15rem 0 0", color: "#4b5563", fontSize: 12 }}>
-                      Die E-Mail bleibt bei Reaktivierung fuer Kursleitung unveraendert.
-                    </p>
-                  )}
-                  {canEditRoles && (
+                  {createCanUnlockReactivationEmail ? (
                     <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
                       <input
                         type="checkbox"
                         checked={createOverwriteEmailOnReactivate}
-                        onChange={(e) => setCreateOverwriteEmailOnReactivate(e.target.checked)}
+                        onChange={(e) => {
+                          const nextChecked = e.target.checked;
+                          setCreateOverwriteEmailOnReactivate(nextChecked);
+                          if (!nextChecked) {
+                            const fallbackEmail = createMatchedParticipant?.email ?? "";
+                            setCreateEmail(fallbackEmail);
+                            setCreateEmailAutoFilled(!!fallbackEmail);
+                          }
+                        }}
                         disabled={createSaving}
                       />
-                      Eingegebene E-Mail fuer Reaktivierung uebernehmen
+                      E-Mail fuer Reaktivierung bearbeiten
                     </label>
+                  ) : (
+                    <p style={{ margin: "0.15rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                      Bei Reaktivierung bleibt die bestehende E-Mail unverändert.
+                    </p>
                   )}
                   <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
                     {createOverwriteEmailOnReactivate && createEmail.trim()
@@ -1092,7 +1264,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       {" "}
                       <button
                         type="button"
-                        onClick={() => setCreateNickname(createSuggestedNickname)}
+                        onClick={() => {
+                          setCreateNickname(createSuggestedNickname);
+                          setCreateError("");
+                          resetCreateNicknameResolution();
+                        }}
                         disabled={createSaving}
                         style={{ marginLeft: 6 }}
                       >
@@ -1137,7 +1313,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 type="button"
                 className="btn-primary modal-action-btn"
                 onClick={saveCreate}
-                disabled={createSaving || createActiveConflict}
+                disabled={createSaving || createActiveConflict || createNicknameCheckState === "exists_in_tenant"}
               >
                 {createSaving
                   ? createReactivationUserId
@@ -1153,7 +1329,14 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       )}
 
       {deleteTarget && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Teilnehmer löschen">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Teilnehmer löschen"
+          ref={deleteModalRef}
+          tabIndex={-1}
+        >
           <div className="modal modal-compact">
             <h4>Teilnehmer löschen</h4>
             <p style={{ marginTop: 0, color: "#4b5563" }}>

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -90,6 +90,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const editingModalRef = useRef<HTMLDivElement | null>(null);
   const createModalRef = useRef<HTMLDivElement | null>(null);
   const deleteModalRef = useRef<HTMLDivElement | null>(null);
+  const createNicknameInputRef = useRef<HTMLInputElement | null>(null);
+  const createEmailInputRef = useRef<HTMLInputElement | null>(null);
+  const createRoleSelectRef = useRef<HTMLSelectElement | null>(null);
+  const createCancelButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const refreshParticipants = async () => {
     setParticipantsLoading(true);
@@ -288,6 +292,17 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     },
     [getFocusableElements],
   );
+  const shouldHandleModalEnter = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key !== "Enter") return false;
+    if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return false;
+    const target = event.target as HTMLElement | null;
+    if (!target) return false;
+    const tag = target.tagName;
+    if (tag === "TEXTAREA" || tag === "SELECT" || tag === "BUTTON" || tag === "A") return false;
+    if ((target as HTMLInputElement).type === "checkbox") return false;
+    return true;
+  };
+  const shouldHandleModalEscape = (event: React.KeyboardEvent<HTMLElement>) => event.key === "Escape";
   const isInviteEligible = useCallback(
     (p: ParticipantWithStatus) =>
       !!p.email &&
@@ -502,6 +517,17 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
 
     const onDocumentKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Tab") return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        target === createNicknameInputRef.current &&
+        !event.shiftKey &&
+        !createEmailEditable
+      ) {
+        // Let the nickname field handler run first so it can resolve
+        // the nickname and send focus to the proper next control.
+        return;
+      }
       const activeModal =
         (editingUserId && editingModalRef.current) ||
         (createOpen && createModalRef.current) ||
@@ -520,25 +546,70 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       const last = focusable[focusable.length - 1];
       const active = document.activeElement as HTMLElement | null;
       const isInsideModal = !!active && activeModal.contains(active);
+      const activeIndex = isInsideModal ? focusable.indexOf(active as HTMLElement) : -1;
 
-      if (event.shiftKey) {
-        if (!isInsideModal || active === first) {
-          event.preventDefault();
+      // Safari can jump to the browser chrome on Tab. We fully control
+      // focus movement while a modal is open to keep focus trapped.
+      event.preventDefault();
+
+      if (!isInsideModal || activeIndex < 0) {
+        if (event.shiftKey) {
           last.focus();
+        } else {
+          first.focus();
         }
         return;
       }
-      if (!isInsideModal || active === last) {
-        event.preventDefault();
-        first.focus();
+
+      if (event.shiftKey) {
+        const prevIndex = activeIndex <= 0 ? focusable.length - 1 : activeIndex - 1;
+        focusable[prevIndex].focus();
+        return;
       }
+      const nextIndex = activeIndex >= focusable.length - 1 ? 0 : activeIndex + 1;
+      focusable[nextIndex].focus();
     };
 
     document.addEventListener("keydown", onDocumentKeyDown, true);
     return () => {
       document.removeEventListener("keydown", onDocumentKeyDown, true);
     };
-  }, [editingUserId, createOpen, deleteTarget, getFocusableElements]);
+  }, [editingUserId, createOpen, deleteTarget, getFocusableElements, createEmailEditable]);
+  useEffect(() => {
+    if (!createOpen) return;
+    if (createNicknameCheckState !== "new") return;
+    if (document.activeElement !== createNicknameInputRef.current) return;
+    setTimeout(() => {
+      createEmailInputRef.current?.focus();
+    }, 0);
+  }, [createOpen, createNicknameCheckState]);
+  const handleCreateNicknameKeyDown = async (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Tab" || event.shiftKey) return;
+    if (createEmailEditable || createSaving) return;
+    const nicknameValue = createNickname.trim();
+    if (nicknameValue.length < 3) return;
+
+    event.preventDefault();
+    const resolved = await resolveCreateNicknameContext(nicknameValue);
+    if (resolved.state === "new") {
+      const focusEmailWhenEnabled = (attempt = 0) => {
+        const emailEl = createEmailInputRef.current;
+        if (!emailEl) return;
+        if (!emailEl.disabled) {
+          emailEl.focus();
+          return;
+        }
+        if (attempt >= 6) return;
+        setTimeout(() => focusEmailWhenEnabled(attempt + 1), 0);
+      };
+      focusEmailWhenEnabled();
+      return;
+    }
+    const fallbackTarget = canEditRoles
+      ? createRoleSelectRef.current ?? createCancelButtonRef.current
+      : createCancelButtonRef.current;
+    fallbackTarget?.focus();
+  };
 
   const saveCreate = async () => {
     const nicknameValue = createNickname.trim();
@@ -1088,6 +1159,18 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           aria-label="Teilnehmer E-Mail bearbeiten"
           ref={editingModalRef}
           tabIndex={-1}
+          onKeyDown={(event) => {
+            if (shouldHandleModalEscape(event)) {
+              if (editingSaving) return;
+              event.preventDefault();
+              setEditingUserId(null);
+              return;
+            }
+            if (!shouldHandleModalEnter(event)) return;
+            if (editingSaving || !editingHasChanges) return;
+            event.preventDefault();
+            void saveEditEmail();
+          }}
         >
           <div className="modal modal-compact">
             <h4>Teilnehmer bearbeiten</h4>
@@ -1168,6 +1251,20 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           aria-label="Teilnehmer anlegen"
           ref={createModalRef}
           tabIndex={-1}
+          onKeyDown={(event) => {
+            if (shouldHandleModalEscape(event)) {
+              if (createSaving) return;
+              event.preventDefault();
+              setCreateOpen(false);
+              return;
+            }
+            if (!shouldHandleModalEnter(event)) return;
+            if (createSaving || createActiveConflict || createNicknameCheckState === "exists_in_tenant") {
+              return;
+            }
+            event.preventDefault();
+            void saveCreate();
+          }}
         >
           <div className="modal modal-compact">
             <h4>Teilnehmer anlegen</h4>
@@ -1177,11 +1274,15 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 type="text"
                 aria-label="Spitzname"
                 placeholder="Spitzname"
+                ref={createNicknameInputRef}
                 value={createNickname}
                 onChange={(e) => {
                   const nextNickname = e.target.value;
                   setCreateNickname(nextNickname);
                   resetCreateNicknameResolution();
+                }}
+                onKeyDown={(event) => {
+                  void handleCreateNicknameKeyDown(event);
                 }}
                 onBlur={() => {
                   void resolveCreateNicknameContext(createNickname);
@@ -1194,6 +1295,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 type="email"
                 aria-label="E-Mail"
                 placeholder="E-Mail"
+                ref={createEmailInputRef}
                 value={createEmail}
                 onChange={(e) => {
                   if (!createEmailEditable) return;
@@ -1265,9 +1367,18 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                       <button
                         type="button"
                         onClick={() => {
-                          setCreateNickname(createSuggestedNickname);
+                          const nextNickname = createSuggestedNickname;
+                          setCreateNickname(nextNickname);
                           setCreateError("");
                           resetCreateNicknameResolution();
+                          setCreateNicknameCheckState("new");
+                          queueMicrotask(() => {
+                            void resolveCreateNicknameContext(nextNickname).then((resolved) => {
+                              if (resolved.state === "new") {
+                                createEmailInputRef.current?.focus();
+                              }
+                            });
+                          });
                         }}
                         disabled={createSaving}
                         style={{ marginLeft: 6 }}
@@ -1282,6 +1393,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               {canEditRoles && (
                 <select
                   aria-label="Rolle"
+                  ref={createRoleSelectRef}
                   value={createRole}
                   onChange={(e) =>
                     setCreateRole(e.target.value as "participant" | "instructor" | "admin")
@@ -1304,6 +1416,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
               <button
                 type="button"
                 className="modal-action-btn"
+                ref={createCancelButtonRef}
                 onClick={() => setCreateOpen(false)}
                 disabled={createSaving}
               >
@@ -1336,6 +1449,12 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           aria-label="Teilnehmer löschen"
           ref={deleteModalRef}
           tabIndex={-1}
+          onKeyDown={(event) => {
+            if (!shouldHandleModalEscape(event)) return;
+            if (deleteRunningByUserId[deleteTarget.userId]) return;
+            event.preventDefault();
+            setDeleteTarget(null);
+          }}
         >
           <div className="modal modal-compact">
             <h4>Teilnehmer löschen</h4>

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -194,6 +194,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
           ? remoteMatch.userId
           : null,
       );
+      if (!canEditRoles && remoteMatch && remoteMatch.status !== "active") {
+        setCreateEmail(remoteMatch.email ?? "");
+        setCreateEmailAutoFilled(!!remoteMatch.email);
+        return;
+      }
       if (remoteMatch?.email) {
         setCreateEmail((prev) => (prev.trim() ? prev : remoteMatch.email ?? ""));
         setCreateEmailAutoFilled(true);
@@ -374,6 +379,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   const editingSendsInvite = editingOriginal?.status === "invited";
   const editingHasChanges =
     editingEmailChanged || editingRoleChanged || (editingCanSendReset && editingForcePasswordResetOnEmailChange);
+  const createIsTrainerReactivationReadonly = !canEditRoles && !!createReactivationUserId;
 
   const openCreate = () => {
     setCreateOpen(true);
@@ -413,7 +419,10 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
     setCreateError("");
     try {
       const shouldPreUpdateEmailForReactivation =
-        !!createReactivationUserId && createOverwriteEmailOnReactivate && emailValue.length > 0;
+        canEditRoles &&
+        !!createReactivationUserId &&
+        createOverwriteEmailOnReactivate &&
+        emailValue.length > 0;
 
       if (shouldPreUpdateEmailForReactivation) {
         await updateParticipant(createReactivationUserId, { email: emailValue });
@@ -436,11 +445,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
 
       if (
         emailValue.length > 0 &&
-        (!result.reactivated || createOverwriteEmailOnReactivate) &&
+        (!result.reactivated || (canEditRoles && createOverwriteEmailOnReactivate)) &&
         !shouldPreUpdateEmailForReactivation
       ) {
         await updateParticipant(result.username ?? nicknameValue.toLowerCase(), { email: emailValue });
-      } else if (emailValue.length > 0 && result.reactivated && !createOverwriteEmailOnReactivate) {
+      } else if (emailValue.length > 0 && result.reactivated && (!canEditRoles || !createOverwriteEmailOnReactivate)) {
         setBulkInviteResult(
           "Reaktivierung: bestehende E-Mail blieb unverändert (kein Überschreiben).",
         );
@@ -449,7 +458,7 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
       const effectiveEmail = emailValue || createEmail;
       if (result.reactivated) {
         const reactivationNotificationTarget =
-          createOverwriteEmailOnReactivate && emailValue
+          canEditRoles && createOverwriteEmailOnReactivate && emailValue
             ? emailValue
             : "bestehende Profil-E-Mail";
         if (result.emailSent) {
@@ -1003,6 +1012,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   if (localMatch?.status === "active") {
                     setCreateOverwriteEmailOnReactivate(false);
                   }
+                  if (!canEditRoles && localMatch && localMatch.status !== "active") {
+                    setCreateEmail(localMatch.email ?? "");
+                    setCreateEmailAutoFilled(!!localMatch.email);
+                    return;
+                  }
                   if (createEmail.trim()) return;
                   const suggestedEmail = getKnownEmailByNickname(nextNickname);
                   if (suggestedEmail) setCreateEmail(suggestedEmail);
@@ -1021,10 +1035,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                 placeholder="E-Mail"
                 value={createEmail}
                 onChange={(e) => {
+                  if (createIsTrainerReactivationReadonly) return;
                   setCreateEmail(e.target.value);
                   setCreateEmailAutoFilled(false);
                 }}
-                disabled={createSaving}
+                disabled={createSaving || createIsTrainerReactivationReadonly}
                 className="dialog-field"
               />
               {createEmailAutoFilled && (
@@ -1043,15 +1058,22 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
                   <p style={{ margin: "0.15rem 0 0", color: "#92400e", fontSize: 12 }}>
                     Spitzname existiert bereits (case-insensitiv). Es wird kein neuer User angelegt.
                   </p>
-                  <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                    <input
-                      type="checkbox"
-                      checked={createOverwriteEmailOnReactivate}
-                      onChange={(e) => setCreateOverwriteEmailOnReactivate(e.target.checked)}
-                      disabled={createSaving}
-                    />
-                    Eingegebene E-Mail fuer Reaktivierung uebernehmen
-                  </label>
+                  {!canEditRoles && (
+                    <p style={{ margin: "0.15rem 0 0", color: "#4b5563", fontSize: 12 }}>
+                      Die E-Mail bleibt bei Reaktivierung fuer Kursleitung unveraendert.
+                    </p>
+                  )}
+                  {canEditRoles && (
+                    <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <input
+                        type="checkbox"
+                        checked={createOverwriteEmailOnReactivate}
+                        onChange={(e) => setCreateOverwriteEmailOnReactivate(e.target.checked)}
+                        disabled={createSaving}
+                      />
+                      Eingegebene E-Mail fuer Reaktivierung uebernehmen
+                    </label>
+                  )}
                   <p style={{ margin: "0.1rem 0 0", color: "#4b5563", fontSize: 12 }}>
                     {createOverwriteEmailOnReactivate && createEmail.trim()
                       ? `Mail geht an: ${createEmail.trim()}`

--- a/backend/src/lambdas/createParticipants/index.test.ts
+++ b/backend/src/lambdas/createParticipants/index.test.ts
@@ -97,6 +97,30 @@ describe('createParticipants Lambda', () => {
     expect(cognitoMockSend).not.toHaveBeenCalled();
   });
 
+  test('returns 403 when instructor tries to create non-participant role', async () => {
+    dynamoMockSend.mockResolvedValueOnce({
+      Item: {
+        tenantId: { S: 'test-tenant' },
+        userId: { S: 'trainer-1' },
+        role: { S: 'instructor' },
+      },
+    });
+
+    const event = baseEvent({
+      email: 'admin@example.com',
+      nickname: 'newadmin',
+      role: 'admin',
+    });
+    event.headers = { 'x-tenant-id': 'test-tenant' };
+    event.requestContext = { authorizer: { principalId: 'trainer-1' } } as any;
+
+    const result = await handler(event);
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Instructors can only create\/invite participants/i);
+    expect(cognitoMockSend).not.toHaveBeenCalled();
+    expect(sesMockSend).not.toHaveBeenCalled();
+  });
+
   test('creates a foreign-managed participant if email is empty (skips Cognito/SES)', async () => {
     const event = baseEvent({
       email: '',

--- a/backend/src/lambdas/createParticipants/index.ts
+++ b/backend/src/lambdas/createParticipants/index.ts
@@ -10,6 +10,7 @@ import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { GetItemCommand, PutItemCommand, QueryCommand, type AttributeValue } from "@aws-sdk/client-dynamodb";
 import crypto from "crypto";
 import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
 import {
   buildInviteMail,
   buildInvitePreparationMail,
@@ -149,6 +150,7 @@ export const handler = async (event: any) => {
   const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
   const { email, nickname, role } = body ?? {};
   const tenantId = getTenantId(event);
+  const { userId: actorUserId } = getTenantContext(event as any);
   const tokensTable = process.env.AUTH_TOKENS_TABLE;
   const tokenInviteEnabled = !!tokensTable;
   const mailLocale = process.env.MAIL_LOCALE || "de";
@@ -160,6 +162,33 @@ export const handler = async (event: any) => {
 
   if (!nicknameRaw || !role) {
     return { statusCode: 400, body: JSON.stringify({ error: "Missing required fields" }) };
+  }
+
+  // AuthZ guard: instructors may only create/invite participants.
+  // (Admins may invite all supported roles.)
+  let actorRole: string | undefined;
+  if (actorUserId && process.env.MEMBERSHIPS_TABLE) {
+    try {
+      const actorMembership = await dynamodb.send(
+        new GetItemCommand({
+          TableName: process.env.MEMBERSHIPS_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: actorUserId },
+          },
+          ConsistentRead: true,
+        }),
+      );
+      actorRole = actorMembership.Item?.role?.S;
+    } catch (authErr) {
+      console.warn("Could not resolve actor membership role in createParticipants:", authErr);
+    }
+  }
+  if (actorRole === "instructor" && role !== "participant") {
+    return {
+      statusCode: 403,
+      body: JSON.stringify({ error: "Instructors can only create/invite participants" }),
+    };
   }
 
   // "First entry wins": resolve canonical userId case-insensitively.
@@ -212,6 +241,30 @@ export const handler = async (event: any) => {
       }
     } catch (lookupErr) {
       console.warn("Failed canonical participant lookup, fallback to raw nickname", lookupErr);
+    }
+  }
+
+  if (actorRole === "instructor" && process.env.MEMBERSHIPS_TABLE) {
+    try {
+      const targetMembership = await dynamodb.send(
+        new GetItemCommand({
+          TableName: process.env.MEMBERSHIPS_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: canonicalUserId },
+          },
+          ConsistentRead: true,
+        }),
+      );
+      const targetRole = targetMembership.Item?.role?.S;
+      if (targetRole && targetRole !== "participant") {
+        return {
+          statusCode: 403,
+          body: JSON.stringify({ error: "Instructors can only invite participant accounts" }),
+        };
+      }
+    } catch (authErr) {
+      console.warn("Could not resolve target membership role in createParticipants:", authErr);
     }
   }
 

--- a/backend/src/lambdas/deleteParticipant/index.test.ts
+++ b/backend/src/lambdas/deleteParticipant/index.test.ts
@@ -52,7 +52,7 @@ describe("deleteParticipant Lambda", () => {
       ...overrides,
     } as any);
 
-  test("deletes membership and profile for no-login participant without other memberships", async () => {
+  test("deletes membership and profile for no-login participant without sending notification mail", async () => {
     mockSend
       .mockResolvedValueOnce({
         Item: {
@@ -84,8 +84,6 @@ describe("deleteParticipant Lambda", () => {
       .mockResolvedValueOnce({}) // membership delete
       .mockResolvedValueOnce({ Count: 0, Items: [] }) // no remaining memberships
       .mockResolvedValueOnce({}); // participant delete
-    sesMockSend.mockResolvedValueOnce({});
-
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({
@@ -93,21 +91,9 @@ describe("deleteParticipant Lambda", () => {
       membershipDeleted: true,
       profileDeleted: true,
       notificationEmail: "alice@example.com",
-      notificationEmailSent: true,
+      notificationEmailSent: false,
     });
-    expect(sesMockSend).toHaveBeenCalledTimes(1);
-    expect(sesMockSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        Message: expect.objectContaining({
-          Subject: { Data: "YogaSwap: Zugang im Studio entfernt" },
-          Body: expect.objectContaining({
-            Html: expect.objectContaining({
-              Data: expect.stringContaining("Accountname (Spitzname): alice"),
-            }),
-          }),
-        }),
-      }),
-    );
+    expect(sesMockSend).not.toHaveBeenCalled();
   });
 
   test("deletes only membership when participant has authUserId", async () => {

--- a/backend/src/lambdas/deleteParticipant/index.ts
+++ b/backend/src/lambdas/deleteParticipant/index.ts
@@ -96,6 +96,7 @@ export const handler = async (
 
     let profileDeleted = false;
     const hasAuthUserId = !!profile?.authUserId;
+    const hasRegistrationHistory = !!profile?.authUserId || !!profile?.inviteCompletedAt;
     const notificationEmail = profile?.email?.trim() || "";
     let notificationEmailSent = false;
 
@@ -126,8 +127,9 @@ export const handler = async (
       }
     }
 
-    // Optional notification email when participant has an email address.
-    if (profile?.email) {
+    // Optional notification email only for participants with login history.
+    // Never-registered invited/no-login users are removed quietly to avoid confusing mails.
+    if (profile?.email && hasRegistrationHistory) {
       const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
       const mailLocale = process.env.MAIL_LOCALE || "de";
       const removedMail = buildStudioAccessRemovedMail({

--- a/backend/src/lambdas/updateParticipant/index.test.ts
+++ b/backend/src/lambdas/updateParticipant/index.test.ts
@@ -653,6 +653,13 @@ describe("updateParticipant Lambda", () => {
           inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
         },
       })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          role: { S: "participant" },
+        },
+      }) // target membership role
       .mockResolvedValueOnce({});
     cognitoMockSend.mockResolvedValue({});
 
@@ -691,6 +698,60 @@ describe("updateParticipant Lambda", () => {
           userId: { S: "alice" },
           email: { S: "old@example.com" },
           authUserId: { S: "sub-123" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          role: { S: "participant" },
+        },
+      });
+
+    const result = await handler(
+      makeEvent({
+        requestContext: { authorizer: { principalId: "instructor-1" } } as any,
+        body: JSON.stringify({ email: "new@example.com" }),
+      }),
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toMatch(/Only admins can change email of registered participants/i);
+  });
+
+  test("returns 403 when instructor tries to change email of previously registered invited participant", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // canManage membership lookup
+      .mockResolvedValueOnce({
+        Item: { tenantId: { S: "default-tenant" }, name: { S: "Demo" } },
+      }) // canManage tenant lookup
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "instructor-1" },
+          role: { S: "instructor" },
+        },
+      }) // actor role check (email change)
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          email: { S: "old@example.com" },
+          inviteSentAt: { S: "2026-01-01T12:00:00.000Z" },
+          inviteCompletedAt: { S: "2026-01-02T12:00:00.000Z" },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          userId: { S: "alice" },
+          role: { S: "participant" },
         },
       });
 

--- a/backend/src/lambdas/updateParticipant/index.ts
+++ b/backend/src/lambdas/updateParticipant/index.ts
@@ -206,13 +206,38 @@ export const handler = async (
     const existing = unmarshall(existingItem) as ParticipantProfile;
     const existingCognitoUsername = existingItem.cognitoUsername?.S;
     const existingStatus = deriveParticipantStatus(existing);
+    let targetMembershipRole: UserRole | undefined;
+    if (actorMembershipRole === "instructor" || requestsRoleChange) {
+      const targetMembershipResp = await client.send(
+        new GetItemCommand({
+          TableName: membershipsTable,
+          Key: {
+            tenantId: { S: tenantId },
+            userId: { S: targetUserId },
+          },
+          ConsistentRead: true,
+        }),
+      );
+      targetMembershipRole = targetMembershipResp.Item?.role?.S as UserRole | undefined;
+    }
     if (requestsEmailChange) {
       const requestedEmail = typeof body.email === "string" ? body.email.trim() : body.email;
       const currentEmail = (existing.email ?? "").trim().toLowerCase();
       const nextEmail = (requestedEmail ?? "").trim().toLowerCase();
       const emailChanged = currentEmail !== nextEmail;
       const hasAuthLink = !!existing.authUserId;
-      if (emailChanged && actorMembershipRole !== "admin" && (existingStatus === "active" || hasAuthLink)) {
+      const wasPreviouslyRegistered = !!existing.inviteCompletedAt;
+      if (emailChanged && actorMembershipRole === "instructor" && targetMembershipRole && targetMembershipRole !== "participant") {
+        return {
+          statusCode: 403,
+          body: JSON.stringify({ error: "Instructors can update participants only" }),
+        };
+      }
+      if (
+        emailChanged &&
+        actorMembershipRole !== "admin" &&
+        (existingStatus === "active" || hasAuthLink || wasPreviouslyRegistered)
+      ) {
         return {
           statusCode: 403,
           body: JSON.stringify({ error: "Only admins can change email of registered participants" }),
@@ -260,7 +285,7 @@ export const handler = async (
                 ],
               }),
             );
-            if (emailChanged) {
+            if (emailChanged && existingStatus === "active") {
               await cognito.send(
                 new AdminUserGlobalSignOutCommand({
                   UserPoolId: userPoolId,
@@ -269,7 +294,7 @@ export const handler = async (
               );
             }
 
-            if (emailChanged) {
+            if (emailChanged && existingStatus === "active") {
               const baseUrlEnv = process.env.BASE_URL || "";
               const baseUrl = baseUrlEnv.startsWith("http") ? baseUrlEnv : `https://${baseUrlEnv}`;
               const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "yogaswap@example.com";
@@ -327,7 +352,7 @@ export const handler = async (
               }
             }
 
-            if (emailChanged && body.forcePasswordResetOnEmailChange) {
+            if (emailChanged && existingStatus === "active" && body.forcePasswordResetOnEmailChange) {
               const authTokensTable = process.env.AUTH_TOKENS_TABLE;
               if (!authTokensTable) {
                 return {
@@ -448,17 +473,7 @@ export const handler = async (
           body: JSON.stringify({ error: "Invalid role value" }),
         };
       }
-      const targetMembershipResp = await client.send(
-        new GetItemCommand({
-          TableName: membershipsTable,
-          Key: {
-            tenantId: { S: tenantId },
-            userId: { S: targetUserId },
-          },
-          ConsistentRead: true,
-        }),
-      );
-      const currentRole = targetMembershipResp.Item?.role?.S as UserRole | undefined;
+      const currentRole = targetMembershipRole;
       await client.send(
         new PutItemCommand({
           TableName: membershipsTable,


### PR DESCRIPTION
## Summary
- schärft die Dialog- und Statuslogik im `AdminPanel` für Nickname-Prüfung, Reaktivierung und den Status `invited` inklusive klarerem Speichern-und-Senden-Flow
- verbessert Accessibility und Tastatur-Bedienung in den Modalen (Tab-Fokusfalle, Enter/Escape-Verhalten, sichtbarer Fokuszustand für Reaktivierungs-Checkbox)
- ergänzt Backend-Guards für Trainer-Berechtigungen in `createParticipants` und `updateParticipant` sowie präzisiert Lösch-Mail-Verhalten für nie registrierte Nutzer
- erweitert die Tests in Frontend und Backend für die neuen Rollenregeln, Dialogzustände und Lösch-/Mailpfade

## Test plan
- [x] Frontend-Tests (`AdminPanel`) laufen lokal grün
- [x] Backend-Tests für `createParticipants`, `updateParticipant`, `deleteParticipant` laufen lokal grün
- [x] Manueller Smoke-Test: invited/edit/save-send, Reaktivierung mit/ohne E-Mail-Überschreibung, Trainer-Berechtigungen
- [x] Manueller Smoke-Test: Modale Tastatursteuerung (Tab/Shift+Tab, Enter, Escape)

Made with [Cursor](https://cursor.com)