### PR TITLE
#129 Guardrails for stale exceptions and lifecycle

### DIFF
--- a/backend/src/lambdas/createCourse/index.test.ts
+++ b/backend/src/lambdas/createCourse/index.test.ts
@@ -217,4 +217,44 @@ describe("createCourse Lambda", () => {
     expect(body.visibleDates).toContain("2026-02-04");
     expect(body.visibleDates).not.toContain("2026-02-02");
   });
+
+  test("prunes bounded exceptions and auto-downgrades active course without future dates", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        name: "Archiv Block",
+        weekday: "Mon",
+        time: "18:00",
+        capacity: 12,
+        status: "active",
+        planningMode: "bounded_series",
+        visibilityMode: "fixed_window",
+        seriesStartDate: "2020-01-01",
+        seriesEndDate: "2020-01-31",
+        visibleFrom: "2020-01-01",
+        visibleUntil: "2020-01-31",
+        excludedDates: ["2019-12-01", "2020-01-13", "2020-03-01"],
+        includedDates: ["2019-12-31", "2020-01-15", "2020-04-01"],
+      }),
+    );
+
+    expect(result.statusCode).toBe(201);
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          status: { S: "inactive" },
+          excludedDates: { L: [{ S: "2020-01-13" }] },
+          includedDates: { L: [{ S: "2020-01-15" }] },
+        }),
+      }),
+    );
+    const body = JSON.parse(result.body);
+    expect(body.status).toBe("inactive");
+    expect(body.excludedDates).toEqual(["2020-01-13"]);
+    expect(body.includedDates).toEqual(["2020-01-15"]);
+  });
 });

--- a/backend/src/lambdas/createCourse/index.ts
+++ b/backend/src/lambdas/createCourse/index.ts
@@ -2,7 +2,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { GetItemCommand, PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
-import { deriveVisibleDates } from "../shared/courseDates";
+import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
@@ -93,8 +93,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     typeof body.visibleUntil === "string" ? body.visibleUntil.trim() : undefined;
   const visibilityHorizonWeeks =
     Number.isFinite(body.visibilityHorizonWeeks) ? Number(body.visibilityHorizonWeeks) : undefined;
-  const excludedDates = normalizeDateListInput(body.excludedDates);
-  const includedDates = normalizeDateListInput(body.includedDates);
+  const excludedDatesInput = normalizeDateListInput(body.excludedDates);
+  const includedDatesInput = normalizeDateListInput(body.includedDates);
   const capacity = Number.isFinite(body.capacity) ? Number(body.capacity) : NaN;
 
   if (!name) {
@@ -145,7 +145,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }),
     };
   }
-  if (!excludedDates || !includedDates) {
+  if (!excludedDatesInput || !includedDatesInput) {
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "excludedDates/includedDates must contain ISO dates (YYYY-MM-DD)" }),
@@ -167,6 +167,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     if (actorRole !== "admin") {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
     }
