### PR TITLE
#116 Kurs-CRUD API: create/update/delete für Kurse

### DIFF
--- a/app/src/api/courses.test.ts
+++ b/app/src/api/courses.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getCourses } from "./courses";
+import { createCourse, deleteCourse, getCourses, updateCourse } from "./courses";
 import axios from "axios";
 
 vi.mock("axios");
@@ -7,6 +7,9 @@ vi.mock("axios");
 describe("getCourses", () => {
   beforeEach(() => {
     vi.mocked(axios.get).mockReset();
+    vi.mocked(axios.post).mockReset();
+    vi.mocked(axios.put).mockReset();
+    vi.mocked(axios.delete).mockReset();
   });
 
   it("gibt gemappte Course-Liste zurück bei erfolgreicher Antwort", async () => {
@@ -18,6 +21,7 @@ describe("getCourses", () => {
           weekday: "Mon",
           time: "18:30",
           capacity: 10,
+          status: "draft",
           participants: ["alice"],
           dates: ["2025-06-16"],
         },
@@ -34,6 +38,7 @@ describe("getCourses", () => {
       weekday: "Mon",
       time: "18:30",
       capacity: 10,
+      status: "draft",
       participants: ["alice"],
       dates: ["2025-06-16"],
     });
@@ -46,6 +51,7 @@ describe("getCourses", () => {
 
     const result = await getCourses();
 
+    expect(result[0].status).toBe("active");
     expect(result[0].participants).toEqual([]);
     expect(result[0].dates).toEqual([]);
   });
@@ -56,5 +62,81 @@ describe("getCourses", () => {
     const result = await getCourses();
 
     expect(result).toEqual([]);
+  });
+
+  it("legt Kurs an", async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({
+      data: {
+        id: 3,
+        name: "Core",
+        weekday: "Wed",
+        time: "19:00",
+        capacity: 14,
+        status: "draft",
+        participants: [],
+        dates: [],
+      },
+    });
+
+    const result = await createCourse({
+      name: "Core",
+      weekday: "Wed",
+      time: "19:00",
+      capacity: 14,
+      status: "draft",
+    });
+
+    expect(axios.post).toHaveBeenCalledWith("/courses", {
+      name: "Core",
+      weekday: "Wed",
+      time: "19:00",
+      capacity: 14,
+      status: "draft",
+    });
+    expect(result).toEqual({
+      id: 3,
+      name: "Core",
+      weekday: "Wed",
+      time: "19:00",
+      capacity: 14,
+      status: "draft",
+      participants: [],
+      dates: [],
+    });
+  });
+
+  it("bearbeitet Kurs", async () => {
+    vi.mocked(axios.put).mockResolvedValueOnce({
+      data: {
+        id: 1,
+        name: "Yoga Flow",
+        weekday: "Tue",
+        time: "18:00",
+        capacity: 16,
+        status: "active",
+        participants: ["luna"],
+        dates: ["2026-04-15"],
+      },
+    });
+
+    const result = await updateCourse(1, { status: "active", capacity: 16 });
+
+    expect(axios.put).toHaveBeenCalledWith("/courses/1", {
+      status: "active",
+      capacity: 16,
+    });
+    expect(result.status).toBe("active");
+    expect(result.capacity).toBe(16);
+  });
+
+  it("löscht Kurs", async () => {
+    vi.mocked(axios.delete).mockResolvedValueOnce({
+      data: { success: true, courseId: "1" },
+    });
+
+    const result = await deleteCourse(1);
+
+    expect(axios.delete).toHaveBeenCalledWith("/courses/1");
+    expect(result).toEqual({ success: true, courseId: "1" });
   });
 });

--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -1,9 +1,24 @@
 import axios from "axios";
-import { Course } from "shared/types";
+import { Course, CourseStatus } from "shared/types";
 
 type ApiCourse = Omit<Course, "participants" | "dates"> & {
   participants?: string[];
   dates?: string[];
+};
+
+export type CreateCourseRequest = {
+  name: string;
+  weekday: string;
+  time: string;
+  capacity: number;
+  status?: CourseStatus;
+};
+
+export type UpdateCourseRequest = Partial<CreateCourseRequest>;
+
+export type DeleteCourseResponse = {
+  success: boolean;
+  courseId: string;
 };
 
 export async function getCourses(): Promise<Course[]> {
@@ -15,6 +30,7 @@ export async function getCourses(): Promise<Course[]> {
       weekday: item.weekday,
       time: item.time,
       capacity: item.capacity,
+      status: item.status ?? "active",
       participants: item.participants ?? [],
       dates: item.dates ?? [],
     }));
@@ -22,4 +38,39 @@ export async function getCourses(): Promise<Course[]> {
     console.error("Fehler beim Laden der Courses:", error);
     return [];
   }
+}
+
+export async function createCourse(request: CreateCourseRequest): Promise<Course> {
+  const response = await axios.post<ApiCourse>("/courses", request);
+  return {
+    id: response.data.id,
+    name: response.data.name,
+    weekday: response.data.weekday,
+    time: response.data.time,
+    capacity: response.data.capacity,
+    status: response.data.status ?? "active",
+    participants: response.data.participants ?? [],
+    dates: response.data.dates ?? [],
+  };
+}
+
+export async function updateCourse(courseId: number | string, request: UpdateCourseRequest): Promise<Course> {
+  const response = await axios.put<ApiCourse>(`/courses/${encodeURIComponent(String(courseId))}`, request);
+  return {
+    id: response.data.id,
+    name: response.data.name,
+    weekday: response.data.weekday,
+    time: response.data.time,
+    capacity: response.data.capacity,
+    status: response.data.status ?? "active",
+    participants: response.data.participants ?? [],
+    dates: response.data.dates ?? [],
+  };
+}
+
+export async function deleteCourse(courseId: number | string): Promise<DeleteCourseResponse> {
+  const response = await axios.delete<DeleteCourseResponse>(
+    `/courses/${encodeURIComponent(String(courseId))}`,
+  );
+  return response.data;
 }

