### PR TITLE
#134 Extract course dialogs from CourseList

### DIFF
--- a/app/src/components/CourseCreateDialog.tsx
+++ b/app/src/components/CourseCreateDialog.tsx
@@ -1,0 +1,144 @@
+import type { KeyboardEvent, RefObject } from "react";
+import type { CoursePlanningMode, CourseStatus } from "shared/types";
+
+type CourseCreateState = {
+  name: string;
+  weekday: string;
+  time: string;
+  capacity: string;
+  status: CourseStatus;
+  planningMode: CoursePlanningMode;
+};
+
+type WeekdayOption = { value: string; label: string };
+type StatusOption = { value: CourseStatus; label: string };
+type PlanningModeOption = { value: CoursePlanningMode; label: string };
+
+type CourseCreateDialogProps = {
+  open: boolean;
+  saving: boolean;
+  formError: string | null;
+  state: CourseCreateState;
+  canSubmit: boolean;
+  modalRef: RefObject<HTMLDivElement | null>;
+  weekdayOptions: readonly WeekdayOption[];
+  statusOptions: readonly StatusOption[];
+  planningModeOptions: readonly PlanningModeOption[];
+  planningModeHint: (mode: CoursePlanningMode) => string;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onClose: () => void;
+  onSave: () => void;
+  onChange: (next: CourseCreateState) => void;
+};
+
+export default function CourseCreateDialog({
+  open,
+  saving,
+  formError,
+  state,
+  canSubmit,
+  modalRef,
+  weekdayOptions,
+  statusOptions,
+  planningModeOptions,
+  planningModeHint,
+  onKeyDown,
+  onClose,
+  onSave,
+  onChange,
+}: CourseCreateDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs anlegen" onKeyDown={onKeyDown}>
+      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
+        <h4>Kurs anlegen</h4>
+        <p className="course-editor-note">
+          Stammdaten jetzt anlegen. Mitglieder-Zuordnung und Terminplanung folgen als eigene Schritte.
+        </p>
+        <div className="dialog-stack">
+          <input
+            type="text"
+            aria-label="Kursname"
+            placeholder="Kursname"
+            value={state.name}
+            onChange={(event) => onChange({ ...state, name: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <select
+            aria-label="Wochentag"
+            value={state.weekday}
+            onChange={(event) => onChange({ ...state, weekday: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          >
+            {weekdayOptions.map((weekday) => (
+              <option key={weekday.value} value={weekday.value}>
+                {weekday.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="time"
+            aria-label="Uhrzeit"
+            value={state.time}
+            onChange={(event) => onChange({ ...state, time: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <input
+            type="number"
+            aria-label="Kapazität"
+            min={0}
+            value={state.capacity}
+            onChange={(event) => onChange({ ...state, capacity: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <select
+            aria-label="Status"
+            value={state.status}
+            onChange={(event) => onChange({ ...state, status: event.target.value as CourseStatus })}
+            disabled={saving}
+            className="dialog-field"
+          >
+            {statusOptions.map((status) => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Planungsmodus"
+            value={state.planningMode}
+            onChange={(event) =>
+              onChange({
+                ...state,
+                planningMode: event.target.value as CoursePlanningMode,
+              })
+            }
+            disabled={saving}
+            className="dialog-field"
+          >
+            {planningModeOptions.map((mode) => (
+              <option key={mode.value} value={mode.value}>
+                {mode.label}
+              </option>
+            ))}
+          </select>
+          <p className="course-editor-inline-hint">{planningModeHint(state.planningMode)}</p>
+          {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+        </div>
+        <div className="modal-actions dialog-actions">
+          <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
+            Abbrechen
+          </button>
+          <button type="button" className="btn-primary modal-action-btn" onClick={onSave} disabled={!canSubmit}>
+            {saving ? "Speichere..." : "Anlegen"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/CourseCreateDialog.tsx
+++ b/app/src/components/CourseCreateDialog.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, RefObject } from "react";
 import type { CoursePlanningMode, CourseStatus } from "shared/types";
+import CourseModalFrame from "./CourseModalFrame";
 
 type CourseCreateState = {
   name: string;
@@ -50,9 +51,7 @@ export default function CourseCreateDialog({
   if (!open) return null;
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs anlegen" onKeyDown={onKeyDown}>
-      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
-        <h4>Kurs anlegen</h4>
+    <CourseModalFrame ariaLabel="Kurs anlegen" title="Kurs anlegen" modalRef={modalRef} onKeyDown={onKeyDown}>
         <p className="course-editor-note">
           Stammdaten jetzt anlegen. Mitglieder-Zuordnung und Terminplanung folgen als eigene Schritte.
         </p>
@@ -138,7 +137,6 @@ export default function CourseCreateDialog({
             {saving ? "Speichere..." : "Anlegen"}
           </button>
         </div>
-      </div>
-    </div>
+    </CourseModalFrame>
   );
 }

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObjec
 import { Calendar } from "lucide-react";
 import type { Course } from "shared/types";
 import { updateCourse } from "../api/courses";
+import CourseModalFrame from "./CourseModalFrame";
 import {
   DEFAULT_ROLLING_HORIZON_WEEKS,
   DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS,
@@ -424,17 +425,14 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
   if (!course || !datesState) return null;
 
   return (
-    <div
-      className="modal-backdrop"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Kurstermine bearbeiten"
+    <CourseModalFrame
+      ariaLabel="Kurstermine bearbeiten"
+      title="Termine verwalten"
+      modalRef={modalRef}
       onKeyDown={(event) => {
         handleFocusTrap(event, modalRef);
       }}
     >
-      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
-        <h4>Termine verwalten</h4>
         <p className="course-editor-note">
           Kurs: <strong>{course.name}</strong>
         </p>
@@ -717,7 +715,6 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
             </>
           )}
         </div>
-      </div>
-    </div>
+    </CourseModalFrame>
   );
 }

--- a/app/src/components/CourseDeleteDialog.tsx
+++ b/app/src/components/CourseDeleteDialog.tsx
@@ -1,0 +1,49 @@
+import type { KeyboardEvent, RefObject } from "react";
+
+type CourseDeleteDialogProps = {
+  open: boolean;
+  saving: boolean;
+  formError: string | null;
+  courseName?: string;
+  modalRef: RefObject<HTMLDivElement | null>;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onClose: () => void;
+  onConfirmDelete: () => void;
+};
+
+export default function CourseDeleteDialog({
+  open,
+  saving,
+  formError,
+  courseName,
+  modalRef,
+  onKeyDown,
+  onClose,
+  onConfirmDelete,
+}: CourseDeleteDialogProps) {
+  if (!open || !courseName) return null;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs löschen" onKeyDown={onKeyDown}>
+      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
+        <h4>Kurs löschen</h4>
+        <p style={{ marginTop: 0, color: "#4b5563" }}>
+          Kurs <strong>{courseName}</strong> wirklich löschen?
+        </p>
+        <p style={{ marginTop: 0, color: "#6b7280", fontSize: 14 }}>
+          Löschen ist nur möglich, wenn der Kurs inaktiv ist und keine offenen Termin-/Tauschbezüge
+          mehr bestehen.
+        </p>
+        {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+        <div className="modal-actions">
+          <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
+            Abbrechen
+          </button>
+          <button type="button" className="btn-primary modal-action-btn" onClick={onConfirmDelete} disabled={saving}>
+            {saving ? "Lösche..." : "Löschen"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/CourseDeleteDialog.tsx
+++ b/app/src/components/CourseDeleteDialog.tsx
@@ -1,4 +1,5 @@
 import type { KeyboardEvent, RefObject } from "react";
+import CourseModalFrame from "./CourseModalFrame";
 
 type CourseDeleteDialogProps = {
   open: boolean;
@@ -24,9 +25,7 @@ export default function CourseDeleteDialog({
   if (!open || !courseName) return null;
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs löschen" onKeyDown={onKeyDown}>
-      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
-        <h4>Kurs löschen</h4>
+    <CourseModalFrame ariaLabel="Kurs löschen" title="Kurs löschen" modalRef={modalRef} onKeyDown={onKeyDown}>
         <p style={{ marginTop: 0, color: "#4b5563" }}>
           Kurs <strong>{courseName}</strong> wirklich löschen?
         </p>
@@ -43,7 +42,6 @@ export default function CourseDeleteDialog({
             {saving ? "Lösche..." : "Löschen"}
           </button>
         </div>
-      </div>
-    </div>
+    </CourseModalFrame>
   );
 }

--- a/app/src/components/CourseEditDialog.tsx
+++ b/app/src/components/CourseEditDialog.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, RefObject } from "react";
 import type { CoursePlanningMode, CourseStatus } from "shared/types";
+import CourseModalFrame from "./CourseModalFrame";
 
 type CourseEditorState = {
   id: number;
@@ -51,9 +52,7 @@ export default function CourseEditDialog({
   if (!open || !state) return null;
 
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs bearbeiten" onKeyDown={onKeyDown}>
-      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
-        <h4>Kurs bearbeiten</h4>
+    <CourseModalFrame ariaLabel="Kurs bearbeiten" title="Kurs bearbeiten" modalRef={modalRef} onKeyDown={onKeyDown}>
         <p className="course-editor-note" style={{ marginTop: 0 }}>
           Stammdaten bearbeiten. Mitglieder und Termine werden im nächsten Schritt hier ergänzt.
         </p>
@@ -138,7 +137,6 @@ export default function CourseEditDialog({
             {saving ? "Speichere..." : "Speichern"}
           </button>
         </div>
-      </div>
-    </div>
+    </CourseModalFrame>
   );
 }

--- a/app/src/components/CourseEditDialog.tsx
+++ b/app/src/components/CourseEditDialog.tsx
@@ -1,0 +1,144 @@
+import type { KeyboardEvent, RefObject } from "react";
+import type { CoursePlanningMode, CourseStatus } from "shared/types";
+
+type CourseEditorState = {
+  id: number;
+  name: string;
+  weekday: string;
+  time: string;
+  capacity: string;
+  status: CourseStatus;
+  planningMode: CoursePlanningMode;
+};
+
+type WeekdayOption = { value: string; label: string };
+type StatusOption = { value: CourseStatus; label: string };
+type PlanningModeOption = { value: CoursePlanningMode; label: string };
+
+type CourseEditDialogProps = {
+  open: boolean;
+  saving: boolean;
+  formError: string | null;
+  state: CourseEditorState | null;
+  canSubmit: boolean;
+  modalRef: RefObject<HTMLDivElement | null>;
+  weekdayOptions: readonly WeekdayOption[];
+  statusOptions: readonly StatusOption[];
+  planningModeOptions: readonly PlanningModeOption[];
+  planningModeHint: (mode: CoursePlanningMode) => string;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onClose: () => void;
+  onSave: () => void;
+  onChange: (next: CourseEditorState) => void;
+};
+
+export default function CourseEditDialog({
+  open,
+  saving,
+  formError,
+  state,
+  canSubmit,
+  modalRef,
+  weekdayOptions,
+  statusOptions,
+  planningModeOptions,
+  planningModeHint,
+  onKeyDown,
+  onClose,
+  onSave,
+  onChange,
+}: CourseEditDialogProps) {
+  if (!open || !state) return null;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Kurs bearbeiten" onKeyDown={onKeyDown}>
+      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
+        <h4>Kurs bearbeiten</h4>
+        <p className="course-editor-note" style={{ marginTop: 0 }}>
+          Stammdaten bearbeiten. Mitglieder und Termine werden im nächsten Schritt hier ergänzt.
+        </p>
+        <div className="dialog-stack">
+          <input
+            type="text"
+            aria-label="Kursname bearbeiten"
+            value={state.name}
+            onChange={(event) => onChange({ ...state, name: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <select
+            aria-label="Wochentag bearbeiten"
+            value={state.weekday}
+            onChange={(event) => onChange({ ...state, weekday: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          >
+            {weekdayOptions.map((weekday) => (
+              <option key={weekday.value} value={weekday.value}>
+                {weekday.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="time"
+            aria-label="Uhrzeit bearbeiten"
+            value={state.time}
+            onChange={(event) => onChange({ ...state, time: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <input
+            type="number"
+            aria-label="Kapazität bearbeiten"
+            min={0}
+            value={state.capacity}
+            onChange={(event) => onChange({ ...state, capacity: event.target.value })}
+            disabled={saving}
+            className="dialog-field"
+          />
+          <select
+            aria-label="Status bearbeiten"
+            value={state.status}
+            onChange={(event) => onChange({ ...state, status: event.target.value as CourseStatus })}
+            disabled={saving}
+            className="dialog-field"
+          >
+            {statusOptions.map((status) => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Planungsmodus bearbeiten"
+            value={state.planningMode}
+            onChange={(event) =>
+              onChange({
+                ...state,
+                planningMode: event.target.value as CoursePlanningMode,
+              })
+            }
+            disabled={saving}
+            className="dialog-field"
+          >
+            {planningModeOptions.map((mode) => (
+              <option key={mode.value} value={mode.value}>
+                {mode.label}
+              </option>
+            ))}
+          </select>
+          <p className="course-editor-inline-hint">{planningModeHint(state.planningMode)}</p>
+          {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+        </div>
+        <div className="modal-actions dialog-actions">
+          <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
+            Abbrechen
+          </button>
+          <button type="button" className="btn-primary modal-action-btn" onClick={onSave} disabled={!canSubmit}>
+            {saving ? "Speichere..." : "Speichern"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -1,5 +1,8 @@
 import CourseCard from "./CourseCard";
 import CourseDatesDialog from "./CourseDatesDialog";
+import CourseCreateDialog from "./CourseCreateDialog";
+import CourseEditDialog from "./CourseEditDialog";
+import CourseDeleteDialog from "./CourseDeleteDialog";
 import { useCourseSwaps } from "./useCourseSwaps";
 import { useEffect, useState, useMemo, useCallback, useRef, type KeyboardEvent, type RefObject } from "react";
 import { Plus, Pencil, Trash2, Users, CalendarDays } from "lucide-react";
@@ -403,6 +406,30 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       editState.planningMode !== editInitialState.planningMode);
   const canSubmitEdit = canManageCourses && !saving && !!editState && editNameValid && editCapacityValid && editChanged;
 
+  const handleCreateDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    handleFocusTrap(event, createModalRef);
+    if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
+      event.preventDefault();
+      saveCreateCourse();
+    }
+  };
+
+  const handleEditDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    handleFocusTrap(event, editModalRef);
+    if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
+      event.preventDefault();
+      saveEditCourse();
+    }
+  };
+
+  const handleDeleteDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    handleFocusTrap(event, deleteModalRef);
+    if (event.key === "Enter") {
+      event.preventDefault();
+      confirmDeleteCourse();
+    }
+  };
+
   useEffect(() => {
     const activeModal = createOpen
       ? createModalRef.current
@@ -649,250 +676,39 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         })}
       </div>
 
-      {createOpen && (
-        <div
-          className="modal-backdrop"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Kurs anlegen"
-          onKeyDown={(event) => {
-            handleFocusTrap(event, createModalRef);
-            if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
-              event.preventDefault();
-              saveCreateCourse();
-            }
-          }}
-        >
-          <div className="modal modal-compact" ref={createModalRef} tabIndex={-1}>
-            <h4>Kurs anlegen</h4>
-            <p className="course-editor-note">
-              Stammdaten jetzt anlegen. Mitglieder-Zuordnung und Terminplanung folgen als eigene Schritte.
-            </p>
-            <div className="dialog-stack">
-              <input
-                type="text"
-                aria-label="Kursname"
-                placeholder="Kursname"
-                value={createState.name}
-                onChange={(event) =>
-                  setCreateState((prev) => ({ ...prev, name: event.target.value }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <select
-                aria-label="Wochentag"
-                value={createState.weekday}
-                onChange={(event) =>
-                  setCreateState((prev) => ({ ...prev, weekday: event.target.value }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {WEEKDAY_OPTIONS.map((weekday) => (
-                  <option key={weekday.value} value={weekday.value}>
-                    {weekday.label}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="time"
-                aria-label="Uhrzeit"
-                value={createState.time}
-                onChange={(event) =>
-                  setCreateState((prev) => ({ ...prev, time: event.target.value }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <input
-                type="number"
-                aria-label="Kapazität"
-                min={0}
-                value={createState.capacity}
-                onChange={(event) =>
-                  setCreateState((prev) => ({ ...prev, capacity: event.target.value }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <select
-                aria-label="Status"
-                value={createState.status}
-                onChange={(event) =>
-                  setCreateState((prev) => ({ ...prev, status: event.target.value as CourseStatus }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {STATUS_OPTIONS.map((status) => (
-                  <option key={status.value} value={status.value}>
-                    {status.label}
-                  </option>
-                ))}
-              </select>
-              <select
-                aria-label="Planungsmodus"
-                value={createState.planningMode}
-                onChange={(event) =>
-                  setCreateState((prev) => ({
-                    ...prev,
-                    planningMode: event.target.value as CoursePlanningMode,
-                  }))
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {PLANNING_MODE_OPTIONS.map((mode) => (
-                  <option key={mode.value} value={mode.value}>
-                    {mode.label}
-                  </option>
-                ))}
-              </select>
-              <p className="course-editor-inline-hint">{planningModeHint(createState.planningMode)}</p>
-              {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
-            </div>
-            <div className="modal-actions dialog-actions">
-              <button type="button" className="modal-action-btn" onClick={closeCreateModal} disabled={saving}>
-                Abbrechen
-              </button>
-              <button
-                type="button"
-                className="btn-primary modal-action-btn"
-                onClick={saveCreateCourse}
-                disabled={!canSubmitCreate}
-              >
-                {saving ? "Speichere..." : "Anlegen"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <CourseCreateDialog
+        open={createOpen}
+        saving={saving}
+        formError={formError}
+        state={createState}
+        canSubmit={canSubmitCreate}
+        modalRef={createModalRef}
+        weekdayOptions={WEEKDAY_OPTIONS}
+        statusOptions={STATUS_OPTIONS}
+        planningModeOptions={PLANNING_MODE_OPTIONS}
+        planningModeHint={planningModeHint}
+        onKeyDown={handleCreateDialogKeyDown}
+        onClose={closeCreateModal}
+        onSave={saveCreateCourse}
+        onChange={setCreateState}
+      />
 
-      {editOpen && editState && (
-        <div
-          className="modal-backdrop"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Kurs bearbeiten"
-          onKeyDown={(event) => {
-            handleFocusTrap(event, editModalRef);
-            if (event.key === "Enter" && !(event.target instanceof HTMLTextAreaElement)) {
-              event.preventDefault();
-              saveEditCourse();
-            }
-          }}
-        >
-          <div className="modal modal-compact" ref={editModalRef} tabIndex={-1}>
-            <h4>Kurs bearbeiten</h4>
-            <p className="course-editor-note" style={{ marginTop: 0 }}>
-              Stammdaten bearbeiten. Mitglieder und Termine werden im nächsten Schritt hier ergänzt.
-            </p>
-            <div className="dialog-stack">
-              <input
-                type="text"
-                aria-label="Kursname bearbeiten"
-                value={editState.name}
-                onChange={(event) =>
-                  setEditState((prev) => (prev ? { ...prev, name: event.target.value } : prev))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <select
-                aria-label="Wochentag bearbeiten"
-                value={editState.weekday}
-                onChange={(event) =>
-                  setEditState((prev) => (prev ? { ...prev, weekday: event.target.value } : prev))
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {WEEKDAY_OPTIONS.map((weekday) => (
-                  <option key={weekday.value} value={weekday.value}>
-                    {weekday.label}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="time"
-                aria-label="Uhrzeit bearbeiten"
-                value={editState.time}
-                onChange={(event) =>
-                  setEditState((prev) => (prev ? { ...prev, time: event.target.value } : prev))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <input
-                type="number"
-                aria-label="Kapazität bearbeiten"
-                min={0}
-                value={editState.capacity}
-                onChange={(event) =>
-                  setEditState((prev) => (prev ? { ...prev, capacity: event.target.value } : prev))
-                }
-                disabled={saving}
-                className="dialog-field"
-              />
-              <select
-                aria-label="Status bearbeiten"
-                value={editState.status}
-                onChange={(event) =>
-                  setEditState((prev) =>
-                    prev ? { ...prev, status: event.target.value as CourseStatus } : prev,
-                  )
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {STATUS_OPTIONS.map((status) => (
-                  <option key={status.value} value={status.value}>
-                    {status.label}
-                  </option>
-                ))}
-              </select>
-              <select
-                aria-label="Planungsmodus bearbeiten"
-                value={editState.planningMode}
-                onChange={(event) =>
-                  setEditState((prev) =>
-                    prev ? { ...prev, planningMode: event.target.value as CoursePlanningMode } : prev,
-                  )
-                }
-                disabled={saving}
-                className="dialog-field"
-              >
-                {PLANNING_MODE_OPTIONS.map((mode) => (
-                  <option key={mode.value} value={mode.value}>
-                    {mode.label}
-                  </option>
-                ))}
-              </select>
-              <p className="course-editor-inline-hint">{planningModeHint(editState.planningMode)}</p>
-              {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
-            </div>
-            <div className="modal-actions dialog-actions">
-              <button
-                type="button"
-                className="modal-action-btn"
-                onClick={closeEditModal}
-                disabled={saving}
-              >
-                Abbrechen
-              </button>
-              <button
-                type="button"
-                className="btn-primary modal-action-btn"
-                onClick={saveEditCourse}
-                disabled={!canSubmitEdit}
-              >
-                {saving ? "Speichere..." : "Speichern"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <CourseEditDialog
+        open={editOpen}
+        saving={saving}
+        formError={formError}
+        state={editState}
+        canSubmit={canSubmitEdit}
+        modalRef={editModalRef}
+        weekdayOptions={WEEKDAY_OPTIONS}
+        statusOptions={STATUS_OPTIONS}
+        planningModeOptions={PLANNING_MODE_OPTIONS}
+        planningModeHint={planningModeHint}
+        onKeyDown={handleEditDialogKeyDown}
+        onClose={closeEditModal}
+        onSave={saveEditCourse}
+        onChange={(next) => setEditState(next)}
+      />
 
       {membersTargetCourse && (
         <div
@@ -928,51 +744,16 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         onSaved={fetchData}
       />
 
-      {deleteOpen && deleteTargetCourse && (
-        <div
-          className="modal-backdrop"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Kurs löschen"
-          onKeyDown={(event) => {
-            handleFocusTrap(event, deleteModalRef);
-            if (event.key === "Enter") {
-              event.preventDefault();
-              confirmDeleteCourse();
-            }
-          }}
-        >
-          <div className="modal modal-compact" ref={deleteModalRef} tabIndex={-1}>
-            <h4>Kurs löschen</h4>
-            <p style={{ marginTop: 0, color: "#4b5563" }}>
-              Kurs <strong>{deleteTargetCourse.name}</strong> wirklich löschen?
-            </p>
-            <p style={{ marginTop: 0, color: "#6b7280", fontSize: 14 }}>
-              Löschen ist nur möglich, wenn der Kurs inaktiv ist und keine offenen Termin-/Tauschbezüge
-              mehr bestehen.
-            </p>
-            {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
-            <div className="modal-actions">
-              <button
-                type="button"
-                className="modal-action-btn"
-                onClick={closeDeleteModal}
-                disabled={saving}
-              >
-                Abbrechen
-              </button>
-              <button
-                type="button"
-                className="btn-primary modal-action-btn"
-                onClick={confirmDeleteCourse}
-                disabled={saving}
-              >
-                {saving ? "Lösche..." : "Löschen"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <CourseDeleteDialog
+        open={deleteOpen}
+        saving={saving}
+        formError={formError}
+        courseName={deleteTargetCourse?.name}
+        modalRef={deleteModalRef}
+        onKeyDown={handleDeleteDialogKeyDown}
+        onClose={closeDeleteModal}
+        onConfirmDelete={confirmDeleteCourse}
+      />
     </>
   );
 }

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -3,6 +3,7 @@ import CourseDatesDialog from "./CourseDatesDialog";
 import CourseCreateDialog from "./CourseCreateDialog";
 import CourseEditDialog from "./CourseEditDialog";
 import CourseDeleteDialog from "./CourseDeleteDialog";
+import CourseMembersDialog from "./CourseMembersDialog";
 import { useCourseSwaps } from "./useCourseSwaps";
 import { useEffect, useState, useMemo, useCallback, useRef, type KeyboardEvent, type RefObject } from "react";
 import { Plus, Pencil, Trash2, Users, CalendarDays } from "lucide-react";
@@ -710,32 +711,16 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
         onChange={(next) => setEditState(next)}
       />
 
-      {membersTargetCourse && (
-        <div
-          className="modal-backdrop"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Kursmitglieder bearbeiten"
-          onKeyDown={(event) => {
-            handleFocusTrap(event, membersModalRef);
-          }}
-        >
-          <div className="modal modal-compact" ref={membersModalRef} tabIndex={-1}>
-            <h4>Mitglieder verwalten</h4>
-            <p className="course-editor-note">
-              Kurs: <strong>{membersTargetCourse.name}</strong>
-            </p>
-            <p className="course-editor-note">
-              Hier folgt als Nächstes die Zuordnung von Teilnehmern zu diesem Kurs (inkl. Kapazitätsprüfung).
-            </p>
-            <div className="modal-actions">
-              <button type="button" className="modal-action-btn" onClick={closeMembersModal} disabled={saving}>
-                Schließen
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <CourseMembersDialog
+        open={!!membersTargetCourse}
+        saving={saving}
+        courseName={membersTargetCourse?.name}
+        modalRef={membersModalRef}
+        onKeyDown={(event) => {
+          handleFocusTrap(event, membersModalRef);
+        }}
+        onClose={closeMembersModal}
+      />
 
       <CourseDatesDialog
         course={datesTargetCourse ?? null}

--- a/app/src/components/CourseMembersDialog.test.tsx
+++ b/app/src/components/CourseMembersDialog.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import CourseMembersDialog from "./CourseMembersDialog";
+
+describe("CourseMembersDialog", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <CourseMembersDialog
+        open={false}
+        saving={false}
+        courseName="Yoga Flow"
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog", { name: "Kursmitglieder bearbeiten" })).not.toBeInTheDocument();
+  });
+
+  it("renders course info and calls close handler", async () => {
+    const onClose = vi.fn();
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseName="Yoga Flow"
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Kursmitglieder bearbeiten" })).toBeInTheDocument();
+    expect(screen.getByText("Yoga Flow")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Schließen" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/CourseMembersDialog.tsx
+++ b/app/src/components/CourseMembersDialog.tsx
@@ -1,0 +1,43 @@
+import type { KeyboardEvent, RefObject } from "react";
+import CourseModalFrame from "./CourseModalFrame";
+
+type CourseMembersDialogProps = {
+  open: boolean;
+  saving: boolean;
+  courseName?: string;
+  modalRef: RefObject<HTMLDivElement | null>;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onClose: () => void;
+};
+
+export default function CourseMembersDialog({
+  open,
+  saving,
+  courseName,
+  modalRef,
+  onKeyDown,
+  onClose,
+}: CourseMembersDialogProps) {
+  if (!open || !courseName) return null;
+
+  return (
+    <CourseModalFrame
+      ariaLabel="Kursmitglieder bearbeiten"
+      title="Mitglieder verwalten"
+      modalRef={modalRef}
+      onKeyDown={onKeyDown}
+    >
+      <p className="course-editor-note">
+        Kurs: <strong>{courseName}</strong>
+      </p>
+      <p className="course-editor-note">
+        Hier folgt als Nächstes die Zuordnung von Teilnehmern zu diesem Kurs (inkl. Kapazitätsprüfung).
+      </p>
+      <div className="modal-actions">
+        <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
+          Schließen
+        </button>
+      </div>
+    </CourseModalFrame>
+  );
+}

--- a/app/src/components/CourseModalFrame.test.tsx
+++ b/app/src/components/CourseModalFrame.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import CourseModalFrame from "./CourseModalFrame";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CourseModalFrame", () => {
+  it("renders title, aria label, and children", () => {
+    const modalRef = createRef<HTMLDivElement>();
+    render(
+      <CourseModalFrame
+        ariaLabel="Test Modal"
+        title="Test Titel"
+        modalRef={modalRef}
+        onKeyDown={vi.fn()}
+      >
+        <p>Inhalt</p>
+      </CourseModalFrame>,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Test Modal" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Test Titel" })).toBeInTheDocument();
+    expect(screen.getByText("Inhalt")).toBeInTheDocument();
+  });
+
+  it("forwards keydown events", () => {
+    const onKeyDown = vi.fn();
+    const modalRef = createRef<HTMLDivElement>();
+    render(
+      <CourseModalFrame
+        ariaLabel="Test Modal"
+        title="Test Titel"
+        modalRef={modalRef}
+        onKeyDown={onKeyDown}
+      >
+        <p>Inhalt</p>
+      </CourseModalFrame>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog", { name: "Test Modal" }), { key: "Tab" });
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/CourseModalFrame.tsx
+++ b/app/src/components/CourseModalFrame.tsx
@@ -1,0 +1,26 @@
+import type { KeyboardEvent, ReactNode, RefObject } from "react";
+
+type CourseModalFrameProps = {
+  ariaLabel: string;
+  title: string;
+  modalRef: RefObject<HTMLDivElement | null>;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  children: ReactNode;
+};
+
+export default function CourseModalFrame({
+  ariaLabel,
+  title,
+  modalRef,
+  onKeyDown,
+  children,
+}: CourseModalFrameProps) {
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label={ariaLabel} onKeyDown={onKeyDown}>
+      <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
+        <h4>{title}</h4>
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract course CRUD dialogs from `CourseList` into dedicated components: `CourseCreateDialog`, `CourseEditDialog`, and `CourseDeleteDialog`
- extract the existing members placeholder dialog into `CourseMembersDialog` and introduce shared `CourseModalFrame` for consistent modal structure
- migrate `CourseDatesDialog` to the shared modal frame while preserving current focus-trap, ESC handling, and save behavior
- add focused unit tests for the newly extracted modal building blocks (`CourseModalFrame`, `CourseMembersDialog`)

## Test plan
- [x] `npm run test --prefix app -- src/components/CourseList.test.tsx`
- [x] `npm run test --prefix app -- src/components/CourseDatesDialog.test.tsx`
- [x] `npm run test --prefix app -- src/components/CourseModalFrame.test.tsx src/components/CourseMembersDialog.test.tsx`
- [x] `npm run test --prefix app -- src/components/CourseList.test.tsx src/components/CourseDatesDialog.test.tsx src/components/CourseModalFrame.test.tsx src/components/CourseMembersDialog.test.tsx`

## Notes
- no API/auth/functional flow changes intended; refactor focuses on readability and maintainability (#134)

Made with [Cursor](https://cursor.com)