+
+    const prunedExceptions = pruneScheduleExceptions({
+      planningMode,
+      seriesStartDate,
+      seriesEndDate,
+      visibilityHorizonWeeks,
+      excludedDates: excludedDatesInput,
+      includedDates: includedDatesInput,
+    });
+    const excludedDates = prunedExceptions.excludedDates;
+    const includedDates = prunedExceptions.includedDates;
 
     const coursesResp = await client.send(
       new QueryCommand({
@@ -198,6 +209,24 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       includedDates,
       fallbackDates: [],
     });
+    const todayIso = new Date().toISOString().slice(0, 10);
+    const hasFutureVisibleDates = visibleDates.some((entry) => entry >= todayIso);
+    const effectiveStatus =
+      status === "active" && planningMode === "bounded_series" && !hasFutureVisibleDates
+        ? "inactive"
+        : status;
+    if (effectiveStatus !== status) {
+      console.info(
+        JSON.stringify({
+          actor: "system",
+          timestamp: new Date().toISOString(),
+          courseId: nextCourseId,
+          reason: "empty_future_schedule",
+          previousStatus: status,
+          nextStatus: effectiveStatus,
+        }),
+      );
+    }
 
     const item: Record<string, any> = {
       tenantId: { S: tenantId },
@@ -207,7 +236,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       weekday: { S: weekday },
       time: { S: time },
       capacity: { N: String(capacity) },
-      status: { S: status },
+      status: { S: effectiveStatus },
       participants: { L: [] },
       dates: { L: visibleDates.map((entry) => ({ S: entry })) },
     };
@@ -244,7 +273,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         weekday,
         time,
         capacity,
-        status,
+        status: effectiveStatus,
         planningMode,
         visibilityMode,
         seriesStartDate,

--- a/backend/src/lambdas/shared/courseDates.ts
+++ b/backend/src/lambdas/shared/courseDates.ts
@@ -81,6 +81,71 @@ export type DeriveVisibleDatesInput = {
   now?: Date;
 };
 
+type PruneScheduleExceptionsInput = {
+  planningMode?: string;
+  seriesStartDate?: string;
+  seriesEndDate?: string;
+  visibilityHorizonWeeks?: number;
+  excludedDates: string[];
+  includedDates: string[];
+  now?: Date;
+};
+
+type PruneScheduleExceptionsResult = {
+  excludedDates: string[];
+  includedDates: string[];
+  windowStart?: string;
+  windowEnd?: string;
+};
+
+const ROLLING_PRUNE_PAST_DAYS = 14;
+
+function inWindow(date: string, start: string, end: string): boolean {
+  return date >= start && date <= end;
+}
+
+export function pruneScheduleExceptions(input: PruneScheduleExceptionsInput): PruneScheduleExceptionsResult {
+  const now = input.now ?? new Date();
+  const normalizedExcluded = normalizeDateList(input.excludedDates);
+  const normalizedIncluded = normalizeDateList(input.includedDates);
+
+  if (input.planningMode === "bounded_series") {
+    const seriesStart = parseDateOnlyUtc(input.seriesStartDate);
+    const seriesEnd = parseDateOnlyUtc(input.seriesEndDate);
+    if (!seriesStart || !seriesEnd) {
+      return {
+        excludedDates: normalizedExcluded,
+        includedDates: normalizedIncluded,
+      };
+    }
+    const start = toDateOnlyUtc(seriesStart);
+    const end = toDateOnlyUtc(seriesEnd);
+    return {
+      excludedDates: normalizedExcluded.filter((entry) => inWindow(entry, start, end)),
+      includedDates: normalizedIncluded.filter((entry) => inWindow(entry, start, end)),
+      windowStart: start,
+      windowEnd: end,
+    };
+  }
+
+  if (input.planningMode === "rolling_continuous") {
+    const todayUtc = startOfTodayUtc(now);
+    const start = toDateOnlyUtc(addDaysUtc(todayUtc, -ROLLING_PRUNE_PAST_DAYS));
+    return {
+      // Rolling courses may be planned far in advance (holidays, public holidays).
+      // Therefore we only prune stale past exceptions and keep all future entries.
+      excludedDates: normalizedExcluded.filter((entry) => entry >= start),
+      includedDates: normalizedIncluded.filter((entry) => entry >= start),
+      windowStart: start,
+    };
+  }
+
+  return {
+    excludedDates: normalizedExcluded,
+    includedDates: normalizedIncluded,
+  };
+}
+
 export function deriveVisibleDates(input: DeriveVisibleDatesInput): string[] {
   const fallbackDates = normalizeDateList(input.fallbackDates);
   const planningMode = input.planningMode;

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -211,6 +211,10 @@ describe("updateCourse Lambda", () => {
   });
 
   test("updates scheduling model fields", async () => {
+    const allowed = new Date();
+    allowed.setDate(allowed.getDate() + 50);
+    const allowedIso = allowed.toISOString().slice(0, 10);
+
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
@@ -221,7 +225,7 @@ describe("updateCourse Lambda", () => {
         planningMode: "rolling_continuous",
         visibilityMode: "rolling_horizon",
         visibilityHorizonWeeks: 10,
-        excludedDates: ["2026-04-06"],
+        excludedDates: [allowedIso],
         includedDates: [],
       }),
     );
@@ -233,7 +237,7 @@ describe("updateCourse Lambda", () => {
           planningMode: { S: "rolling_continuous" },
           visibilityMode: { S: "rolling_horizon" },
           visibilityHorizonWeeks: { N: "10" },
-          excludedDates: { L: [{ S: "2026-04-06" }] },
+          excludedDates: { L: [{ S: allowedIso }] },
         }),
       }),
     );
