### PR TITLE
#117 Kurs-Editor UI/UX: Modale für Kurse + A11y-Feinschliff

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -26,6 +26,44 @@ body {
   margin-top: 1.5rem;
 }
 
+.course-management-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 12px;
+  text-align: left;
+}
+
+.course-management-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.course-management-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.course-card-actions-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 6px;
+}
+
+.course-card-actions-status {
+  font-size: 12px;
+  color: #4b5563;
+}
+
+.course-card-actions-buttons {
+  display: inline-flex;
+  gap: 4px;
+}
+
 /* Header */
 .app-top {
   display: flex;
@@ -406,6 +444,10 @@ a:focus-visible {
   }
   .main-section-admin {
     margin-top: 1rem;
+  }
+  .course-management-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
   }
   .admin-panel {
     padding: 0.75rem;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -273,6 +273,7 @@ a:focus-visible {
   border-radius: 8px; max-width: 480px; width: 90%;
   box-shadow: 0 10px 30px rgba(0,0,0,0.2);
   text-align: left;
+  position: relative;
 }
 .modal.modal-compact {
   max-width: 520px;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -313,6 +313,13 @@ a:focus-visible {
   box-sizing: border-box;
 }
 
+.course-editor-note {
+  margin: 0 0 10px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
 /* Footer (Impressum / Datenschutz) */
 .app-footer {
   margin-top: 2rem;

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -338,5 +338,139 @@ describe("CourseList", () => {
         .some((button) => button.hasAttribute("disabled")),
     ).toBe(true);
   });
+
+  it("aktiviert Speichern im Edit-Dialog erst nach Änderungen", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "draft",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+    mockedUpdateCourse.mockResolvedValue({
+      ...mockCourses[0],
+      name: "Kurs A Neu",
+    });
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const courseMatches = await screen.findAllByText("Kurs A");
+    expect(courseMatches.length).toBeGreaterThan(0);
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole("button", { name: /kurs bearbeiten kurs a/i })[0]);
+
+    const saveButton = screen.getByRole("button", { name: /^speichern$/i });
+    expect(saveButton).toBeDisabled();
+
+    const nameInput = screen.getByLabelText("Kursname bearbeiten");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Kurs A Neu");
+    expect(saveButton).not.toBeDisabled();
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockedUpdateCourse).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          name: "Kurs A Neu",
+        }),
+      );
+    });
+  });
+
+  it("setzt Fokus beim Öffnen ins Edit-Modal und hält Tab im Dialog", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "draft",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const user = userEvent.setup();
+    await screen.findAllByText("Kurs A");
+    await user.click(screen.getAllByRole("button", { name: /kurs bearbeiten kurs a/i })[0]);
+
+    const nameInput = screen.getByLabelText("Kursname bearbeiten");
+    await waitFor(() => {
+      expect(nameInput).toHaveFocus();
+    });
+
+    // Durch viele Tabs darf der Fokus den Dialog nicht verlassen.
+    for (let i = 0; i < 10; i += 1) {
+      await user.tab();
+      const active = document.activeElement;
+      expect(active).not.toBeNull();
+      expect(screen.getByLabelText("Kurs bearbeiten").contains(active as Node)).toBe(true);
+    }
+  });
+
+  it("schließt den Lösch-Dialog mit Escape", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "inactive",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const user = userEvent.setup();
+    await screen.findAllByText("Kurs A");
+    await user.click(screen.getAllByRole("button", { name: /kurs löschen kurs a/i })[0]);
+
+    expect(screen.getByLabelText("Kurs löschen")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Kurs löschen")).not.toBeInTheDocument();
+    });
+  });
 });
 

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -337,6 +337,16 @@ describe("CourseList", () => {
         .getAllByRole("button", { name: /kurs löschen kurs a/i })
         .some((button) => button.hasAttribute("disabled")),
     ).toBe(true);
+    expect(
+      screen
+        .getAllByRole("button", { name: /mitglieder bearbeiten kurs a/i })
+        .some((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
+    expect(
+      screen
+        .getAllByRole("button", { name: /termine bearbeiten kurs a/i })
+        .some((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
   });
 
   it("aktiviert Speichern im Edit-Dialog erst nach Änderungen", async () => {
@@ -471,6 +481,45 @@ describe("CourseList", () => {
     await waitFor(() => {
       expect(screen.queryByLabelText("Kurs löschen")).not.toBeInTheDocument();
     });
+  });
+
+  it("öffnet Mitglieder- und Termine-Dialog über Statusleisten-Icons", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "active",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const user = userEvent.setup();
+    await screen.findAllByText("Kurs A");
+
+    await user.click(screen.getAllByRole("button", { name: /mitglieder bearbeiten kurs a/i })[0]);
+    expect(screen.getByLabelText("Kursmitglieder bearbeiten")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Kursmitglieder bearbeiten")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole("button", { name: /termine bearbeiten kurs a/i })[0]);
+    expect(screen.getByLabelText("Kurstermine bearbeiten")).toBeInTheDocument();
   });
 });
 

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import CourseList from "./CourseList";
-import { getCourses } from "../api/courses";
+import { createCourse, deleteCourse, getCourses, updateCourse } from "../api/courses";
 import { getOverrides } from "../api/overrides";
 import { getSwaps } from "../api/swaps";
 import type { User, Tenant, UserTenantMembership, Course } from "shared/types";
+import { canSeeCourse } from "shared/permissions";
 
 vi.mock("../api/courses");
 vi.mock("../api/overrides");
@@ -24,8 +26,12 @@ vi.mock("./useCourseSwaps", () => {
 });
 
 const mockedGetCourses = getCourses as unknown as ReturnType<typeof vi.fn>;
+const mockedCreateCourse = createCourse as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdateCourse = updateCourse as unknown as ReturnType<typeof vi.fn>;
+const mockedDeleteCourse = deleteCourse as unknown as ReturnType<typeof vi.fn>;
 const mockedGetOverrides = getOverrides as unknown as ReturnType<typeof vi.fn>;
 const mockedGetSwaps = getSwaps as unknown as ReturnType<typeof vi.fn>;
+const mockedCanSeeCourse = canSeeCourse as unknown as ReturnType<typeof vi.fn>;
 
 vi.mock("shared/permissions", () => ({
   canSeeCourse: vi.fn(),
@@ -52,6 +58,10 @@ const baseMembership: UserTenantMembership = {
 describe("CourseList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedCreateCourse.mockReset();
+    mockedUpdateCourse.mockReset();
+    mockedDeleteCourse.mockReset();
+    mockedCanSeeCourse.mockImplementation(() => true);
   });
 
   it("zeigt während des Ladens 'Loading...' an und rendert anschließend Kurse (mit zukünftigen Terminen)", async () => {
@@ -170,7 +180,7 @@ describe("CourseList", () => {
     (canSeeCourse as unknown as ReturnType<typeof vi.fn>)
       .mockImplementation((membershipArg: UserTenantMembership, _settings, courseArg: Course) => {
         // Nur Kurs mit ID 2 ist sichtbar
-        expect(membershipArg).toBe(baseMembership);
+        expect(membershipArg).toEqual(baseMembership);
         return courseArg.id === 2;
       });
 
@@ -226,6 +236,107 @@ describe("CourseList", () => {
 
     // Ohne Tenant/Membership wird canSeeCourse nicht aufgerufen
     expect(canSeeCourse).not.toHaveBeenCalled();
+  });
+
+  it("zeigt Admin-Kursverwaltung und legt Kurs über Modal an", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "draft",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+    mockedCreateCourse.mockResolvedValue({
+      id: 2,
+      name: "Neuer Kurs",
+      weekday: "Tue",
+      time: "18:30",
+      capacity: 12,
+      status: "draft",
+      participants: [],
+      dates: [],
+    });
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const courseMatches = await screen.findAllByText("Kurs A");
+    expect(courseMatches.length).toBeGreaterThan(0);
+
+    const user = userEvent.setup();
+    const createButtons = screen.getAllByRole("button", { name: /kurs anlegen/i });
+    await user.click(createButtons[createButtons.length - 1]);
+    await user.type(screen.getByLabelText("Kursname"), "Neuer Kurs");
+    await user.clear(screen.getByLabelText("Kapazität"));
+    await user.type(screen.getByLabelText("Kapazität"), "12");
+    await user.click(screen.getByRole("button", { name: /^anlegen$/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateCourse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Neuer Kurs",
+          capacity: 12,
+        }),
+      );
+    });
+  });
+
+  it("zeigt Instructor-Aktionen deaktiviert", async () => {
+    const instructorMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "instructor",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurs A",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "active",
+        participants: [],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={instructorMembership} />);
+
+    const courseMatches = await screen.findAllByText("Kurs A");
+    expect(courseMatches.length).toBeGreaterThan(0);
+
+    expect(
+      screen
+        .getAllByRole("button", { name: /kurs anlegen/i })
+        .some((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
+    expect(
+      screen
+        .getAllByRole("button", { name: /kurs bearbeiten kurs a/i })
+        .some((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
+    expect(
+      screen
+        .getAllByRole("button", { name: /kurs löschen kurs a/i })
+        .some((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
   });
 });
 

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -1,7 +1,7 @@
 import CourseCard from "./CourseCard";
 import { useCourseSwaps } from "./useCourseSwaps";
 import { useEffect, useState, useMemo, useCallback, useRef, type KeyboardEvent, type RefObject } from "react";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Users, CalendarDays } from "lucide-react";
 import {
   Course,
   CourseDateOverride,
@@ -127,9 +127,13 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
   const [editState, setEditState] = useState<CourseEditorState | null>(null);
   const [editInitialState, setEditInitialState] = useState<CourseEditorState | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [membersTargetId, setMembersTargetId] = useState<number | null>(null);
+  const [datesTargetId, setDatesTargetId] = useState<number | null>(null);
   const createModalRef = useRef<HTMLDivElement | null>(null);
   const editModalRef = useRef<HTMLDivElement | null>(null);
   const deleteModalRef = useRef<HTMLDivElement | null>(null);
+  const membersModalRef = useRef<HTMLDivElement | null>(null);
+  const datesModalRef = useRef<HTMLDivElement | null>(null);
 
   const isAdmin = membership?.role === "admin";
   const isInstructor = membership?.role === "instructor";
@@ -214,6 +218,12 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
   const deleteTargetCourse = deleteTargetId
     ? visibleCourses.find((course) => course.id === deleteTargetId)
     : undefined;
+  const membersTargetCourse = membersTargetId
+    ? visibleCourses.find((course) => course.id === membersTargetId)
+    : undefined;
+  const datesTargetCourse = datesTargetId
+    ? visibleCourses.find((course) => course.id === datesTargetId)
+    : undefined;
 
   const resetFormError = () => setFormError(null);
 
@@ -243,6 +253,16 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     setDeleteOpen(true);
   };
 
+  const openMembersModal = (courseId: number) => {
+    setMembersTargetId(courseId);
+    resetFormError();
+  };
+
+  const openDatesModal = (courseId: number) => {
+    setDatesTargetId(courseId);
+    resetFormError();
+  };
+
   const parseCapacity = (capacityText: string): number | null => {
     const parsed = Number.parseInt(capacityText, 10);
     if (!Number.isInteger(parsed) || parsed < 0) return null;
@@ -265,6 +285,16 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     if (saving) return;
     setDeleteOpen(false);
     setDeleteTargetId(null);
+  };
+
+  const closeMembersModal = () => {
+    if (saving) return;
+    setMembersTargetId(null);
+  };
+
+  const closeDatesModal = () => {
+    if (saving) return;
+    setDatesTargetId(null);
   };
 
   const handleFocusTrap = (event: KeyboardEvent<HTMLDivElement>, modalRef: RefObject<HTMLDivElement | null>) => {
@@ -321,6 +351,10 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       ? editModalRef.current
       : deleteOpen
       ? deleteModalRef.current
+      : membersTargetId
+      ? membersModalRef.current
+      : datesTargetId
+      ? datesModalRef.current
       : null;
     if (!activeModal) return;
 
@@ -330,16 +364,20 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       return;
     }
     activeModal.focus();
-  }, [createOpen, editOpen, deleteOpen]);
+  }, [createOpen, editOpen, deleteOpen, membersTargetId, datesTargetId]);
 
   useEffect(() => {
-    if (!createOpen && !editOpen && !deleteOpen) return;
+    if (!createOpen && !editOpen && !deleteOpen && !membersTargetId && !datesTargetId) return;
 
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key !== "Escape") return;
       if (saving) return;
       event.preventDefault();
-      if (deleteOpen) {
+      if (datesTargetId) {
+        setDatesTargetId(null);
+      } else if (membersTargetId) {
+        setMembersTargetId(null);
+      } else if (deleteOpen) {
         setDeleteOpen(false);
         setDeleteTargetId(null);
       } else if (editOpen) {
@@ -353,7 +391,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [createOpen, editOpen, deleteOpen, saving]);
+  }, [createOpen, editOpen, deleteOpen, membersTargetId, datesTargetId, saving]);
 
   const saveCreateCourse = async () => {
     if (!canManageCourses) return;
@@ -500,6 +538,24 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
                     </strong>
                   </span>
                   <div className="course-card-actions-buttons">
+                    <button
+                      type="button"
+                      title={canManageCourses ? "Mitglieder bearbeiten" : "Nur Admin kann Mitglieder bearbeiten"}
+                      aria-label={`Mitglieder bearbeiten ${course.name}`}
+                      disabled={!canManageCourses || saving}
+                      onClick={() => openMembersModal(course.id)}
+                    >
+                      <Users size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      title={canManageCourses ? "Termine bearbeiten" : "Nur Admin kann Termine bearbeiten"}
+                      aria-label={`Termine bearbeiten ${course.name}`}
+                      disabled={!canManageCourses || saving}
+                      onClick={() => openDatesModal(course.id)}
+                    >
+                      <CalendarDays size={14} aria-hidden="true" />
+                    </button>
                     <button
                       type="button"
                       title={canManageCourses ? "Kurs bearbeiten" : "Nur Admin kann Kurse bearbeiten"}
@@ -740,6 +796,60 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
                 disabled={!canSubmitEdit}
               >
                 {saving ? "Speichere..." : "Speichern"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {membersTargetCourse && (
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kursmitglieder bearbeiten"
+          onKeyDown={(event) => {
+            handleFocusTrap(event, membersModalRef);
+          }}
+        >
+          <div className="modal modal-compact" ref={membersModalRef} tabIndex={-1}>
+            <h4>Mitglieder verwalten</h4>
+            <p className="course-editor-note">
+              Kurs: <strong>{membersTargetCourse.name}</strong>
+            </p>
+            <p className="course-editor-note">
+              Hier folgt als Nächstes die Zuordnung von Teilnehmern zu diesem Kurs (inkl. Kapazitätsprüfung).
+            </p>
+            <div className="modal-actions">
+              <button type="button" className="modal-action-btn" onClick={closeMembersModal} disabled={saving}>
+                Schließen
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {datesTargetCourse && (
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kurstermine bearbeiten"
+          onKeyDown={(event) => {
+            handleFocusTrap(event, datesModalRef);
+          }}
+        >
+          <div className="modal modal-compact" ref={datesModalRef} tabIndex={-1}>
+            <h4>Termine verwalten</h4>
+            <p className="course-editor-note">
+              Kurs: <strong>{datesTargetCourse.name}</strong>
+            </p>
+            <p className="course-editor-note">
+              Hier folgt als Nächstes die Terminliste mit Absagen/Status pro Termin als erster MVP-Schritt.
+            </p>
+            <div className="modal-actions">
+              <button type="button" className="modal-action-btn" onClick={closeDatesModal} disabled={saving}>
+                Schließen
               </button>
             </div>
           </div>

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -1,11 +1,25 @@
 import CourseCard from "./CourseCard";
 import { useCourseSwaps } from "./useCourseSwaps";
 import { useEffect, useState, useMemo, useCallback } from "react";
-import { Course, CourseDateOverride, Swap, User, Tenant, UserTenantMembership } from "shared/types";
+import { Plus, Pencil, Trash2 } from "lucide-react";
+import {
+  Course,
+  CourseDateOverride,
+  CourseStatus,
+  Swap,
+  User,
+  Tenant,
+  UserTenantMembership,
+} from "shared/types";
 import { getSwaps } from "../api/swaps";
 import { getOverrides } from "../api/overrides";
 import { getCourseDates } from "../lib/dates";
-import { getCourses } from "../api/courses";
+import {
+  createCourse,
+  deleteCourse,
+  getCourses,
+  updateCourse,
+} from "../api/courses";
 import { canSeeCourse } from "shared/permissions";
 
 type Props = {
@@ -14,12 +28,100 @@ type Props = {
   membership?: UserTenantMembership;
 };
 
+type CourseEditorState = {
+  id: number;
+  name: string;
+  weekday: string;
+  time: string;
+  capacity: string;
+  status: CourseStatus;
+};
+
+type CourseCreateState = {
+  name: string;
+  weekday: string;
+  time: string;
+  capacity: string;
+  status: CourseStatus;
+};
+
+const WEEKDAY_ORDER: Record<string, number> = {
+  Mon: 1,
+  Monday: 1,
+  Tue: 2,
+  Tuesday: 2,
+  Wed: 3,
+  Wednesday: 3,
+  Thu: 4,
+  Thursday: 4,
+  Fri: 5,
+  Friday: 5,
+  Sat: 6,
+  Saturday: 6,
+  Sun: 7,
+  Sunday: 7,
+};
+
+const WEEKDAY_OPTIONS = [
+  { value: "Mon", label: "Montag" },
+  { value: "Tue", label: "Dienstag" },
+  { value: "Wed", label: "Mittwoch" },
+  { value: "Thu", label: "Donnerstag" },
+  { value: "Fri", label: "Freitag" },
+  { value: "Sat", label: "Samstag" },
+  { value: "Sun", label: "Sonntag" },
+] as const;
+
+const STATUS_OPTIONS: Array<{ value: CourseStatus; label: string }> = [
+  { value: "inactive", label: "Inaktiv" },
+  { value: "draft", label: "In Planung" },
+  { value: "active", label: "Aktiv" },
+];
+
+function sortCoursesForDisplay(a: Course, b: Course): number {
+  const weekdayA = WEEKDAY_ORDER[a.weekday] ?? 99;
+  const weekdayB = WEEKDAY_ORDER[b.weekday] ?? 99;
+  if (weekdayA !== weekdayB) return weekdayA - weekdayB;
+  if (a.time !== b.time) return a.time.localeCompare(b.time);
+  return a.id - b.id;
+}
+
+function toEditorState(course: Course): CourseEditorState {
+  return {
+    id: course.id,
+    name: course.name,
+    weekday: course.weekday,
+    time: course.time,
+    capacity: String(course.capacity),
+    status: course.status ?? "active",
+  };
+}
+
 export default function CourseList({ currentUser, tenant, membership }: Props) {
   const [swaps, setSwaps] = useState<Swap[]>([]);
   const [overrides, setOverrides] = useState<CourseDateOverride[]>([]);
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [createState, setCreateState] = useState<CourseCreateState>({
+    name: "",
+    weekday: "Mon",
+    time: "18:00",
+    capacity: "10",
+    status: "draft",
+  });
+  const [editState, setEditState] = useState<CourseEditorState | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+
+  const isAdmin = membership?.role === "admin";
+  const isInstructor = membership?.role === "instructor";
+  const canSeeCourseManagement = isAdmin || isInstructor;
+  const canManageCourses = isAdmin;
 
   const fetchData = useCallback(async () => {
     try {
@@ -38,7 +140,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         overrideData,
         swapsData,
       });
-      setCourses(courseData.sort((a, b) => a.id - b.id));
+      setCourses(courseData.sort(sortCoursesForDisplay));
       setOverrides(Array.isArray(overrideData) ? overrideData : []);
       setSwaps(swapsData);
       setError(null);
@@ -94,6 +196,128 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     );
   }, [courses, tenant?.settings, membership, currentUser.nickname]);
 
+  const coursesWithUpcoming = visibleCourses.filter((c) => getCourseDates(c).length > 0);
+  const coursesToRender = canSeeCourseManagement ? visibleCourses : coursesWithUpcoming;
+  const deleteTargetCourse = deleteTargetId
+    ? visibleCourses.find((course) => course.id === deleteTargetId)
+    : undefined;
+
+  const resetFormError = () => setFormError(null);
+
+  const openCreateModal = () => {
+    setCreateState({
+      name: "",
+      weekday: "Mon",
+      time: "18:00",
+      capacity: "10",
+      status: "draft",
+    });
+    resetFormError();
+    setCreateOpen(true);
+  };
+
+  const openEditModal = (course: Course) => {
+    setEditState(toEditorState(course));
+    resetFormError();
+    setEditOpen(true);
+  };
+
+  const openDeleteModal = (courseId: number) => {
+    setDeleteTargetId(courseId);
+    resetFormError();
+    setDeleteOpen(true);
+  };
+
+  const parseCapacity = (capacityText: string): number | null => {
+    const parsed = Number.parseInt(capacityText, 10);
+    if (!Number.isInteger(parsed) || parsed < 0) return null;
+    return parsed;
+  };
+
+  const saveCreateCourse = async () => {
+    if (!canManageCourses) return;
+    const trimmedName = createState.name.trim();
+    if (!trimmedName) {
+      setFormError("Bitte einen Kursnamen eingeben.");
+      return;
+    }
+    const capacity = parseCapacity(createState.capacity);
+    if (capacity == null) {
+      setFormError("Kapazität muss eine nicht-negative ganze Zahl sein.");
+      return;
+    }
+
+    setSaving(true);
+    setFormError(null);
+    try {
+      await createCourse({
+        name: trimmedName,
+        weekday: createState.weekday,
+        time: createState.time,
+        capacity,
+        status: createState.status,
+      });
+      setCreateOpen(false);
+      await fetchData();
+    } catch (err) {
+      console.error("Failed to create course", err);
+      setFormError("Kurs konnte nicht angelegt werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveEditCourse = async () => {
+    if (!canManageCourses || !editState) return;
+    const trimmedName = editState.name.trim();
+    if (!trimmedName) {
+      setFormError("Bitte einen Kursnamen eingeben.");
+      return;
+    }
+    const capacity = parseCapacity(editState.capacity);
+    if (capacity == null) {
+      setFormError("Kapazität muss eine nicht-negative ganze Zahl sein.");
+      return;
+    }
+
+    setSaving(true);
+    setFormError(null);
+    try {
+      await updateCourse(editState.id, {
+        name: trimmedName,
+        weekday: editState.weekday,
+        time: editState.time,
+        capacity,
+        status: editState.status,
+      });
+      setEditOpen(false);
+      setEditState(null);
+      await fetchData();
+    } catch (err) {
+      console.error("Failed to update course", err);
+      setFormError(err instanceof Error ? err.message : "Kurs konnte nicht gespeichert werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDeleteCourse = async () => {
+    if (!canManageCourses || !deleteTargetId) return;
+    setSaving(true);
+    setFormError(null);
+    try {
+      await deleteCourse(deleteTargetId);
+      setDeleteOpen(false);
+      setDeleteTargetId(null);
+      await fetchData();
+    } catch (err) {
+      console.error("Failed to delete course", err);
+      setFormError(err instanceof Error ? err.message : "Kurs konnte nicht gelöscht werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (loading) {
     return (
       <div role="status" aria-live="polite">
@@ -105,37 +329,306 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     return <div role="alert">{error}</div>;
   }
 
-  const coursesWithUpcoming = visibleCourses.filter((c) => getCourseDates(c).length > 0);
-  if (visibleCourses.length === 0 || coursesWithUpcoming.length === 0) {
+  if (visibleCourses.length === 0 || (!canSeeCourseManagement && coursesWithUpcoming.length === 0)) {
     return (
       <div className="muted" style={{ textAlign: "center", padding: "2rem" }} role="status" aria-live="polite">
-        Aktuell keine Termine zum Anzeigen. Es gibt nur vergangene Termine oder noch keine Kurse.
+        {canSeeCourseManagement
+          ? "Aktuell sind noch keine Kurse angelegt."
+          : "Aktuell keine Termine zum Anzeigen. Es gibt nur vergangene Termine oder noch keine Kurse."}
       </div>
     );
   }
 
   return (
     <>
+      {canSeeCourseManagement && (
+        <div className="course-management-toolbar">
+          <div className="course-management-title-group">
+            <h3 className="course-management-title">Kurse verwalten</h3>
+            {!canManageCourses && (
+              <span className="muted" style={{ fontSize: 12 }}>
+                Nur Admin kann Kurse anlegen, bearbeiten oder löschen.
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={openCreateModal}
+            disabled={!canManageCourses || saving}
+            title={canManageCourses ? "Neuen Kurs anlegen" : "Nur Admin kann Kurse anlegen"}
+            aria-label="Kurs anlegen"
+          >
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <Plus size={16} aria-hidden="true" />
+              Kurs
+            </span>
+          </button>
+        </div>
+      )}
+
       <div className="grid">
-        {visibleCourses.map((course) => {
+        {coursesToRender.map((course) => {
           const dates = getCourseDates(course);
           return (
-            <CourseCard
-              key={course.id}
-              course={course} 
-              allCourses={courses}
-              currentUser={currentUser}
-              dates={dates}
-              overrides={filteredOverrides}
-              swaps={swaps}
-              onToggleAbsence={onToggleAbsence}
-              confirmSwap={confirmSwap}
-              requestSwap={requestSwap}
-              cancelSwap={cancelSwap}
-            />
+            <div key={course.id}>
+              {canSeeCourseManagement && (
+                <div className="course-card-actions-row">
+                  <span className="course-card-actions-status">
+                    Status:{" "}
+                    <strong>
+                      {STATUS_OPTIONS.find((entry) => entry.value === (course.status ?? "active"))?.label ??
+                        "Aktiv"}
+                    </strong>
+                  </span>
+                  <div className="course-card-actions-buttons">
+                    <button
+                      type="button"
+                      title={canManageCourses ? "Kurs bearbeiten" : "Nur Admin kann Kurse bearbeiten"}
+                      aria-label={`Kurs bearbeiten ${course.name}`}
+                      disabled={!canManageCourses || saving}
+                      onClick={() => openEditModal(course)}
+                    >
+                      <Pencil size={14} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      title={canManageCourses ? "Kurs löschen" : "Nur Admin kann Kurse löschen"}
+                      aria-label={`Kurs löschen ${course.name}`}
+                      disabled={!canManageCourses || saving}
+                      onClick={() => openDeleteModal(course.id)}
+                    >
+                      <Trash2 size={14} aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+              )}
+              <CourseCard
+                course={course}
+                allCourses={courses}
+                currentUser={currentUser}
+                dates={dates}
+                overrides={filteredOverrides}
+                swaps={swaps}
+                onToggleAbsence={onToggleAbsence}
+                confirmSwap={confirmSwap}
+                requestSwap={requestSwap}
+                cancelSwap={cancelSwap}
+              />
+            </div>
           );
         })}
       </div>
+
+      {createOpen && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs anlegen">
+          <div className="modal modal-compact">
+            <h4>Kurs anlegen</h4>
+            <div className="dialog-stack">
+              <input
+                type="text"
+                aria-label="Kursname"
+                placeholder="Kursname"
+                value={createState.name}
+                onChange={(event) =>
+                  setCreateState((prev) => ({ ...prev, name: event.target.value }))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <select
+                aria-label="Wochentag"
+                value={createState.weekday}
+                onChange={(event) =>
+                  setCreateState((prev) => ({ ...prev, weekday: event.target.value }))
+                }
+                disabled={saving}
+                className="dialog-field"
+              >
+                {WEEKDAY_OPTIONS.map((weekday) => (
+                  <option key={weekday.value} value={weekday.value}>
+                    {weekday.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="time"
+                aria-label="Uhrzeit"
+                value={createState.time}
+                onChange={(event) =>
+                  setCreateState((prev) => ({ ...prev, time: event.target.value }))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <input
+                type="number"
+                aria-label="Kapazität"
+                min={0}
+                value={createState.capacity}
+                onChange={(event) =>
+                  setCreateState((prev) => ({ ...prev, capacity: event.target.value }))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <select
+                aria-label="Status"
+                value={createState.status}
+                onChange={(event) =>
+                  setCreateState((prev) => ({ ...prev, status: event.target.value as CourseStatus }))
+                }
+                disabled={saving}
+                className="dialog-field"
+              >
+                {STATUS_OPTIONS.map((status) => (
+                  <option key={status.value} value={status.value}>
+                    {status.label}
+                  </option>
+                ))}
+              </select>
+              {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+            </div>
+            <div className="modal-actions dialog-actions">
+              <button type="button" className="modal-action-btn" onClick={() => setCreateOpen(false)} disabled={saving}>
+                Abbrechen
+              </button>
+              <button type="button" className="btn-primary modal-action-btn" onClick={saveCreateCourse} disabled={saving}>
+                {saving ? "Speichere..." : "Anlegen"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {editOpen && editState && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs bearbeiten">
+          <div className="modal modal-compact">
+            <h4>Kurs bearbeiten</h4>
+            <p style={{ marginTop: 0, color: "#4b5563" }}>
+              Kurs-ID: <strong>{editState.id}</strong>
+            </p>
+            <div className="dialog-stack">
+              <input
+                type="text"
+                aria-label="Kursname bearbeiten"
+                value={editState.name}
+                onChange={(event) =>
+                  setEditState((prev) => (prev ? { ...prev, name: event.target.value } : prev))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <select
+                aria-label="Wochentag bearbeiten"
+                value={editState.weekday}
+                onChange={(event) =>
+                  setEditState((prev) => (prev ? { ...prev, weekday: event.target.value } : prev))
+                }
+                disabled={saving}
+                className="dialog-field"
+              >
+                {WEEKDAY_OPTIONS.map((weekday) => (
+                  <option key={weekday.value} value={weekday.value}>
+                    {weekday.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="time"
+                aria-label="Uhrzeit bearbeiten"
+                value={editState.time}
+                onChange={(event) =>
+                  setEditState((prev) => (prev ? { ...prev, time: event.target.value } : prev))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <input
+                type="number"
+                aria-label="Kapazität bearbeiten"
+                min={0}
+                value={editState.capacity}
+                onChange={(event) =>
+                  setEditState((prev) => (prev ? { ...prev, capacity: event.target.value } : prev))
+                }
+                disabled={saving}
+                className="dialog-field"
+              />
+              <select
+                aria-label="Status bearbeiten"
+                value={editState.status}
+                onChange={(event) =>
+                  setEditState((prev) =>
+                    prev ? { ...prev, status: event.target.value as CourseStatus } : prev,
+                  )
+                }
+                disabled={saving}
+                className="dialog-field"
+              >
+                {STATUS_OPTIONS.map((status) => (
+                  <option key={status.value} value={status.value}>
+                    {status.label}
+                  </option>
+                ))}
+              </select>
+              {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+            </div>
+            <div className="modal-actions dialog-actions">
+              <button
+                type="button"
+                className="modal-action-btn"
+                onClick={() => {
+                  setEditOpen(false);
+                  setEditState(null);
+                }}
+                disabled={saving}
+              >
+                Abbrechen
+              </button>
+              <button type="button" className="btn-primary modal-action-btn" onClick={saveEditCourse} disabled={saving}>
+                {saving ? "Speichere..." : "Speichern"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteOpen && deleteTargetCourse && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs löschen">
+          <div className="modal modal-compact">
+            <h4>Kurs löschen</h4>
+            <p style={{ marginTop: 0, color: "#4b5563" }}>
+              Kurs <strong>{deleteTargetCourse.name}</strong> wirklich löschen?
+            </p>
+            <p style={{ marginTop: 0, color: "#6b7280", fontSize: 14 }}>
+              Löschen ist nur möglich, wenn der Kurs inaktiv ist und keine offenen Termin-/Tauschbezüge
+              mehr bestehen.
+            </p>
+            {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="modal-action-btn"
+                onClick={() => {
+                  setDeleteOpen(false);
+                  setDeleteTargetId(null);
+                }}
+                disabled={saving}
+              >
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                className="btn-primary modal-action-btn"
+                onClick={confirmDeleteCourse}
+                disabled={saving}
+              >
+                {saving ? "Lösche..." : "Löschen"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -87,6 +87,19 @@ const FOCUSABLE_SELECTOR = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(", ");
 
+function getFocusableElements(node: HTMLElement): HTMLElement[] {
+  return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+function focusFirstElement(node: HTMLElement): void {
+  const focusables = getFocusableElements(node);
+  if (focusables.length > 0) {
+    focusables[0].focus();
+    return;
+  }
+  node.focus();
+}
+
 function sortCoursesForDisplay(a: Course, b: Course): number {
   const weekdayA = WEEKDAY_ORDER[a.weekday] ?? 99;
   const weekdayB = WEEKDAY_ORDER[b.weekday] ?? 99;
@@ -301,31 +314,26 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     if (event.key !== "Tab") return;
     const modalNode = modalRef.current;
     if (!modalNode) return;
+    event.preventDefault();
 
-    const focusables = Array.from(modalNode.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const focusables = getFocusableElements(modalNode);
     if (focusables.length === 0) {
-      event.preventDefault();
       modalNode.focus();
       return;
     }
 
-    const first = focusables[0];
-    const last = focusables[focusables.length - 1];
     const active = document.activeElement as HTMLElement | null;
+    const currentIndex = active ? focusables.indexOf(active) : -1;
 
-    if (!active || !modalNode.contains(active)) {
-      event.preventDefault();
-      first.focus();
+    if (currentIndex === -1) {
+      focusables[0].focus();
       return;
     }
 
-    if (!event.shiftKey && active === last) {
-      event.preventDefault();
-      first.focus();
-    } else if (event.shiftKey && active === first) {
-      event.preventDefault();
-      last.focus();
-    }
+    const nextIndex = event.shiftKey
+      ? (currentIndex - 1 + focusables.length) % focusables.length
+      : (currentIndex + 1) % focusables.length;
+    focusables[nextIndex].focus();
   };
 
   const createNameValid = createState.name.trim().length > 0;
@@ -358,12 +366,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       : null;
     if (!activeModal) return;
 
-    const firstFocusable = activeModal.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-    if (firstFocusable) {
-      firstFocusable.focus();
-      return;
-    }
-    activeModal.focus();
+    focusFirstElement(activeModal);
   }, [createOpen, editOpen, deleteOpen, membersTargetId, datesTargetId]);
 
   useEffect(() => {

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -1,6 +1,6 @@
 import CourseCard from "./CourseCard";
 import { useCourseSwaps } from "./useCourseSwaps";
-import { useEffect, useState, useMemo, useCallback } from "react";
+import { useEffect, useState, useMemo, useCallback, useRef, type KeyboardEvent, type RefObject } from "react";
 import { Plus, Pencil, Trash2 } from "lucide-react";
 import {
   Course,
@@ -78,6 +78,15 @@ const STATUS_OPTIONS: Array<{ value: CourseStatus; label: string }> = [
   { value: "active", label: "Aktiv" },
 ];
 
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[href]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
 function sortCoursesForDisplay(a: Course, b: Course): number {
   const weekdayA = WEEKDAY_ORDER[a.weekday] ?? 99;
   const weekdayB = WEEKDAY_ORDER[b.weekday] ?? 99;
@@ -116,7 +125,11 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     status: "draft",
   });
   const [editState, setEditState] = useState<CourseEditorState | null>(null);
+  const [editInitialState, setEditInitialState] = useState<CourseEditorState | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const createModalRef = useRef<HTMLDivElement | null>(null);
+  const editModalRef = useRef<HTMLDivElement | null>(null);
+  const deleteModalRef = useRef<HTMLDivElement | null>(null);
 
   const isAdmin = membership?.role === "admin";
   const isInstructor = membership?.role === "instructor";
@@ -217,7 +230,9 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
   };
 
   const openEditModal = (course: Course) => {
-    setEditState(toEditorState(course));
+    const next = toEditorState(course);
+    setEditState(next);
+    setEditInitialState(next);
     resetFormError();
     setEditOpen(true);
   };
@@ -233,6 +248,112 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     if (!Number.isInteger(parsed) || parsed < 0) return null;
     return parsed;
   };
+
+  const closeCreateModal = () => {
+    if (saving) return;
+    setCreateOpen(false);
+  };
+
+  const closeEditModal = () => {
+    if (saving) return;
+    setEditOpen(false);
+    setEditState(null);
+    setEditInitialState(null);
+  };
+
+  const closeDeleteModal = () => {
+    if (saving) return;
+    setDeleteOpen(false);
+    setDeleteTargetId(null);
+  };
+
+  const handleFocusTrap = (event: KeyboardEvent<HTMLDivElement>, modalRef: RefObject<HTMLDivElement | null>) => {
+    if (event.key !== "Tab") return;
+    const modalNode = modalRef.current;
+    if (!modalNode) return;
+
+    const focusables = Array.from(modalNode.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    if (focusables.length === 0) {
+      event.preventDefault();
+      modalNode.focus();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (!active || !modalNode.contains(active)) {
+      event.preventDefault();
+      first.focus();
+      return;
+    }
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    }
+  };
+
+  const createNameValid = createState.name.trim().length > 0;
+  const createCapacityValid = parseCapacity(createState.capacity) != null;
+  const canSubmitCreate = canManageCourses && !saving && createNameValid && createCapacityValid;
+
+  const editNameValid = (editState?.name.trim().length ?? 0) > 0;
+  const editCapacityValid = editState ? parseCapacity(editState.capacity) != null : false;
+  const editChanged =
+    !!editState &&
+    !!editInitialState &&
+    (editState.name !== editInitialState.name ||
+      editState.weekday !== editInitialState.weekday ||
+      editState.time !== editInitialState.time ||
+      editState.capacity !== editInitialState.capacity ||
+      editState.status !== editInitialState.status);
+  const canSubmitEdit = canManageCourses && !saving && !!editState && editNameValid && editCapacityValid && editChanged;
+
+  useEffect(() => {
+    const activeModal = createOpen
+      ? createModalRef.current
+      : editOpen
+      ? editModalRef.current
+      : deleteOpen
+      ? deleteModalRef.current
+      : null;
+    if (!activeModal) return;
+
+    const firstFocusable = activeModal.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (firstFocusable) {
+      firstFocusable.focus();
+      return;
+    }
+    activeModal.focus();
+  }, [createOpen, editOpen, deleteOpen]);
+
+  useEffect(() => {
+    if (!createOpen && !editOpen && !deleteOpen) return;
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (saving) return;
+      event.preventDefault();
+      if (deleteOpen) {
+        setDeleteOpen(false);
+        setDeleteTargetId(null);
+      } else if (editOpen) {
+        setEditOpen(false);
+        setEditState(null);
+        setEditInitialState(null);
+      } else if (createOpen) {
+        setCreateOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [createOpen, editOpen, deleteOpen, saving]);
 
   const saveCreateCourse = async () => {
     if (!canManageCourses) return;
@@ -257,7 +378,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         capacity,
         status: createState.status,
       });
-      setCreateOpen(false);
+      closeCreateModal();
       await fetchData();
     } catch (err) {
       console.error("Failed to create course", err);
@@ -268,7 +389,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
   };
 
   const saveEditCourse = async () => {
-    if (!canManageCourses || !editState) return;
+    if (!canManageCourses || !editState || !editChanged) return;
     const trimmedName = editState.name.trim();
     if (!trimmedName) {
       setFormError("Bitte einen Kursnamen eingeben.");
@@ -290,8 +411,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         capacity,
         status: editState.status,
       });
-      setEditOpen(false);
-      setEditState(null);
+      closeEditModal();
       await fetchData();
     } catch (err) {
       console.error("Failed to update course", err);
@@ -307,8 +427,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     setFormError(null);
     try {
       await deleteCourse(deleteTargetId);
-      setDeleteOpen(false);
-      setDeleteTargetId(null);
+      closeDeleteModal();
       await fetchData();
     } catch (err) {
       console.error("Failed to delete course", err);
@@ -420,9 +539,24 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       </div>
 
       {createOpen && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs anlegen">
-          <div className="modal modal-compact">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kurs anlegen"
+          onKeyDown={(event) => {
+            handleFocusTrap(event, createModalRef);
+            if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
+              event.preventDefault();
+              saveCreateCourse();
+            }
+          }}
+        >
+          <div className="modal modal-compact" ref={createModalRef} tabIndex={-1}>
             <h4>Kurs anlegen</h4>
+            <p className="course-editor-note">
+              Stammdaten jetzt anlegen. Mitglieder-Zuordnung und Terminplanung folgen als eigene Schritte.
+            </p>
             <div className="dialog-stack">
               <input
                 type="text"
@@ -489,10 +623,15 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
               {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
             </div>
             <div className="modal-actions dialog-actions">
-              <button type="button" className="modal-action-btn" onClick={() => setCreateOpen(false)} disabled={saving}>
+              <button type="button" className="modal-action-btn" onClick={closeCreateModal} disabled={saving}>
                 Abbrechen
               </button>
-              <button type="button" className="btn-primary modal-action-btn" onClick={saveCreateCourse} disabled={saving}>
+              <button
+                type="button"
+                className="btn-primary modal-action-btn"
+                onClick={saveCreateCourse}
+                disabled={!canSubmitCreate}
+              >
                 {saving ? "Speichere..." : "Anlegen"}
               </button>
             </div>
@@ -501,11 +640,23 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       )}
 
       {editOpen && editState && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs bearbeiten">
-          <div className="modal modal-compact">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kurs bearbeiten"
+          onKeyDown={(event) => {
+            handleFocusTrap(event, editModalRef);
+            if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
+              event.preventDefault();
+              saveEditCourse();
+            }
+          }}
+        >
+          <div className="modal modal-compact" ref={editModalRef} tabIndex={-1}>
             <h4>Kurs bearbeiten</h4>
-            <p style={{ marginTop: 0, color: "#4b5563" }}>
-              Kurs-ID: <strong>{editState.id}</strong>
+            <p className="course-editor-note" style={{ marginTop: 0 }}>
+              Stammdaten bearbeiten. Mitglieder und Termine werden im nächsten Schritt hier ergänzt.
             </p>
             <div className="dialog-stack">
               <input
@@ -577,15 +728,17 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
               <button
                 type="button"
                 className="modal-action-btn"
-                onClick={() => {
-                  setEditOpen(false);
-                  setEditState(null);
-                }}
+                onClick={closeEditModal}
                 disabled={saving}
               >
                 Abbrechen
               </button>
-              <button type="button" className="btn-primary modal-action-btn" onClick={saveEditCourse} disabled={saving}>
+              <button
+                type="button"
+                className="btn-primary modal-action-btn"
+                onClick={saveEditCourse}
+                disabled={!canSubmitEdit}
+              >
                 {saving ? "Speichere..." : "Speichern"}
               </button>
             </div>
@@ -594,8 +747,20 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       )}
 
       {deleteOpen && deleteTargetCourse && (
-        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs löschen">
-          <div className="modal modal-compact">
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kurs löschen"
+          onKeyDown={(event) => {
+            handleFocusTrap(event, deleteModalRef);
+            if (event.key === "Enter") {
+              event.preventDefault();
+              confirmDeleteCourse();
+            }
+          }}
+        >
+          <div className="modal modal-compact" ref={deleteModalRef} tabIndex={-1}>
             <h4>Kurs löschen</h4>
             <p style={{ marginTop: 0, color: "#4b5563" }}>
               Kurs <strong>{deleteTargetCourse.name}</strong> wirklich löschen?
@@ -609,10 +774,7 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
               <button
                 type="button"
                 className="modal-action-btn"
-                onClick={() => {
-                  setDeleteOpen(false);
-                  setDeleteTargetId(null);
-                }}
+                onClick={closeDeleteModal}
                 disabled={saving}
               >
                 Abbrechen


### PR DESCRIPTION
## Summary
- erweitert `CourseList` um einen vollständigen Kurs-Editor-Flow mit Admin-Aktionen für Anlegen, Bearbeiten und Löschen sowie Statusanzeige pro Kurs.
- ergänzt separate Dialog-Grundlagen für Mitglieder- und Terminverwaltung (als nächste Ausbaustufe), inklusive konsistenter Rollen-Disabled-States für Trainer.
- verbessert A11y/Keyboard-Bedienung in allen Kurs-Dialogen (Initialfokus, Tab-Zyklus im Modal, `Escape`-Schließen) und ergänzt die entsprechenden Component-Tests.

## Test plan
- [x] `npm run test --prefix app`
- [x] Manuell: Kurs anlegen/bearbeiten/löschen als Admin im Browser prüfen
- [x] Manuell: Disabled-Aktionen als Trainer prüfen (inkl. Tooltips)
- [x] Manuell: Tastatur-Flow in allen Kurs-Dialogen prüfen (`Tab`/`Shift+Tab`, `Escape`, Enter-Verhalten)

Made with [Cursor](https://cursor.com)