--- a/backend/src/lambdas/createCourse/index.test.ts
+++ b/backend/src/lambdas/createCourse/index.test.ts
@@ -1,0 +1,150 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { GetItemCommand, PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+function makeEvent(body: unknown, headers?: Record<string, string>): APIGatewayProxyEvent {
+  return {
+    body: body == null ? null : JSON.stringify(body),
+    headers: headers ?? {},
+    requestContext: {
+      authorizer: {
+        jwt: { claims: { nickname: "admin1" } },
+      },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  } as APIGatewayProxyEvent;
+}
+
+describe("createCourse Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      COURSES_TABLE: "test-courses",
+      MEMBERSHIPS_TABLE: "test-memberships",
+    };
+    mockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("returns 500 when required env vars are missing", async () => {
+    delete process.env.COURSES_TABLE;
+    const result = await handler(makeEvent({}));
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body).error).toMatch(/COURSES_TABLE or MEMBERSHIPS_TABLE/);
+  });
+
+  test("returns 403 when actor is missing", async () => {
+    const event = {
+      body: JSON.stringify({ name: "Yoga", weekday: "Mon", time: "18:00", capacity: 10 }),
+      headers: {},
+      requestContext: {},
+    } as APIGatewayProxyEvent;
+    const result = await handler(event);
+    expect(result.statusCode).toBe(403);
+  });
+
+  test("returns 403 for non-admin membership role", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "instructor" } } });
+    const result = await handler(makeEvent({ name: "Yoga", weekday: "Mon", time: "18:00", capacity: 10 }));
+    expect(result.statusCode).toBe(403);
+    expect(GetItemCommand).toHaveBeenCalled();
+  });
+
+  test("returns 400 on invalid input", async () => {
+    const result = await handler(makeEvent({ name: " ", weekday: "Mon", time: "18:99", capacity: -1 }));
+    expect(result.statusCode).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test("creates course with default draft status", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Items: [{ courseId: { S: "1" } }, { id: { N: "4" } }],
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent(
+        { name: "Morgen Flow", weekday: "Mon", time: "08:30", capacity: 12 },
+        { "x-tenant-id": "studio-a" },
+      ),
+    );
+
+    expect(result.statusCode).toBe(201);
+    const body = JSON.parse(result.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        id: 5,
+        courseId: "5",
+        name: "Morgen Flow",
+        weekday: "Mon",
+        time: "08:30",
+        capacity: 12,
+        status: "draft",
+      }),
+    );
+
+    expect(GetItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-memberships",
+        Key: {
+          tenantId: { S: "studio-a" },
+          userId: { S: "admin1" },
+        },
+      }),
+    );
+    expect(QueryCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-courses",
+        KeyConditionExpression: "tenantId = :tid",
+        ExpressionAttributeValues: { ":tid": { S: "studio-a" } },
+      }),
+    );
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-courses",
+        Item: expect.objectContaining({
+          tenantId: { S: "studio-a" },
+          courseId: { S: "5" },
+          id: { N: "5" },
+          status: { S: "draft" },
+        }),
+      }),
+    );
+  });
+
+  test("returns 409 on id collision", async () => {
+    const condErr = new Error("collision");
+    (condErr as { name?: string }).name = "ConditionalCheckFailedException";
+
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockRejectedValueOnce(condErr);
+
+    const result = await handler(
+      makeEvent({ name: "Yoga", weekday: "Mon", time: "10:00", capacity: 8, status: "inactive" }),
+    );
+
+    expect(result.statusCode).toBe(409);
+  });
+});