@@ -244,7 +248,7 @@ describe("updateCourse Lambda", () => {
         planningMode: "rolling_continuous",
         visibilityMode: "rolling_horizon",
         visibilityHorizonWeeks: 10,
-        excludedDates: ["2026-04-06"],
+        excludedDates: [allowedIso],
       }),
     );
   });
@@ -286,5 +290,101 @@ describe("updateCourse Lambda", () => {
     );
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).error).toMatch(/visibleFrom and visibleUntil/);
+  });
+
+  test("prunes out-of-window exceptions for bounded_series", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        excludedDates: ["2025-12-29", "2026-02-02", "2026-04-06"],
+        includedDates: ["2025-12-31", "2026-02-04", "2026-05-01"],
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          excludedDates: { L: [{ S: "2026-02-02" }] },
+          includedDates: { L: [{ S: "2026-02-04" }] },
+        }),
+      }),
+    );
+    const body = JSON.parse(result.body);
+    expect(body.excludedDates).toEqual(["2026-02-02"]);
+    expect(body.includedDates).toEqual(["2026-02-04"]);
+  });
+
+  test("keeps far-future exceptions for rolling_continuous and prunes only stale past", async () => {
+    const farFuture = new Date();
+    farFuture.setDate(farFuture.getDate() + 240);
+    const farFutureIso = farFuture.toISOString().slice(0, 10);
+    const stalePast = new Date();
+    stalePast.setDate(stalePast.getDate() - 40);
+    const stalePastIso = stalePast.toISOString().slice(0, 10);
+
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("draft"),
+          planningMode: { S: "rolling_continuous" },
+          visibilityMode: { S: "rolling_horizon" },
+          visibilityHorizonWeeks: { N: "10" },
+          excludedDates: { L: [] },
+          includedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        planningMode: "rolling_continuous",
+        visibilityMode: "rolling_horizon",
+        visibilityHorizonWeeks: 10,
+        excludedDates: [stalePastIso, farFutureIso],
+        includedDates: [],
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          excludedDates: { L: [{ S: farFutureIso }] },
+        }),
+      }),
+    );
+    expect(JSON.parse(result.body).excludedDates).toEqual([farFutureIso]);
+  });
+
+  test("auto-sets active bounded_series to inactive when no future visible dates remain", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          seriesStartDate: { S: "2020-01-01" },
+          seriesEndDate: { S: "2020-01-31" },
+          visibleFrom: { S: "2020-01-01" },
+          visibleUntil: { S: "2020-01-31" },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent({ name: "Vergangener Kursblock" }));
+    expect(result.statusCode).toBe(200);
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          status: { S: "inactive" },
+        }),
+      }),
+    );
+    expect(JSON.parse(result.body).status).toBe("inactive");
   });
 });

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
-import { deriveVisibleDates } from "../shared/courseDates";
+import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
@@ -392,10 +392,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const nextVisibilityHorizonWeeks =
       visibilityHorizonWeeks ??
       (item.visibilityHorizonWeeks?.N ? Number.parseInt(item.visibilityHorizonWeeks.N, 10) : undefined);
-    const nextExcludedDates =
+    const nextExcludedDatesRaw =
       excludedDates ?? (item.excludedDates?.L?.map((entry) => entry.S ?? "").filter(Boolean) ?? []);
-    const nextIncludedDates =
+    const nextIncludedDatesRaw =
       includedDates ?? (item.includedDates?.L?.map((entry) => entry.S ?? "").filter(Boolean) ?? []);
+    const prunedExceptions = pruneScheduleExceptions({
+      planningMode: nextPlanningMode,
+      seriesStartDate: nextSeriesStartDate,
+      seriesEndDate: nextSeriesEndDate,
+      visibilityHorizonWeeks: nextVisibilityHorizonWeeks,
+      excludedDates: nextExcludedDatesRaw,
+      includedDates: nextIncludedDatesRaw,
+    });
+    const nextExcludedDates = prunedExceptions.excludedDates;
+    const nextIncludedDates = prunedExceptions.includedDates;
     const currentExcludedDates =
       item.excludedDates?.L?.map((entry) => entry.S ?? "").filter(Boolean) ?? [];
 
@@ -467,6 +477,41 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       includedDates: nextIncludedDates,
       fallbackDates: item.dates?.L?.map((entry) => entry.S ?? "").filter(Boolean) ?? [],
     });
+    const todayIso = new Date().toISOString().slice(0, 10);
+    const hasFutureVisibleDates = nextDates.some((entry) => entry >= todayIso);
+    let effectiveStatus = nextStatus;
+    if (effectiveStatus === "active" && nextPlanningMode === "bounded_series" && !hasFutureVisibleDates) {
+      effectiveStatus = "inactive";
+      console.info(
+        JSON.stringify({
+          actor: "system",
+          timestamp: new Date().toISOString(),
+          courseId,
+          reason: "empty_future_schedule",
+          previousStatus: nextStatus,
+          nextStatus: effectiveStatus,
+        }),
+      );
+    }
+
+    if (
+      nextExcludedDates.length !== nextExcludedDatesRaw.length ||
+      nextIncludedDates.length !== nextIncludedDatesRaw.length
+    ) {
+      console.info(
+        JSON.stringify({
+          actor: actorUserId,
+          timestamp: new Date().toISOString(),
+          courseId,
+          reason: "schedule_exceptions_pruned",
+          planningMode: nextPlanningMode,
+          windowStart: prunedExceptions.windowStart,
+          windowEnd: prunedExceptions.windowEnd,
+          removedExcluded: nextExcludedDatesRaw.length - nextExcludedDates.length,
+          removedIncluded: nextIncludedDatesRaw.length - nextIncludedDates.length,
+        }),
+      );
+    }
 
     const updateItem: Record<string, any> = {
       tenantId: { S: tenantId },
@@ -476,7 +521,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       weekday: { S: nextWeekday },
       time: { S: nextTime },
       capacity: { N: String(nextCapacity) },
-      status: { S: nextStatus },
+      status: { S: effectiveStatus },
       participants: { L: nextParticipants },
       dates: { L: nextDates.map((entry) => ({ S: entry })) },
     };
@@ -512,7 +557,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         weekday: nextWeekday,
         time: nextTime,
         capacity: nextCapacity,
-        status: nextStatus,
+        status: effectiveStatus,
         planningMode: nextPlanningMode,
         visibilityMode: nextVisibilityMode,
         seriesStartDate: nextSeriesStartDate,


### PR DESCRIPTION
## Summary
- add centralized server-side pruning for schedule exceptions in `shared/courseDates` and apply it in both `createCourse` and `updateCourse`
- keep `bounded_series` exceptions strictly within series range, while `rolling_continuous` only prunes stale past entries and keeps far-future exceptions for holiday planning
- add lifecycle guardrail to auto-set `active` bounded-series courses to `inactive` when no future visible dates remain, with CloudWatch audit-trace logs
- extend backend tests for pruning behavior, rolling far-future retention, and automatic status downgrade

## Test plan
- [x] `npm run test --prefix backend -- --runInBand src/lambdas/updateCourse/index.test.ts src/lambdas/createCourse/index.test.ts`

## Notes
- aligns with updated scope in issue #129 (write-flow only, no `getCourses` side effects)
- audit trace remains CloudWatch-only for MVP (no separate audit store)

Made with [Cursor](https://cursor.com)