--- a/backend/src/lambdas/createCourse/index.ts
+++ b/backend/src/lambdas/createCourse/index.ts
@@ -1,0 +1,145 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { GetItemCommand, PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+type CreateCourseBody = {
+  name?: string;
+  weekday?: string;
+  time?: string;
+  capacity?: number;
+  status?: string;
+};
+
+function parseBody(event: APIGatewayProxyEvent): CreateCourseBody | null {
+  if (!event.body) return null;
+  try {
+    const parsed = JSON.parse(event.body);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as CreateCourseBody;
+  } catch {
+    return null;
+  }
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const coursesTable = process.env.COURSES_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  if (!coursesTable || !membershipsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "COURSES_TABLE or MEMBERSHIPS_TABLE env var is not set" }),
+    };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  const body = parseBody(event);
+  if (!body) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON body" }) };
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const weekday = typeof body.weekday === "string" ? body.weekday.trim() : "";
+  const time = typeof body.time === "string" ? body.time.trim() : "";
+  const status = typeof body.status === "string" ? body.status.trim() : "draft";
+  const capacity = Number.isFinite(body.capacity) ? Number(body.capacity) : NaN;
+
+  if (!name) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing course name" }) };
+  }
+  if (!weekday) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing weekday" }) };
+  }
+  if (!TIME_REGEX.test(time)) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid time format (expected HH:mm)" }) };
+  }
+  if (!Number.isInteger(capacity) || capacity < 0) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Capacity must be a non-negative integer" }) };
+  }
+  if (!COURSE_STATUSES.has(status)) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid status value" }) };
+  }
+
+  try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = membershipResp.Item?.role?.S;
+    if (actorRole !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const coursesResp = await client.send(
+      new QueryCommand({
+        TableName: coursesTable,
+        KeyConditionExpression: "tenantId = :tid",
+        ExpressionAttributeValues: { ":tid": { S: tenantId } },
+        ProjectionExpression: "courseId, id",
+      }),
+    );
+
+    const maxId = (coursesResp.Items ?? []).reduce((acc, item) => {
+      const courseIdRaw = item.courseId?.S;
+      const idRaw = item.id?.N;
+      const parsedId = Number.parseInt(courseIdRaw ?? idRaw ?? "", 10);
+      return Number.isFinite(parsedId) ? Math.max(acc, parsedId) : acc;
+    }, 0);
+    const nextId = maxId + 1;
+    const nextCourseId = String(nextId);
+
+    await client.send(
+      new PutItemCommand({
+        TableName: coursesTable,
+        Item: {
+          tenantId: { S: tenantId },
+          courseId: { S: nextCourseId },
+          id: { N: String(nextId) },
+          name: { S: name },
+          weekday: { S: weekday },
+          time: { S: time },
+          capacity: { N: String(capacity) },
+          status: { S: status },
+          participants: { L: [] },
+          dates: { L: [] },
+        },
+        ConditionExpression: "attribute_not_exists(courseId)",
+      }),
+    );
+
+    return {
+      statusCode: 201,
+      body: JSON.stringify({
+        id: nextId,
+        courseId: nextCourseId,
+        name,
+        weekday,
+        time,
+        capacity,
+        status,
+        participants: [],
+        dates: [],
+      }),
+    };
+  } catch (error: unknown) {
+    if ((error as { name?: string })?.name === "ConditionalCheckFailedException") {
+      return { statusCode: 409, body: JSON.stringify({ error: "Course ID collision, retry request" }) };
+    }
+    console.error("Error creating course:", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to create course" }) };
+  }
+};

--- a/backend/src/lambdas/deleteCourse/index.test.ts
+++ b/backend/src/lambdas/deleteCourse/index.test.ts
@@ -1,0 +1,165 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import {
+  DeleteItemCommand,
+  GetItemCommand,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    DeleteItemCommand: jest.fn((input) => input),
+    GetItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
+    ScanCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+function makeEvent(pathCourseId = "1", headers?: Record<string, string>): APIGatewayProxyEvent {
+  return ({
+    body: null,
+    headers: headers ?? {},
+    pathParameters: { courseId: pathCourseId },
+    requestContext: {
+      authorizer: {
+        jwt: { claims: { nickname: "admin1" } },
+      },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  } as unknown) as APIGatewayProxyEvent;
+}
+
+function baseCourseItem(status = "inactive") {
+  return {
+    tenantId: { S: "default-tenant" },
+    courseId: { S: "1" },
+    id: { N: "1" },
+    name: { S: "Alt" },
+    weekday: { S: "Mon" },
+    time: { S: "09:00" },
+    capacity: { N: "12" },
+    status: { S: status },
+    participants: { L: [] },
+    dates: { L: [] },
+  };
+}
+
+describe("deleteCourse Lambda", () => {
+  const OLD_ENV = process.env;
+  const deleteError =
+    "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.";
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      COURSES_TABLE: "test-courses",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      OVERRIDES_TABLE: "test-overrides",
+      SWAPS_TABLE: "test-swaps",
+    };
+    mockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("returns 403 for non-admin", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "instructor" } } });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(403);
+    expect(GetItemCommand).toHaveBeenCalled();
+  });
+
+  test("returns 404 when course not found", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } }).mockResolvedValueOnce({});
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(404);
+  });
+
+  test("blocks delete when status is not inactive", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("active") });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe(deleteError);
+  });
+
+  test("blocks delete when participants still exist", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: { ...baseCourseItem("inactive"), participants: { L: [{ S: "luna" }] } },
+      });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe(deleteError);
+  });
+
+  test("blocks delete when future dates exist", async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: { ...baseCourseItem("inactive"), dates: { L: [{ S: tomorrow.toISOString().slice(0, 10) }] } },
+      });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe(deleteError);
+  });
+
+  test("blocks delete when open overrides exist", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("inactive") })
+      .mockResolvedValueOnce({
+        Items: [{ date: { S: new Date().toISOString().slice(0, 10) }, participants: { L: [{ S: "luna" }] } }],
+      });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(QueryCommand).toHaveBeenCalled();
+    expect(ScanCommand).not.toHaveBeenCalled();
+  });
+
+  test("blocks delete when open swaps exist", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("inactive") })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [{ tenantId: { S: "default-tenant" } }] });
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(400);
+    expect(ScanCommand).toHaveBeenCalled();
+    expect(JSON.parse(result.body).error).toBe(deleteError);
+  });
+
+  test("deletes course when all conditions are met", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("inactive") })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent("1", { "x-tenant-id": "studio-a" }));
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ success: true, courseId: "1" });
+    expect(DeleteItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-courses",
+        Key: {
+          tenantId: { S: "studio-a" },
+          courseId: { S: "1" },
+        },
+      }),
+    );
+  });
+});

--- a/backend/src/lambdas/deleteCourse/index.ts
+++ b/backend/src/lambdas/deleteCourse/index.ts
@@ -1,0 +1,193 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  DeleteItemCommand,
+  GetItemCommand,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+
+function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return false;
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return date >= startOfToday;
+}
+
+function hasAnyListEntries(item: Record<string, { L?: Array<{ S?: string }> }>): boolean {
+  const participantsCount = item.participants?.L?.length ?? 0;
+  const swappedCount = item.swapped?.L?.length ?? 0;
+  const waitlistCount = item.waitlist?.L?.length ?? 0;
+  return participantsCount > 0 || swappedCount > 0 || waitlistCount > 0;
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const coursesTable = process.env.COURSES_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const swapsTable = process.env.SWAPS_TABLE;
+  if (!coursesTable || !membershipsTable || !overridesTable || !swapsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error:
+          "COURSES_TABLE, MEMBERSHIPS_TABLE, OVERRIDES_TABLE or SWAPS_TABLE env var is not set",
+      }),
+    };
+  }
+
+  const courseId = event.pathParameters?.courseId?.trim();
+  if (!courseId) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId in path" }) };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = membershipResp.Item?.role?.S;
+    if (actorRole !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const courseResp = await client.send(
+      new GetItemCommand({
+        TableName: coursesTable,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId: { S: courseId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const item = courseResp.Item;
+    if (!item) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Course not found" }) };
+    }
+
+    const status = item.status?.S ?? "active";
+    if (status !== "inactive") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.",
+        }),
+      };
+    }
+
+    const participantsCount = item.participants?.L?.length ?? 0;
+    if (participantsCount > 0) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.",
+        }),
+      };
+    }
+
+    const now = new Date();
+    const hasUpcomingDates = (item.dates?.L ?? []).some((d) =>
+      d.S ? isFutureOrTodayDateString(d.S, now) : false,
+    );
+    if (hasUpcomingDates) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.",
+        }),
+      };
+    }
+
+    const overridesResp = await client.send(
+      new QueryCommand({
+        TableName: overridesTable,
+        KeyConditionExpression:
+          "tenantId = :tenantId AND begins_with(courseId_date, :coursePrefix)",
+        ExpressionAttributeValues: {
+          ":tenantId": { S: tenantId },
+          ":coursePrefix": { S: `${courseId}_` },
+        },
+      }),
+    );
+    const hasOpenOverrides = (overridesResp.Items ?? []).some((overrideItem) => {
+      const dateValue = overrideItem.date?.S;
+      if (!dateValue || !isFutureOrTodayDateString(dateValue, now)) return false;
+      return hasAnyListEntries(
+        overrideItem as unknown as Record<string, { L?: Array<{ S?: string }> }>,
+      );
+    });
+    if (hasOpenOverrides) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.",
+        }),
+      };
+    }
+
+    const swapsResp = await client.send(
+      new ScanCommand({
+        TableName: swapsTable,
+        FilterExpression:
+          "tenantId = :tenantId AND (fromCourseId = :courseId OR toCourseId = :courseId) AND #status IN (:pending, :active)",
+        ExpressionAttributeNames: {
+          "#status": "status",
+        },
+        ExpressionAttributeValues: {
+          ":tenantId": { S: tenantId },
+          ":courseId": { S: courseId },
+          ":pending": { S: "pending" },
+          ":active": { S: "active" },
+        },
+        ProjectionExpression: "tenantId",
+        Limit: 1,
+      }),
+    );
+    if ((swapsResp.Items?.length ?? 0) > 0) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error:
+            "Kurs kann nicht gelöscht werden: Nur deaktivierte Kurse ohne offene Termin-/Tauschbezüge sind löschbar.",
+        }),
+      };
+    }
+
+    await client.send(
+      new DeleteItemCommand({
+        TableName: coursesTable,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId: { S: courseId },
+        },
+      }),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true, courseId }),
+    };
+  } catch (error) {
+    console.error("Error deleting course:", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to delete course" }) };
+  }
+};

--- a/backend/src/lambdas/getCourses/index.test.ts
+++ b/backend/src/lambdas/getCourses/index.test.ts
@@ -33,10 +33,12 @@ describe("getCourses Lambda", () => {
       Items: [
         {
           id: { N: "1" },
+          courseId: { S: "1" },
           name: { S: "Yoga" },
           weekday: { S: "Monday" },
           time: { S: "10:00" },
           capacity: { N: "12" },
+          status: { S: "draft" },
           participants: { L: [{ S: "Anna" }, { S: "Ben" }] },
           dates: { L: [{ S: "2025-10-01" }, { S: "2025-10-08" }] },
         },
@@ -52,10 +54,12 @@ describe("getCourses Lambda", () => {
     expect(body).toEqual([
       {
         id: 1,
+        courseId: "1",
         name: "Yoga",
         weekday: "Monday",
         time: "10:00",
         capacity: 12,
+        status: "draft",
         participants: ["Anna", "Ben"],
         dates: ["2025-10-01", "2025-10-08"],
       },

--- a/backend/src/lambdas/getCourses/index.ts
+++ b/backend/src/lambdas/getCourses/index.ts
@@ -40,10 +40,12 @@ export const handler = async (
     }
     const courses = items.map((item) => ({
       id: Number(item.id?.N ?? item.courseId?.S ?? 0),
+      courseId: item.courseId?.S,
       name: item.name.S!,
       weekday: item.weekday.S!,
       time: item.time.S!,
       capacity: Number(item.capacity.N!),
+      status: item.status?.S ?? "active",
       participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
       dates: item.dates.L ? item.dates.L.map((d: any) => d.S) : [],
     }));

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -1,0 +1,185 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import {
+  GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
+    ScanCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+function makeEvent(
+  body: unknown,
+  pathCourseId = "1",
+  headers?: Record<string, string>,
+): APIGatewayProxyEvent {
+  return ({
+    body: body == null ? null : JSON.stringify(body),
+    headers: headers ?? {},
+    pathParameters: { courseId: pathCourseId },
+    requestContext: {
+      authorizer: {
+        jwt: { claims: { nickname: "admin1" } },
+      },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  } as unknown) as APIGatewayProxyEvent;
+}
+
+function baseCourseItem(status = "draft") {
+  return {
+    tenantId: { S: "default-tenant" },
+    courseId: { S: "1" },
+    id: { N: "1" },
+    name: { S: "Alt" },
+    weekday: { S: "Mon" },
+    time: { S: "09:00" },
+    capacity: { N: "12" },
+    status: { S: status },
+    participants: { L: [{ S: "luna" }] },
+    dates: { L: [] },
+  };
+}
+
+describe("updateCourse Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      COURSES_TABLE: "test-courses",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      OVERRIDES_TABLE: "test-overrides",
+      SWAPS_TABLE: "test-swaps",
+    };
+    mockSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("returns 403 for non-admin", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "instructor" } } });
+    const result = await handler(makeEvent({ name: "Neu" }));
+    expect(result.statusCode).toBe(403);
+    expect(GetItemCommand).toHaveBeenCalled();
+  });
+
+  test("returns 404 when course not found", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } }).mockResolvedValueOnce({});
+    const result = await handler(makeEvent({ name: "Neu" }));
+    expect(result.statusCode).toBe(404);
+  });
+
+  test("updates editable fields and keeps participants/dates", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({ name: "Morgenkurs", weekday: "Tue", time: "08:00", capacity: 16 }),
+    );
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        courseId: "1",
+        name: "Morgenkurs",
+        weekday: "Tue",
+        time: "08:00",
+        capacity: 16,
+        status: "draft",
+      }),
+    );
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-courses",
+        Item: expect.objectContaining({
+          participants: { L: [{ S: "luna" }] },
+        }),
+      }),
+    );
+  });
+
+  test("rejects invalid status transition inactive -> active", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("inactive") });
+    const result = await handler(makeEvent({ status: "active" }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Invalid status transition/);
+  });
+
+  test("blocks active -> inactive when future dates exist", async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          dates: { L: [{ S: tomorrow.toISOString().slice(0, 10) }] },
+        },
+      });
+
+    const result = await handler(makeEvent({ status: "inactive" }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/Kurs kann nicht deaktiviert werden/);
+  });
+
+  test("blocks active -> inactive when open overrides/swaps exist", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("active") })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            date: { S: new Date().toISOString().slice(0, 10) },
+            participants: { L: [{ S: "luna" }] },
+          },
+        ],
+      });
+
+    const result = await handler(makeEvent({ status: "inactive" }));
+    expect(result.statusCode).toBe(400);
+    expect(QueryCommand).toHaveBeenCalled();
+    expect(ScanCommand).not.toHaveBeenCalled();
+  });
+
+  test("allows active -> inactive when no open dates/refs", async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 30);
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          dates: { L: [{ S: oldDate.toISOString().slice(0, 10) }] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] }) // overrides query
+      .mockResolvedValueOnce({ Items: [] }) // swaps scan
+      .mockResolvedValueOnce({}); // put
+
+    const result = await handler(makeEvent({ status: "inactive" }));
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).status).toBe("inactive");
+    expect(QueryCommand).toHaveBeenCalled();
+    expect(ScanCommand).toHaveBeenCalled();
+  });
+});

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -1,0 +1,281 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+type UpdateCourseBody = {
+  name?: string;
+  weekday?: string;
+  time?: string;
+  capacity?: number;
+  status?: string;
+};
+
+function parseBody(event: APIGatewayProxyEvent): UpdateCourseBody | null {
+  if (!event.body) return null;
+  try {
+    const parsed = JSON.parse(event.body);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as UpdateCourseBody;
+  } catch {
+    return null;
+  }
+}
+
+function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return false;
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return date >= startOfToday;
+}
+
+function hasAnyListEntries(item: Record<string, { L?: Array<{ S?: string }> }>): boolean {
+  const participantsCount = item.participants?.L?.length ?? 0;
+  const swappedCount = item.swapped?.L?.length ?? 0;
+  const waitlistCount = item.waitlist?.L?.length ?? 0;
+  return participantsCount > 0 || swappedCount > 0 || waitlistCount > 0;
+}
+
+async function canDeactivateCourse(params: {
+  tenantId: string;
+  courseId: string;
+  swapsTable: string;
+  overridesTable: string;
+  existingDates: string[];
+}): Promise<boolean> {
+  const now = new Date();
+  const hasUpcomingDates = params.existingDates.some((date) =>
+    isFutureOrTodayDateString(date, now),
+  );
+  if (hasUpcomingDates) return false;
+
+  const overridesResp = await client.send(
+    new QueryCommand({
+      TableName: params.overridesTable,
+      KeyConditionExpression:
+        "tenantId = :tenantId AND begins_with(courseId_date, :coursePrefix)",
+      ExpressionAttributeValues: {
+        ":tenantId": { S: params.tenantId },
+        ":coursePrefix": { S: `${params.courseId}_` },
+      },
+    }),
+  );
+  const hasOpenOverrides = (overridesResp.Items ?? []).some((item) => {
+    const dateValue = item.date?.S;
+    if (!dateValue || !isFutureOrTodayDateString(dateValue, now)) return false;
+    return hasAnyListEntries(item as Record<string, { L?: Array<{ S?: string }> }>);
+  });
+  if (hasOpenOverrides) return false;
+
+  const swapsResp = await client.send(
+    new ScanCommand({
+      TableName: params.swapsTable,
+      FilterExpression:
+        "tenantId = :tenantId AND (fromCourseId = :courseId OR toCourseId = :courseId) AND #status IN (:pending, :active)",
+      ExpressionAttributeNames: {
+        "#status": "status",
+      },
+      ExpressionAttributeValues: {
+        ":tenantId": { S: params.tenantId },
+        ":courseId": { S: params.courseId },
+        ":pending": { S: "pending" },
+        ":active": { S: "active" },
+      },
+      ProjectionExpression: "tenantId",
+      Limit: 1,
+    }),
+  );
+  return (swapsResp.Items?.length ?? 0) === 0;
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const coursesTable = process.env.COURSES_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const swapsTable = process.env.SWAPS_TABLE;
+  if (!coursesTable || !membershipsTable || !overridesTable || !swapsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error:
+          "COURSES_TABLE, MEMBERSHIPS_TABLE, OVERRIDES_TABLE or SWAPS_TABLE env var is not set",
+      }),
+    };
+  }
+
+  const courseId = event.pathParameters?.courseId?.trim();
+  if (!courseId) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId in path" }) };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  const body = parseBody(event);
+  if (!body) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON body" }) };
+  }
+  if (
+    !Object.prototype.hasOwnProperty.call(body, "name") &&
+    !Object.prototype.hasOwnProperty.call(body, "weekday") &&
+    !Object.prototype.hasOwnProperty.call(body, "time") &&
+    !Object.prototype.hasOwnProperty.call(body, "capacity") &&
+    !Object.prototype.hasOwnProperty.call(body, "status")
+  ) {
+    return { statusCode: 400, body: JSON.stringify({ error: "No updatable fields provided" }) };
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : undefined;
+  const weekday = typeof body.weekday === "string" ? body.weekday.trim() : undefined;
+  const time = typeof body.time === "string" ? body.time.trim() : undefined;
+  const status = typeof body.status === "string" ? body.status.trim() : undefined;
+  const capacity =
+    Object.prototype.hasOwnProperty.call(body, "capacity") && Number.isFinite(body.capacity)
+      ? Number(body.capacity)
+      : undefined;
+
+  if (Object.prototype.hasOwnProperty.call(body, "name") && !name) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing course name" }) };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "weekday") && !weekday) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing weekday" }) };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "time") && (!time || !TIME_REGEX.test(time))) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid time format (expected HH:mm)" }) };
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(body, "capacity") &&
+    (capacity == null || !Number.isInteger(capacity) || capacity < 0)
+  ) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Capacity must be a non-negative integer" }) };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "status")) {
+    if (!status || !COURSE_STATUSES.has(status)) {
+      return { statusCode: 400, body: JSON.stringify({ error: "Invalid status value" }) };
+    }
+  }
+
+  try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = membershipResp.Item?.role?.S;
+    if (actorRole !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const courseResp = await client.send(
+      new GetItemCommand({
+        TableName: coursesTable,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId: { S: courseId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const item = courseResp.Item;
+    if (!item) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Course not found" }) };
+    }
+
+    const currentStatus = item.status?.S ?? "active";
+    const nextStatus = status ?? currentStatus;
+    if (status && nextStatus !== currentStatus) {
+      const transitionAllowed =
+        (currentStatus === "inactive" && nextStatus === "draft") ||
+        (currentStatus === "draft" && nextStatus === "active") ||
+        (currentStatus === "active" && nextStatus === "inactive");
+      if (!transitionAllowed) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: `Invalid status transition: ${currentStatus} -> ${nextStatus}` }),
+        };
+      }
+
+      if (currentStatus === "active" && nextStatus === "inactive") {
+        const existingDates = item.dates?.L?.map((d) => d.S ?? "").filter(Boolean) ?? [];
+        const canDeactivate = await canDeactivateCourse({
+          tenantId,
+          courseId,
+          swapsTable,
+          overridesTable,
+          existingDates,
+        });
+        if (!canDeactivate) {
+          return {
+            statusCode: 400,
+            body: JSON.stringify({
+              error:
+                "Kurs kann nicht deaktiviert werden: Alle Termine müssen zuerst abgesagt oder geschlossen sein.",
+            }),
+          };
+        }
+      }
+    }
+
+    const nextName = name ?? item.name?.S ?? "";
+    const nextWeekday = weekday ?? item.weekday?.S ?? "";
+    const nextTime = time ?? item.time?.S ?? "";
+    const nextCapacity =
+      capacity ??
+      (item.capacity?.N ? Number.parseInt(item.capacity.N, 10) : 0);
+    const nextId = item.id?.N ? Number.parseInt(item.id.N, 10) : Number.parseInt(courseId, 10);
+    const nextParticipants = item.participants?.L ?? [];
+    const nextDates = item.dates?.L ?? [];
+
+    await client.send(
+      new PutItemCommand({
+        TableName: coursesTable,
+        Item: {
+          tenantId: { S: tenantId },
+          courseId: { S: courseId },
+          id: { N: String(Number.isFinite(nextId) ? nextId : 0) },
+          name: { S: nextName },
+          weekday: { S: nextWeekday },
+          time: { S: nextTime },
+          capacity: { N: String(nextCapacity) },
+          status: { S: nextStatus },
+          participants: { L: nextParticipants },
+          dates: { L: nextDates },
+        },
+      }),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        id: Number.isFinite(nextId) ? nextId : 0,
+        courseId,
+        name: nextName,
+        weekday: nextWeekday,
+        time: nextTime,
+        capacity: nextCapacity,
+        status: nextStatus,
+        participants: nextParticipants.map((p) => p.S).filter(Boolean),
+        dates: nextDates.map((d) => d.S).filter(Boolean),
+      }),
+    };
+  } catch (error) {
+    console.error("Error updating course:", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to update course" }) };
+  }
+};

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -136,6 +136,13 @@ resource "aws_cloudfront_distribution" "spa" {
       cookies {
         forward = "none"
       }
+      headers = [
+        "Authorization",
+        "x-tenant-id",
+        "Origin",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+      ]
     }
     compress = true
   }

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -149,6 +149,34 @@ locals {
       s3_actions   = []
       s3_resources = []
     },
+    "update_course" = {
+      name             = "update-course"
+      file_name        = "updateCourse.zip"
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query", "dynamodb:Scan"]
+      tables = {
+        "COURSES_TABLE"     = module.courses_table.table_name
+        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+        "OVERRIDES_TABLE"   = module.course_overrides_table.table_name
+        "SWAPS_TABLE"       = module.swaps_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+    },
+    "delete_course" = {
+      name             = "delete-course"
+      file_name        = "deleteCourse.zip"
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan"]
+      tables = {
+        "COURSES_TABLE"     = module.courses_table.table_name
+        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+        "OVERRIDES_TABLE"   = module.course_overrides_table.table_name
+        "SWAPS_TABLE"       = module.swaps_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+    },
     "get_participants" = {
       name             = "get-participants"
       file_name        = "getParticipants.zip"
@@ -374,6 +402,8 @@ locals {
     "POST /process-promotions"                   = "process_promotions"
     "GET /courses"                               = "get_courses"
     "POST /courses"                              = "create_course"
+    "PUT /courses/{courseId}"                    = "update_course"
+    "DELETE /courses/{courseId}"                 = "delete_course"
     "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
     "POST /participants/{userId}/password-reset" = "reset_participant_password"
@@ -405,6 +435,8 @@ module "yogaswap_api" {
     "POST /participants",
     "POST /participants/{userId}/password-reset",
     "POST /courses",
+    "PUT /courses/{courseId}",
+    "DELETE /courses/{courseId}",
     "GET /tenant-context",
   ]
 }

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -137,6 +137,18 @@ locals {
       s3_actions   = []
       s3_resources = []
     },
+    "create_course" = {
+      name             = "create-course"
+      file_name        = "createCourse.zip"
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn]
+      dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem", "dynamodb:PutItem"]
+      tables = {
+        "COURSES_TABLE"     = module.courses_table.table_name
+        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+    },
     "get_participants" = {
       name             = "get-participants"
       file_name        = "getParticipants.zip"
@@ -361,6 +373,7 @@ locals {
     "DELETE /course-overrides/{courseId}/{date}" = "delete_override"
     "POST /process-promotions"                   = "process_promotions"
     "GET /courses"                               = "get_courses"
+    "POST /courses"                              = "create_course"
     "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
     "POST /participants/{userId}/password-reset" = "reset_participant_password"
@@ -391,6 +404,7 @@ module "yogaswap_api" {
     "DELETE /participants/{userId}",
     "POST /participants",
     "POST /participants/{userId}/password-reset",
+    "POST /courses",
     "GET /tenant-context",
   ]
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -32,6 +32,8 @@ export type Swap = {
   status: SwapStatus;
 };
 
+export type CourseStatus = "inactive" | "draft" | "active";
+
 export type Course = {
   // Tenant, zu dem der Kurs gehört
   tenantId?: string;
@@ -40,6 +42,7 @@ export type Course = {
   weekday: string; // z.B. "Mon", "Tue", ...
   time: string;    // z.B. "18:30"
   capacity: number;
+  status?: CourseStatus;
   participants: string[]; // Nicknames
   dates: string[]; // Liste der Termine
   // Optional zugeordnete Kursleiter (Nicknames oder User-IDs)


### PR DESCRIPTION
## Summary
- implementiert Kurs-CRUD im Backend mit neuen Lambdas für `POST /courses`, `PUT /courses/{courseId}` und `DELETE /courses/{courseId}` inklusive Admin-AuthZ und Validierung
- ergänzt Fachregeln für Statusübergänge sowie Schutzlogik für Deaktivieren/Löschen (Termine, Overrides, Swaps, Teilnehmer) und erweitert `getCourses` um `courseId`/`status`
- verdrahtet Infrastruktur (Terraform/API Gateway/Protected Routes/CloudFront) und ergänzt Frontend-API-Funktionen + Tests für `createCourse`, `updateCourse`, `deleteCourse`

## Test plan
- [x] `npm run test --prefix backend getCourses`
- [x] `npm run test --prefix backend createCourse`
- [x] `npm run test --prefix backend updateCourse`
- [x] `npm run test --prefix backend deleteCourse`
- [x] `npx vitest run "src/api/courses.test.ts"` (im `app`-Verzeichnis)
- [x] `tofu apply` im Demo-Environment erfolgreich
- [x] Smoke-Test gegen deployte Lambdas: create -> update(active) -> update(inactive) -> delete


Made with [Cursor](https://cursor.com)