### PR TITLE
#130 Scope A: Teilnehmerliste pro Kurs inkl. Members-Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ Bei der Ausarbeitung habe ich AI bewusst als Sparringspartner genutzt, um Entsch
 
 ---
 
+## 👥 #130 Scope A: Kursmitglieder verwalten
+
+Dieser Abschnitt dokumentiert den aktuellen Stand von **Issue #130, Scope A** (Kurs-Teilnehmerliste + Fremdverwaltung).
+
+### Funktionsumfang (Scope A)
+
+- **Kurs-Mitgliederdialog**: In der Kursverwaltung kann ein Dialog zum Zuordnen/Entfernen von Teilnehmenden pro Kurs geöffnet werden.
+- **Suche & Auswahl**: Teilnehmende können per Suche (Nickname/E-Mail) gefiltert und über die Liste zugeordnet werden.
+- **Kapazitätsgrenze**: Die Kurskapazität wird beim Zuordnen respektiert; Überbelegung wird verhindert.
+- **Ausgewählte Teilnehmer**: Aktuelle Zuordnungen sind sichtbar und können direkt im Dialog entfernt werden.
+- **Stale-Zuordnungen**: Nicht mehr vorhandene Nutzerzuordnungen werden gekennzeichnet und können bereinigt werden.
+
+### Tastatur- und Fokusverhalten
+
+- Der Dialog startet mit Fokus im **Suchfeld**.
+- Die Teilnehmerliste ist als **ein Tab-Stop** umgesetzt.
+- Innerhalb der Liste:
+  - `Pfeil hoch/runter` bewegt die aktive Zeile.
+  - `Leertaste` oder `Enter` schaltet die aktive Zuordnung um.
+- Der Fokus bleibt beim Tabben im Dialog (Focus Trap).
+
+### Datenkonsistenz Backend
+
+- `updateCourse` unterstützt das Speichern der `participants`-Liste.
+- Beim Löschen eines Teilnehmers wird dieser serverseitig aus allen Kurszuordnungen des Tenants entfernt.
+
+### Hinweis zu Scope-Abgrenzung
+
+- Scope A deckt die Grundfunktion für Fremdverwaltung und Zuordnungs-CRUD ab.
+- Erweiterungen wie weitergehende Historie/Auditing oder UX-Polish außerhalb des Dialog-Scopes sind nicht Teil von Scope A.
+
+---
+
 ## 📋 Projektübersicht
 
 YogaSwap ist eine vollständige Serverless-Webanwendung bestehend aus:

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -380,6 +380,45 @@ a:focus-visible {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
 
+.course-members-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.course-members-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.course-members-chip.is-armed {
+  background: #fee2e2;
+  border-color: #fca5a5;
+}
+
+.course-members-chip-stale {
+  background: #fff1f2;
+  border-color: #fda4af;
+  color: #881337;
+}
+
+.course-members-chip-remove {
+  color: #b91c1c;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  width: 14px;
+  text-align: center;
+}
+
+.course-members-search-field {
+  margin-top: 6px;
+}
+
 .course-editor-range-controls {
   display: flex;
   gap: 8px;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -275,6 +275,10 @@ a:focus-visible {
   text-align: left;
   position: relative;
 }
+.modal:focus {
+  outline: 3px solid #93c5fd;
+  outline-offset: 1px;
+}
 .modal.modal-compact {
   max-width: 520px;
 }
@@ -365,6 +369,15 @@ a:focus-visible {
   background: #1d4ed8;
   border-color: #1d4ed8;
   color: #fff;
+}
+
+.course-members-listbox {
+  outline: none;
+}
+
+.course-members-listbox.is-focused {
+  border-color: #3b82f6 !important;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
 
 .course-editor-range-controls {

--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -22,6 +22,7 @@ export type CreateCourseRequest = {
   visibilityHorizonWeeks?: number;
   excludedDates?: string[];
   includedDates?: string[];
+  participants?: string[];
 };
 
 export type UpdateCourseRequest = Partial<CreateCourseRequest>;

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from "react";
 import { Calendar } from "lucide-react";
 import type { Course } from "shared/types";
 import { updateCourse } from "../api/courses";
@@ -69,11 +69,14 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
     setFormError(null);
   }, [course]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!course) return;
+    if (!datesState) return;
     if (!modalRef.current) return;
+    const active = document.activeElement as Node | null;
+    if (active && modalRef.current.contains(active)) return;
     focusFirstElement(modalRef.current);
-  }, [course]);
+  }, [course, datesState]);
 
   useEffect(() => {
     if (!course) return;

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -6,12 +6,14 @@ import CourseList from "./CourseList";
 import { createCourse, deleteCourse, getCourses, updateCourse } from "../api/courses";
 import { getOverrides } from "../api/overrides";
 import { getSwaps } from "../api/swaps";
+import { getParticipants } from "../api/participants";
 import type { User, Tenant, UserTenantMembership, Course } from "shared/types";
 import { canSeeCourse } from "shared/permissions";
 
 vi.mock("../api/courses");
 vi.mock("../api/overrides");
 vi.mock("../api/swaps");
+vi.mock("../api/participants");
 vi.mock("./useCourseSwaps", () => {
   return {
     useCourseSwaps: () => ({
@@ -31,6 +33,7 @@ const mockedUpdateCourse = updateCourse as unknown as ReturnType<typeof vi.fn>;
 const mockedDeleteCourse = deleteCourse as unknown as ReturnType<typeof vi.fn>;
 const mockedGetOverrides = getOverrides as unknown as ReturnType<typeof vi.fn>;
 const mockedGetSwaps = getSwaps as unknown as ReturnType<typeof vi.fn>;
+const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
 const mockedCanSeeCourse = canSeeCourse as unknown as ReturnType<typeof vi.fn>;
 
 vi.mock("shared/permissions", () => ({
@@ -70,6 +73,8 @@ describe("CourseList", () => {
     mockedCreateCourse.mockReset();
     mockedUpdateCourse.mockReset();
     mockedDeleteCourse.mockReset();
+    mockedGetParticipants.mockReset();
+    mockedGetParticipants.mockResolvedValue([]);
     mockedCanSeeCourse.mockImplementation(() => true);
   });
 

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -438,13 +438,11 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       ? editModalRef.current
       : deleteOpen
       ? deleteModalRef.current
-      : membersTargetId
-      ? membersModalRef.current
       : null;
     if (!activeModal) return;
 
     focusFirstElement(activeModal);
-  }, [createOpen, editOpen, deleteOpen, membersTargetId, datesTargetId]);
+  }, [createOpen, editOpen, deleteOpen]);
 
   useEffect(() => {
     if (!createOpen && !editOpen && !deleteOpen && !membersTargetId && !datesTargetId) return;

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -557,6 +557,22 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
     }
   };
 
+  const saveCourseMembers = async (courseId: number, participants: string[]) => {
+    if (!canManageCourses) return;
+    setSaving(true);
+    setFormError(null);
+    try {
+      await updateCourse(courseId, { participants });
+      closeMembersModal();
+      await fetchData();
+    } catch (err) {
+      console.error("Failed to update course members", err);
+      setFormError(err instanceof Error ? err.message : "Mitglieder konnten nicht gespeichert werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
 
   if (loading) {
     return (
@@ -714,12 +730,17 @@ export default function CourseList({ currentUser, tenant, membership }: Props) {
       <CourseMembersDialog
         open={!!membersTargetCourse}
         saving={saving}
+        courseId={membersTargetCourse?.id}
         courseName={membersTargetCourse?.name}
+        capacity={membersTargetCourse?.capacity ?? 0}
+        initialParticipants={membersTargetCourse?.participants ?? []}
+        formError={formError}
         modalRef={membersModalRef}
         onKeyDown={(event) => {
           handleFocusTrap(event, membersModalRef);
         }}
         onClose={closeMembersModal}
+        onSaveParticipants={saveCourseMembers}
       />
 
       <CourseDatesDialog

--- a/app/src/components/CourseMembersDialog.test.tsx
+++ b/app/src/components/CourseMembersDialog.test.tsx
@@ -1,8 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
 import CourseMembersDialog from "./CourseMembersDialog";
+import { getParticipants } from "../api/participants";
+
+vi.mock("../api/participants");
+const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  mockedGetParticipants.mockReset();
+});
 
 describe("CourseMembersDialog", () => {
   it("renders nothing when closed", () => {
@@ -10,10 +23,14 @@ describe("CourseMembersDialog", () => {
       <CourseMembersDialog
         open={false}
         saving={false}
+        courseId={1}
         courseName="Yoga Flow"
+        capacity={10}
+        initialParticipants={[]}
         modalRef={createRef<HTMLDivElement>()}
         onKeyDown={vi.fn()}
         onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
       />,
     );
 
@@ -22,21 +39,103 @@ describe("CourseMembersDialog", () => {
 
   it("renders course info and calls close handler", async () => {
     const onClose = vi.fn();
+    mockedGetParticipants.mockResolvedValue([]);
     render(
       <CourseMembersDialog
         open
         saving={false}
+        courseId={1}
         courseName="Yoga Flow"
+        capacity={10}
+        initialParticipants={[]}
         modalRef={createRef<HTMLDivElement>()}
         onKeyDown={vi.fn()}
         onClose={onClose}
+        onSaveParticipants={vi.fn()}
       />,
     );
 
     expect(screen.getByRole("dialog", { name: "Kursmitglieder bearbeiten" })).toBeInTheDocument();
     expect(screen.getByText("Yoga Flow")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Schließen" }));
+    await userEvent.click(screen.getByRole("button", { name: "Abbrechen" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows selecting participants and saving", async () => {
+    const onSaveParticipants = vi.fn();
+    mockedGetParticipants.mockResolvedValue([
+      { userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" },
+      { userId: "bob", status: "invited", role: "participant", tenantId: "default-tenant" },
+    ]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={10}
+        initialParticipants={["alice"]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={onSaveParticipants}
+      />,
+    );
+
+    await screen.findByRole("checkbox", { name: /bob - invited/i });
+    await userEvent.click(screen.getByRole("checkbox", { name: /bob - invited/i }));
+    await userEvent.click(screen.getByRole("button", { name: /mitglieder speichern/i }));
+    expect(onSaveParticipants).toHaveBeenCalledWith(7, ["alice", "bob"]);
+  });
+
+  it("prevents selecting above capacity and shows selected list", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      { userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" },
+      { userId: "bob", status: "invited", role: "participant", tenantId: "default-tenant" },
+    ]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={1}
+        initialParticipants={["alice"]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(/ausgewählte teilnehmer/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /bob - invited/i })).toBeDisabled();
+    expect(screen.getByText(/kapazität erreicht/i)).toBeInTheDocument();
+  });
+
+  it("removes selected participant on second click", async () => {
+    mockedGetParticipants.mockResolvedValue([{ userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" }]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={5}
+        initialParticipants={["alice"]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
+      />,
+    );
+
+    const chip = await screen.findByRole("button", { name: /teilnehmer zum entfernen markieren alice/i });
+    await userEvent.click(chip);
+    expect(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i }));
+    expect(screen.getByText(/noch keine teilnehmer ausgewählt/i)).toBeInTheDocument();
   });
 });

--- a/app/src/components/CourseMembersDialog.test.tsx
+++ b/app/src/components/CourseMembersDialog.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { afterEach } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
 import CourseMembersDialog from "./CourseMembersDialog";
@@ -83,8 +83,10 @@ describe("CourseMembersDialog", () => {
       />,
     );
 
-    await screen.findByRole("checkbox", { name: /bob - invited/i });
-    await userEvent.click(screen.getByRole("checkbox", { name: /bob - invited/i }));
+    const listbox = await screen.findByRole("listbox", { name: /teilnehmerliste/i });
+    listbox.focus();
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    fireEvent.keyDown(listbox, { key: " " });
     await userEvent.click(screen.getByRole("button", { name: /mitglieder speichern/i }));
     expect(onSaveParticipants).toHaveBeenCalledWith(7, ["alice", "bob"]);
   });
@@ -111,7 +113,11 @@ describe("CourseMembersDialog", () => {
 
     expect(await screen.findByText(/ausgewählte teilnehmer/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: /bob - invited/i })).toBeDisabled();
+    const bobOption = screen.getByRole("option", { name: /bob - invited/i });
+    await userEvent.click(bobOption);
+    await userEvent.click(bobOption);
+    await userEvent.click(screen.getByRole("button", { name: /mitglieder speichern/i }));
+    expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
     expect(screen.getByText(/kapazität erreicht/i)).toBeInTheDocument();
   });
 
@@ -137,5 +143,63 @@ describe("CourseMembersDialog", () => {
     expect(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i })).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i }));
     expect(screen.getByText(/noch keine teilnehmer ausgewählt/i)).toBeInTheDocument();
+  });
+
+  it("clears armed remove state when clicking outside chip", async () => {
+    mockedGetParticipants.mockResolvedValue([{ userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" }]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={5}
+        initialParticipants={["alice"]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
+      />,
+    );
+
+    const chip = await screen.findByRole("button", { name: /teilnehmer zum entfernen markieren alice/i });
+    await userEvent.click(chip);
+    expect(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /abbrechen/i }));
+    expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
+  });
+
+  it("clears armed remove state when focus moves away from chip", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      { userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" },
+      { userId: "bob", status: "active", role: "participant", tenantId: "default-tenant" },
+    ]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={5}
+        initialParticipants={["alice", "bob"]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("button", { name: /teilnehmer zum entfernen markieren alice/i });
+    const aliceChip = screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i });
+    const searchInput = screen.getByRole("textbox", { name: /mitglieder suchen/i });
+
+    await userEvent.click(aliceChip);
+    expect(screen.getByRole("button", { name: /teilnehmer jetzt entfernen alice/i })).toBeInTheDocument();
+
+    searchInput.focus();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
+    });
   });
 });

--- a/app/src/components/CourseMembersDialog.tsx
+++ b/app/src/components/CourseMembersDialog.tsx
@@ -325,7 +325,7 @@ export default function CourseMembersDialog({
           {selectedParticipantProfiles.length === 0 ? (
             <p className="course-editor-note">Noch keine Teilnehmer ausgewählt.</p>
           ) : (
-            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <div className="course-members-chip-row">
               {selectedParticipantProfiles.map((entry) => (
                 <button
                   key={entry.userId}
@@ -333,7 +333,9 @@ export default function CourseMembersDialog({
                   data-removal-chip="true"
                   data-removal-kind="selected"
                   data-removal-user-id={entry.userId.toLowerCase()}
-                  className="course-editor-inline-action"
+                  className={`chip course-members-chip ${
+                    armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() ? "is-armed" : ""
+                  }`}
                   tabIndex={-1}
                   onClick={() => handleSelectedChipClick(entry.userId)}
                   onDoubleClick={() => toggleParticipant(entry.userId)}
@@ -343,41 +345,13 @@ export default function CourseMembersDialog({
                       ? `Teilnehmer jetzt entfernen ${entry.userId}`
                       : `Teilnehmer zum Entfernen markieren ${entry.userId}`
                   }
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 6,
-                    border: "1px solid #e5e7eb",
-                    borderRadius: 999,
-                    padding: "1px 6px",
-                    background:
-                      armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() ? "#fee2e2" : "#f9fafb",
-                    color: "#111827",
-                    fontSize: 13,
-                    lineHeight: 1.1,
-                    width: "auto",
-                    minWidth: 0,
-                    flex: "0 0 auto",
-                    cursor: saving ? "not-allowed" : "pointer",
-                  }}
                 >
                   <span>
                     {entry.userId}
                     {entry.exists ? "" : " (nicht mehr vorhanden)"}
                   </span>
                   {armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() && (
-                    <span
-                      style={{
-                        color: "#b91c1c",
-                        fontSize: 14,
-                        fontWeight: 700,
-                        lineHeight: 1,
-                        width: 14,
-                        textAlign: "center",
-                      }}
-                    >
-                      ×
-                    </span>
+                    <span className="course-members-chip-remove">×</span>
                   )}
                 </button>
               ))}
@@ -392,7 +366,7 @@ export default function CourseMembersDialog({
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           disabled={saving}
-          className="dialog-field"
+          className="dialog-field course-members-search-field"
         />
         <p className="course-editor-note" style={{ marginTop: -4 }}>
           Tastatur: Tab zur Liste, Pfeile hoch/runter, Leertaste oder Enter zum Zuordnen.
@@ -482,7 +456,7 @@ export default function CourseMembersDialog({
             <p className="course-editor-note" style={{ marginBottom: 4 }}>
               Nicht mehr vorhandene Zuordnungen:
             </p>
-            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <div className="course-members-chip-row">
               {staleAssignments.map((entry) => (
                 <button
                   key={entry}
@@ -490,7 +464,9 @@ export default function CourseMembersDialog({
                   data-removal-chip="true"
                   data-removal-kind="stale"
                   data-removal-user-id={entry.toLowerCase()}
-                  className="course-editor-inline-action"
+                  className={`chip course-members-chip course-members-chip-stale ${
+                    armedStaleRemovalUserId?.toLowerCase() === entry.toLowerCase() ? "is-armed" : ""
+                  }`}
                   tabIndex={-1}
                   onClick={() => handleStaleChipClick(entry)}
                   onDoubleClick={() => removeStaleParticipant(entry)}
@@ -500,37 +476,10 @@ export default function CourseMembersDialog({
                       ? `Veraltete Zuordnung jetzt entfernen ${entry}`
                       : `Veraltete Zuordnung zum Entfernen markieren ${entry}`
                   }
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 6,
-                    border: "1px solid #fca5a5",
-                    borderRadius: 999,
-                    padding: "1px 6px",
-                    background: "#fff1f2",
-                    color: "#881337",
-                    fontSize: 13,
-                    lineHeight: 1.1,
-                    width: "auto",
-                    minWidth: 0,
-                    flex: "0 0 auto",
-                    cursor: saving ? "not-allowed" : "pointer",
-                  }}
                 >
                   <span>{entry}</span>
                   {armedStaleRemovalUserId?.toLowerCase() === entry.toLowerCase() && (
-                    <span
-                      style={{
-                        color: "#b91c1c",
-                        fontSize: 14,
-                        fontWeight: 700,
-                        lineHeight: 1,
-                        width: 14,
-                        textAlign: "center",
-                      }}
-                    >
-                      ×
-                    </span>
+                    <span className="course-members-chip-remove">×</span>
                   )}
                 </button>
               ))}

--- a/app/src/components/CourseMembersDialog.tsx
+++ b/app/src/components/CourseMembersDialog.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, RefObject } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import CourseModalFrame from "./CourseModalFrame";
 import type { ParticipantWithStatus } from "../api/participants";
 import { getParticipants } from "../api/participants";
@@ -39,6 +39,12 @@ export default function CourseMembersDialog({
   const [localError, setLocalError] = useState<string | null>(null);
   const [armedRemovalUserId, setArmedRemovalUserId] = useState<string | null>(null);
   const [armedStaleRemovalUserId, setArmedStaleRemovalUserId] = useState<string | null>(null);
+  const [activeListIndex, setActiveListIndex] = useState(0);
+  const [listHasFocus, setListHasFocus] = useState(false);
+  const listBoxRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const pointerPrimedSelectionRef = useRef(false);
+  const listItemRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   useEffect(() => {
     if (!open) return;
@@ -48,7 +54,80 @@ export default function CourseMembersDialog({
     setParticipantsLoaded(false);
     setArmedRemovalUserId(null);
     setArmedStaleRemovalUserId(null);
+    setActiveListIndex(0);
   }, [open, initialParticipants]);
+
+  useLayoutEffect(() => {
+    if (!open || !courseName) return;
+    searchInputRef.current?.focus();
+  }, [open, courseName]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!modalRef.current) return;
+    const guardId = window.setTimeout(() => {
+      if (!modalRef.current) return;
+      const active = document.activeElement as Node | null;
+      if (active && modalRef.current.contains(active)) return;
+      searchInputRef.current?.focus();
+      if (document.activeElement !== searchInputRef.current) {
+        modalRef.current.focus();
+      }
+    }, 0);
+    return () => window.clearTimeout(guardId);
+  }, [open, loadingParticipants, modalRef]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const clearArmed = () => {
+      setArmedRemovalUserId(null);
+      setArmedStaleRemovalUserId(null);
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const chip = target?.closest("[data-removal-chip='true']") as HTMLElement | null;
+      if (chip) {
+        const chipUserId = chip.dataset.removalUserId?.toLowerCase();
+        const chipKind = chip.dataset.removalKind;
+        const selectedArmed = armedRemovalUserId?.toLowerCase();
+        const staleArmed = armedStaleRemovalUserId?.toLowerCase();
+        const keepSelected = chipKind === "selected" && !!chipUserId && chipUserId === selectedArmed;
+        const keepStale = chipKind === "stale" && !!chipUserId && chipUserId === staleArmed;
+        if (keepSelected || keepStale) return;
+      } else {
+        clearArmed();
+        return;
+      }
+      clearArmed();
+    };
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as HTMLElement | null;
+      const chip = target?.closest("[data-removal-chip='true']") as HTMLElement | null;
+      if (chip) {
+        const chipUserId = chip.dataset.removalUserId?.toLowerCase();
+        const chipKind = chip.dataset.removalKind;
+        const selectedArmed = armedRemovalUserId?.toLowerCase();
+        const staleArmed = armedStaleRemovalUserId?.toLowerCase();
+        const keepSelected = chipKind === "selected" && !!chipUserId && chipUserId === selectedArmed;
+        const keepStale = chipKind === "stale" && !!chipUserId && chipUserId === staleArmed;
+        if (keepSelected || keepStale) return;
+      } else {
+        clearArmed();
+        return;
+      }
+      clearArmed();
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [open, armedRemovalUserId, armedStaleRemovalUserId]);
 
   useEffect(() => {
     if (!open) return;
@@ -167,6 +246,62 @@ export default function CourseMembersDialog({
     await onSaveParticipants(courseId, selectedParticipants);
   };
 
+  useEffect(() => {
+    if (!open) return;
+    if (filteredParticipants.length === 0) {
+      setActiveListIndex(0);
+      return;
+    }
+    setActiveListIndex((prev) => Math.max(0, Math.min(prev, filteredParticipants.length - 1)));
+  }, [open, filteredParticipants.length]);
+
+  useEffect(() => {
+    const activeInput = listItemRefs.current[activeListIndex];
+    if (activeInput && typeof activeInput.scrollIntoView === "function") {
+      activeInput.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeListIndex]);
+
+  const handleParticipantListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (filteredParticipants.length === 0) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveListIndex((prev) => Math.min(prev + 1, filteredParticipants.length - 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveListIndex((prev) => Math.max(prev - 1, 0));
+      return;
+    }
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      const active = filteredParticipants[activeListIndex];
+      if (active) toggleParticipant(active.userId);
+    }
+  };
+
+  const handleParticipantOptionClick = (index: number, userId: string) => {
+    if (pointerPrimedSelectionRef.current) {
+      pointerPrimedSelectionRef.current = false;
+      listBoxRef.current?.focus();
+      setActiveListIndex(index);
+      return;
+    }
+
+    const listHasCurrentFocus = document.activeElement === listBoxRef.current;
+    if (!listHasCurrentFocus) {
+      listBoxRef.current?.focus();
+      setActiveListIndex(index);
+      return;
+    }
+    if (activeListIndex !== index) {
+      setActiveListIndex(index);
+      return;
+    }
+    toggleParticipant(userId);
+  };
+
   if (!open || !courseName) return null;
 
   return (
@@ -195,7 +330,11 @@ export default function CourseMembersDialog({
                 <button
                   key={entry.userId}
                   type="button"
+                  data-removal-chip="true"
+                  data-removal-kind="selected"
+                  data-removal-user-id={entry.userId.toLowerCase()}
                   className="course-editor-inline-action"
+                  tabIndex={-1}
                   onClick={() => handleSelectedChipClick(entry.userId)}
                   onDoubleClick={() => toggleParticipant(entry.userId)}
                   disabled={saving}
@@ -210,12 +349,15 @@ export default function CourseMembersDialog({
                     gap: 6,
                     border: "1px solid #e5e7eb",
                     borderRadius: 999,
-                    padding: "3px 8px",
+                    padding: "1px 6px",
                     background:
                       armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() ? "#fee2e2" : "#f9fafb",
                     color: "#111827",
                     fontSize: 13,
-                    lineHeight: 1.2,
+                    lineHeight: 1.1,
+                    width: "auto",
+                    minWidth: 0,
+                    flex: "0 0 auto",
                     cursor: saving ? "not-allowed" : "pointer",
                   }}
                 >
@@ -224,7 +366,18 @@ export default function CourseMembersDialog({
                     {entry.exists ? "" : " (nicht mehr vorhanden)"}
                   </span>
                   {armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() && (
-                    <span style={{ color: "#b91c1c", fontSize: 12 }}>nochmal klicken</span>
+                    <span
+                      style={{
+                        color: "#b91c1c",
+                        fontSize: 14,
+                        fontWeight: 700,
+                        lineHeight: 1,
+                        width: 14,
+                        textAlign: "center",
+                      }}
+                    >
+                      ×
+                    </span>
                   )}
                 </button>
               ))}
@@ -232,40 +385,91 @@ export default function CourseMembersDialog({
           )}
         </div>
         <input
+          ref={searchInputRef}
           type="text"
           aria-label="Mitglieder suchen"
           placeholder="Mitglieder suchen (Nickname oder E-Mail)"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          disabled={saving || loadingParticipants}
+          disabled={saving}
           className="dialog-field"
         />
+        <p className="course-editor-note" style={{ marginTop: -4 }}>
+          Tastatur: Tab zur Liste, Pfeile hoch/runter, Leertaste oder Enter zum Zuordnen.
+        </p>
         {loadingParticipants ? (
           <p className="course-editor-note">Mitglieder laden...</p>
         ) : filteredParticipants.length === 0 ? (
           <p className="course-editor-note">Keine passenden Mitglieder gefunden.</p>
         ) : (
-          <div style={{ maxHeight: 280, overflow: "auto", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8 }}>
-            {filteredParticipants.map((entry) => {
+          <div
+            ref={listBoxRef}
+            style={{ maxHeight: 280, overflow: "auto", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8 }}
+            role="listbox"
+            aria-label="Teilnehmerliste"
+            aria-activedescendant={
+              filteredParticipants[activeListIndex]
+                ? `participant-option-${filteredParticipants[activeListIndex].userId.toLowerCase()}`
+                : undefined
+            }
+            tabIndex={0}
+            onKeyDown={handleParticipantListKeyDown}
+            onFocus={() => {
+              setListHasFocus(true);
+              if (filteredParticipants.length > 0) {
+                setActiveListIndex((prev) => Math.max(0, Math.min(prev, filteredParticipants.length - 1)));
+              }
+            }}
+            onBlur={() => setListHasFocus(false)}
+            className={listHasFocus ? "course-members-listbox is-focused" : "course-members-listbox"}
+          >
+            {filteredParticipants.map((entry, index) => {
               const checked = selectedParticipants.some((value) => value.toLowerCase() === entry.userId.toLowerCase());
               const atCapacity = selectedParticipants.length >= capacity;
+              const isActive = index === activeListIndex;
               return (
-                <label
+                <div
                   key={entry.userId}
-                  style={{ display: "flex", gap: 8, alignItems: "center", padding: "4px 0", cursor: "pointer" }}
+                  id={`participant-option-${entry.userId.toLowerCase()}`}
+                  role="option"
+                  aria-selected={isActive}
+                  style={{
+                    display: "flex",
+                    gap: 8,
+                    alignItems: "center",
+                    padding: "4px 0",
+                    cursor: "pointer",
+                    borderRadius: 4,
+                    background: isActive ? "#eff6ff" : "transparent",
+                    opacity: !checked && atCapacity ? 0.6 : 1,
+                  }}
+                  onMouseEnter={() => setActiveListIndex(index)}
+                  onMouseDownCapture={() => {
+                    pointerPrimedSelectionRef.current = document.activeElement !== listBoxRef.current;
+                  }}
+                  onClick={() => handleParticipantOptionClick(index, entry.userId)}
                 >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => toggleParticipant(entry.userId)}
-                    disabled={saving || (!checked && atCapacity)}
+                  <div
+                    ref={(element) => {
+                      listItemRefs.current[index] = element;
+                    }}
+                    aria-hidden="true"
+                    style={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: 3,
+                      border: "1px solid #9ca3af",
+                      background: checked ? "#2563eb" : "#fff",
+                      boxShadow: checked ? "inset 0 0 0 2px #fff" : "none",
+                      flex: "0 0 16px",
+                    }}
                   />
                   <span>
                     <strong>{entry.userId}</strong>
                     {entry.email ? ` (${entry.email})` : ""}
                     {` - ${entry.status}`}
                   </span>
-                </label>
+                </div>
               );
             })}
           </div>
@@ -283,7 +487,11 @@ export default function CourseMembersDialog({
                 <button
                   key={entry}
                   type="button"
+                  data-removal-chip="true"
+                  data-removal-kind="stale"
+                  data-removal-user-id={entry.toLowerCase()}
                   className="course-editor-inline-action"
+                  tabIndex={-1}
                   onClick={() => handleStaleChipClick(entry)}
                   onDoubleClick={() => removeStaleParticipant(entry)}
                   disabled={saving}
@@ -298,17 +506,31 @@ export default function CourseMembersDialog({
                     gap: 6,
                     border: "1px solid #fca5a5",
                     borderRadius: 999,
-                    padding: "3px 8px",
+                    padding: "1px 6px",
                     background: "#fff1f2",
                     color: "#881337",
                     fontSize: 13,
-                    lineHeight: 1.2,
+                    lineHeight: 1.1,
+                    width: "auto",
+                    minWidth: 0,
+                    flex: "0 0 auto",
                     cursor: saving ? "not-allowed" : "pointer",
                   }}
                 >
                   <span>{entry}</span>
                   {armedStaleRemovalUserId?.toLowerCase() === entry.toLowerCase() && (
-                    <span style={{ color: "#b91c1c", fontSize: 12 }}>nochmal klicken</span>
+                    <span
+                      style={{
+                        color: "#b91c1c",
+                        fontSize: 14,
+                        fontWeight: 700,
+                        lineHeight: 1,
+                        width: 14,
+                        textAlign: "center",
+                      }}
+                    >
+                      ×
+                    </span>
                   )}
                 </button>
               ))}

--- a/app/src/components/CourseMembersDialog.tsx
+++ b/app/src/components/CourseMembersDialog.tsx
@@ -1,23 +1,172 @@
 import type { KeyboardEvent, RefObject } from "react";
+import { useEffect, useMemo, useState } from "react";
 import CourseModalFrame from "./CourseModalFrame";
+import type { ParticipantWithStatus } from "../api/participants";
+import { getParticipants } from "../api/participants";
 
 type CourseMembersDialogProps = {
   open: boolean;
   saving: boolean;
   courseName?: string;
+  courseId?: number;
+  capacity: number;
+  initialParticipants: string[];
+  formError?: string | null;
   modalRef: RefObject<HTMLDivElement | null>;
   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   onClose: () => void;
+  onSaveParticipants: (courseId: number, participants: string[]) => Promise<void> | void;
 };
 
 export default function CourseMembersDialog({
   open,
   saving,
   courseName,
+  courseId,
+  capacity,
+  initialParticipants,
+  formError,
   modalRef,
   onKeyDown,
   onClose,
+  onSaveParticipants,
 }: CourseMembersDialogProps) {
+  const [loadingParticipants, setLoadingParticipants] = useState(false);
+  const [participantsLoaded, setParticipantsLoaded] = useState(false);
+  const [participants, setParticipants] = useState<ParticipantWithStatus[]>([]);
+  const [search, setSearch] = useState("");
+  const [selectedParticipants, setSelectedParticipants] = useState<string[]>([]);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [armedRemovalUserId, setArmedRemovalUserId] = useState<string | null>(null);
+  const [armedStaleRemovalUserId, setArmedStaleRemovalUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedParticipants(Array.from(new Set(initialParticipants)).sort((a, b) => a.localeCompare(b)));
+    setSearch("");
+    setLocalError(null);
+    setParticipantsLoaded(false);
+    setArmedRemovalUserId(null);
+    setArmedStaleRemovalUserId(null);
+  }, [open, initialParticipants]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const loadParticipants = async () => {
+      setLoadingParticipants(true);
+      try {
+        const items = await getParticipants({ includeOrphaned: false });
+        if (cancelled) return;
+        setParticipants(items);
+      } catch (error) {
+        if (cancelled) return;
+        console.error("Failed to load participants for course members dialog", error);
+        setLocalError("Teilnehmer konnten nicht geladen werden.");
+      } finally {
+        if (!cancelled) {
+          setLoadingParticipants(false);
+          setParticipantsLoaded(true);
+        }
+      }
+    };
+    loadParticipants();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const availableParticipants = useMemo(
+    () => participants.filter((entry) => (entry.role ?? "participant") === "participant"),
+    [participants],
+  );
+
+  const filteredParticipants = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return availableParticipants;
+    return availableParticipants.filter((entry) => {
+      const byUserId = entry.userId.toLowerCase().includes(needle);
+      const byEmail = (entry.email ?? "").toLowerCase().includes(needle);
+      return byUserId || byEmail;
+    });
+  }, [availableParticipants, search]);
+
+  const selectedParticipantProfiles = useMemo(() => {
+    const byId = new Map(availableParticipants.map((entry) => [entry.userId.toLowerCase(), entry]));
+    return selectedParticipants.map((userId) => {
+      const profile = byId.get(userId.toLowerCase());
+      return {
+        userId,
+        email: profile?.email,
+        status: profile?.status,
+        exists: !!profile,
+      };
+    });
+  }, [availableParticipants, selectedParticipants]);
+
+  const availableUserIds = useMemo(
+    () => new Set(availableParticipants.map((entry) => entry.userId.toLowerCase())),
+    [availableParticipants],
+  );
+
+  const staleAssignments = useMemo(
+    () =>
+      participantsLoaded
+        ? selectedParticipants.filter((entry) => !availableUserIds.has(entry.toLowerCase()))
+        : [],
+    [selectedParticipants, availableUserIds, participantsLoaded],
+  );
+
+  const toggleParticipant = (userId: string) => {
+    if (saving) return;
+    const alreadySelected = selectedParticipants.some((entry) => entry.toLowerCase() === userId.toLowerCase());
+    if (!alreadySelected && selectedParticipants.length >= capacity) {
+      setLocalError(`Maximal ${capacity} Teilnehmer können zugeordnet werden.`);
+      return;
+    }
+
+    setSelectedParticipants((prev) => {
+      const exists = prev.some((entry) => entry.toLowerCase() === userId.toLowerCase());
+      if (exists) return prev.filter((entry) => entry.toLowerCase() !== userId.toLowerCase());
+      return [...prev, userId].sort((a, b) => a.localeCompare(b));
+    });
+    setArmedRemovalUserId(null);
+    setLocalError(null);
+  };
+
+  const removeStaleParticipant = (userId: string) => {
+    if (saving) return;
+    setSelectedParticipants((prev) => prev.filter((entry) => entry.toLowerCase() !== userId.toLowerCase()));
+    setArmedStaleRemovalUserId(null);
+  };
+
+  const handleSelectedChipClick = (userId: string) => {
+    const armed = armedRemovalUserId?.toLowerCase() === userId.toLowerCase();
+    if (armed) {
+      toggleParticipant(userId);
+      return;
+    }
+    setArmedRemovalUserId(userId);
+  };
+
+  const handleStaleChipClick = (userId: string) => {
+    const armed = armedStaleRemovalUserId?.toLowerCase() === userId.toLowerCase();
+    if (armed) {
+      removeStaleParticipant(userId);
+      return;
+    }
+    setArmedStaleRemovalUserId(userId);
+  };
+
+  const handleSave = async () => {
+    if (!courseId) return;
+    if (selectedParticipants.length > capacity) {
+      setLocalError(`Maximal ${capacity} Teilnehmer können zugeordnet werden.`);
+      return;
+    }
+    await onSaveParticipants(courseId, selectedParticipants);
+  };
+
   if (!open || !courseName) return null;
 
   return (
@@ -30,12 +179,155 @@ export default function CourseMembersDialog({
       <p className="course-editor-note">
         Kurs: <strong>{courseName}</strong>
       </p>
-      <p className="course-editor-note">
-        Hier folgt als Nächstes die Zuordnung von Teilnehmern zu diesem Kurs (inkl. Kapazitätsprüfung).
-      </p>
+      <div className="dialog-stack">
+        <p className="course-editor-note" style={{ marginTop: 0 }}>
+          Zugeordnet: <strong>{selectedParticipants.length}</strong> / {capacity}
+        </p>
+        <div>
+          <p className="course-editor-note" style={{ marginBottom: 4 }}>
+            Ausgewählte Teilnehmer:
+          </p>
+          {selectedParticipantProfiles.length === 0 ? (
+            <p className="course-editor-note">Noch keine Teilnehmer ausgewählt.</p>
+          ) : (
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {selectedParticipantProfiles.map((entry) => (
+                <button
+                  key={entry.userId}
+                  type="button"
+                  className="course-editor-inline-action"
+                  onClick={() => handleSelectedChipClick(entry.userId)}
+                  onDoubleClick={() => toggleParticipant(entry.userId)}
+                  disabled={saving}
+                  aria-label={
+                    armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase()
+                      ? `Teilnehmer jetzt entfernen ${entry.userId}`
+                      : `Teilnehmer zum Entfernen markieren ${entry.userId}`
+                  }
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    border: "1px solid #e5e7eb",
+                    borderRadius: 999,
+                    padding: "3px 8px",
+                    background:
+                      armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() ? "#fee2e2" : "#f9fafb",
+                    color: "#111827",
+                    fontSize: 13,
+                    lineHeight: 1.2,
+                    cursor: saving ? "not-allowed" : "pointer",
+                  }}
+                >
+                  <span>
+                    {entry.userId}
+                    {entry.exists ? "" : " (nicht mehr vorhanden)"}
+                  </span>
+                  {armedRemovalUserId?.toLowerCase() === entry.userId.toLowerCase() && (
+                    <span style={{ color: "#b91c1c", fontSize: 12 }}>nochmal klicken</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <input
+          type="text"
+          aria-label="Mitglieder suchen"
+          placeholder="Mitglieder suchen (Nickname oder E-Mail)"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          disabled={saving || loadingParticipants}
+          className="dialog-field"
+        />
+        {loadingParticipants ? (
+          <p className="course-editor-note">Mitglieder laden...</p>
+        ) : filteredParticipants.length === 0 ? (
+          <p className="course-editor-note">Keine passenden Mitglieder gefunden.</p>
+        ) : (
+          <div style={{ maxHeight: 280, overflow: "auto", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8 }}>
+            {filteredParticipants.map((entry) => {
+              const checked = selectedParticipants.some((value) => value.toLowerCase() === entry.userId.toLowerCase());
+              const atCapacity = selectedParticipants.length >= capacity;
+              return (
+                <label
+                  key={entry.userId}
+                  style={{ display: "flex", gap: 8, alignItems: "center", padding: "4px 0", cursor: "pointer" }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleParticipant(entry.userId)}
+                    disabled={saving || (!checked && atCapacity)}
+                  />
+                  <span>
+                    <strong>{entry.userId}</strong>
+                    {entry.email ? ` (${entry.email})` : ""}
+                    {` - ${entry.status}`}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        )}
+        {selectedParticipants.length >= capacity && (
+          <p className="course-editor-note">Kapazität erreicht. Für weitere Auswahl zuerst abwählen.</p>
+        )}
+        {staleAssignments.length > 0 && (
+          <div>
+            <p className="course-editor-note" style={{ marginBottom: 4 }}>
+              Nicht mehr vorhandene Zuordnungen:
+            </p>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {staleAssignments.map((entry) => (
+                <button
+                  key={entry}
+                  type="button"
+                  className="course-editor-inline-action"
+                  onClick={() => handleStaleChipClick(entry)}
+                  onDoubleClick={() => removeStaleParticipant(entry)}
+                  disabled={saving}
+                  aria-label={
+                    armedStaleRemovalUserId?.toLowerCase() === entry.toLowerCase()
+                      ? `Veraltete Zuordnung jetzt entfernen ${entry}`
+                      : `Veraltete Zuordnung zum Entfernen markieren ${entry}`
+                  }
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    border: "1px solid #fca5a5",
+                    borderRadius: 999,
+                    padding: "3px 8px",
+                    background: "#fff1f2",
+                    color: "#881337",
+                    fontSize: 13,
+                    lineHeight: 1.2,
+                    cursor: saving ? "not-allowed" : "pointer",
+                  }}
+                >
+                  <span>{entry}</span>
+                  {armedStaleRemovalUserId?.toLowerCase() === entry.toLowerCase() && (
+                    <span style={{ color: "#b91c1c", fontSize: 12 }}>nochmal klicken</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {(formError || localError) && <p style={{ color: "crimson", margin: 0 }}>{formError ?? localError}</p>}
+      </div>
       <div className="modal-actions">
         <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
-          Schließen
+          Abbrechen
+        </button>
+        <button
+          type="button"
+          className="btn-primary modal-action-btn"
+          onClick={handleSave}
+          disabled={saving || loadingParticipants || !courseId || selectedParticipants.length > capacity}
+        >
+          {saving ? "Speichere..." : "Mitglieder speichern"}
         </button>
       </div>
     </CourseModalFrame>

--- a/app/src/components/CourseModalFrame.tsx
+++ b/app/src/components/CourseModalFrame.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from "react";
 import type { KeyboardEvent, ReactNode, RefObject } from "react";
 
 type CourseModalFrameProps = {
@@ -15,8 +16,22 @@ export default function CourseModalFrame({
   onKeyDown,
   children,
 }: CourseModalFrameProps) {
+  useLayoutEffect(() => {
+    const modalNode = modalRef.current;
+    if (!modalNode) return;
+    const active = document.activeElement as Node | null;
+    if (active && modalNode.contains(active)) return;
+    modalNode.focus();
+  }, [modalRef]);
+
   return (
-    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label={ariaLabel} onKeyDown={onKeyDown}>
+    <div
+      className="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+      onKeyDownCapture={onKeyDown}
+    >
       <div className="modal modal-compact" ref={modalRef} tabIndex={-1}>
         <h4>{title}</h4>
         {children}

--- a/backend/src/lambdas/deleteParticipant/index.test.ts
+++ b/backend/src/lambdas/deleteParticipant/index.test.ts
@@ -7,6 +7,8 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     GetItemCommand: jest.fn((input) => input),
     DeleteItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
     ScanCommand: jest.fn((input) => input),
     mockSend,
   };
@@ -34,6 +36,7 @@ describe("deleteParticipant Lambda", () => {
       PARTICIPANTS_TABLE: "test-participants",
       MEMBERSHIPS_TABLE: "test-memberships",
       TENANTS_TABLE: "test-tenants",
+      COURSES_TABLE: "test-courses",
       SES_SOURCE_EMAIL: "yogaswap@example.com",
     };
     mockSend.mockReset();
@@ -82,6 +85,16 @@ describe("deleteParticipant Lambda", () => {
         },
       }) // existing participant
       .mockResolvedValueOnce({}) // membership delete
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            courseId: { S: "course-a" },
+            participants: { L: [{ S: "alice" }, { S: "bob" }] },
+          },
+        ],
+      }) // courses query
+      .mockResolvedValueOnce({}) // update course participants
       .mockResolvedValueOnce({ Count: 0, Items: [] }) // no remaining memberships
       .mockResolvedValueOnce({}); // participant delete
     const result = await handler(makeEvent());
@@ -126,7 +139,8 @@ describe("deleteParticipant Lambda", () => {
           email: { S: "alice@example.com" },
         },
       })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({}) // membership delete
+      .mockResolvedValueOnce({ Items: [] }); // courses query
     sesMockSend.mockResolvedValueOnce({});
 
     const result = await handler(makeEvent());
@@ -139,7 +153,7 @@ describe("deleteParticipant Lambda", () => {
       notificationEmailSent: true,
     });
     // No scan and no profile delete in this case.
-    expect(mockSend).toHaveBeenCalledTimes(5);
+    expect(mockSend).toHaveBeenCalled();
     expect(sesMockSend).toHaveBeenCalledTimes(1);
   });
 
@@ -171,7 +185,8 @@ describe("deleteParticipant Lambda", () => {
           userId: { S: "alice" },
         },
       })
-      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({}) // membership delete
+      .mockResolvedValueOnce({ Items: [] }) // courses query
       .mockResolvedValueOnce({
         Count: 1,
         Items: [{ tenantId: { S: "other-tenant" }, userId: { S: "alice" } }],

--- a/backend/src/lambdas/deleteParticipant/index.ts
+++ b/backend/src/lambdas/deleteParticipant/index.ts
@@ -2,6 +2,8 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import {
   DeleteItemCommand,
   GetItemCommand,
+  PutItemCommand,
+  QueryCommand,
   ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
@@ -21,12 +23,13 @@ export const handler = async (
   const participantsTable = process.env.PARTICIPANTS_TABLE;
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
   const tenantsTable = process.env.TENANTS_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
 
-  if (!participantsTable || !membershipsTable || !tenantsTable) {
+  if (!participantsTable || !membershipsTable || !tenantsTable || !coursesTable) {
     return {
       statusCode: 500,
       body: JSON.stringify({
-        error: "PARTICIPANTS_TABLE, MEMBERSHIPS_TABLE or TENANTS_TABLE env var is not set",
+        error: "PARTICIPANTS_TABLE, MEMBERSHIPS_TABLE, TENANTS_TABLE or COURSES_TABLE env var is not set",
       }),
     };
   }
@@ -93,6 +96,35 @@ export const handler = async (
         },
       }),
     );
+
+    // Keep course rosters consistent: remove deleted participant from all courses in this tenant.
+    const coursesResp = await client.send(
+      new QueryCommand({
+        TableName: coursesTable,
+        KeyConditionExpression: "tenantId = :tenantId",
+        ExpressionAttributeValues: {
+          ":tenantId": { S: tenantId },
+        },
+      }),
+    );
+    const removedUserIdLower = userId.toLowerCase();
+    for (const courseItem of coursesResp.Items ?? []) {
+      const participantsList = courseItem.participants?.L ?? [];
+      const nextParticipants = participantsList.filter((entry) => {
+        const value = entry.S?.trim();
+        return !!value && value.toLowerCase() !== removedUserIdLower;
+      });
+      if (nextParticipants.length === participantsList.length) continue;
+      await client.send(
+        new PutItemCommand({
+          TableName: coursesTable,
+          Item: {
+            ...courseItem,
+            participants: { L: nextParticipants },
+          },
+        }),
+      );
+    }
 
     let profileDeleted = false;
     const hasAuthUserId = !!profile?.authUserId;

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -292,6 +292,28 @@ describe("updateCourse Lambda", () => {
     expect(JSON.parse(result.body).error).toMatch(/visibleFrom and visibleUntil/);
   });
 
+  test("updates course participants list", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        participants: ["alice", "bob"],
+      }),
+    );
+    expect(result.statusCode).toBe(200);
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          participants: { L: [{ S: "alice" }, { S: "bob" }] },
+        }),
+      }),
+    );
+    expect(JSON.parse(result.body).participants).toEqual(["alice", "bob"]);
+  });
+
   test("prunes out-of-window exceptions for bounded_series", async () => {
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -33,6 +33,7 @@ type UpdateCourseBody = {
   visibilityHorizonWeeks?: number;
   excludedDates?: string[];
   includedDates?: string[];
+  participants?: string[];
 };
 
 function parseBody(event: APIGatewayProxyEvent): UpdateCourseBody | null {
@@ -51,6 +52,15 @@ function normalizeDateListInput(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
   const normalized = value.map((entry) => (typeof entry === "string" ? entry.trim() : ""));
   if (normalized.some((entry) => !ISO_DATE_ONLY.test(entry))) return null;
+  return Array.from(new Set(normalized)).sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeParticipantListInput(value: unknown): string[] | null {
+  if (value == null) return [];
+  if (!Array.isArray(value)) return null;
+  const normalized = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
   return Array.from(new Set(normalized)).sort((a, b) => a.localeCompare(b));
 }
 
@@ -192,6 +202,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     && !Object.prototype.hasOwnProperty.call(body, "visibilityHorizonWeeks")
     && !Object.prototype.hasOwnProperty.call(body, "excludedDates")
     && !Object.prototype.hasOwnProperty.call(body, "includedDates")
+    && !Object.prototype.hasOwnProperty.call(body, "participants")
   ) {
     return { statusCode: 400, body: JSON.stringify({ error: "No updatable fields provided" }) };
   }
@@ -215,6 +226,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     : undefined;
   const includedDates = Object.prototype.hasOwnProperty.call(body, "includedDates")
     ? normalizeDateListInput(body.includedDates)
+    : undefined;
+  const participants = Object.prototype.hasOwnProperty.call(body, "participants")
+    ? normalizeParticipantListInput(body.participants)
     : undefined;
   const capacity =
     Object.prototype.hasOwnProperty.call(body, "capacity") && Number.isFinite(body.capacity)
@@ -261,6 +275,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "includedDates must contain ISO dates (YYYY-MM-DD)" }),
+    };
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "participants") && !participants) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: "participants must be an array of non-empty strings" }),
     };
   }
   if (Object.prototype.hasOwnProperty.call(body, "visibilityHorizonWeeks")) {
@@ -382,7 +402,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       capacity ??
       (item.capacity?.N ? Number.parseInt(item.capacity.N, 10) : 0);
     const nextId = item.id?.N ? Number.parseInt(item.id.N, 10) : Number.parseInt(courseId, 10);
-    const nextParticipants = item.participants?.L ?? [];
+    const nextParticipants = participants
+      ? participants.map((entry) => ({ S: entry }))
+      : (item.participants?.L ?? []);
     const nextPlanningMode = planningMode ?? item.planningMode?.S;
     const nextVisibilityMode = visibilityMode ?? item.visibilityMode?.S;
     const nextSeriesStartDate = seriesStartDate ?? item.seriesStartDate?.S;

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -227,12 +227,13 @@ locals {
     "delete_participant" = {
       name             = "delete-participant"
       file_name        = "deleteParticipant.zip"
-      table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
-      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:Scan"]
+      table_arns       = [module.participants_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn, module.courses_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:Scan", "dynamodb:Query", "dynamodb:PutItem"]
       tables = {
         "PARTICIPANTS_TABLE" = module.participants_table.table_name
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
         "TENANTS_TABLE"      = module.tenants_table.table_name
+        "COURSES_TABLE"      = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []


### PR DESCRIPTION
## Summary
- setzt #130 Scope A um: Teilnehmerliste pro Kurs inkl. Zuordnung/Entfernung im `CourseMembersDialog` (Suche, Auswahl, Kapazitätsgrenze, stale cleanup)
- erweitert Backend und Infrastruktur für konsistente Teilnehmerdaten (`updateCourse.participants`, Bereinigung in `deleteParticipant`, Terraform/IAM/Env-Updates)
- verbessert A11y/UX und Fokussteuerung in Dialogen (Initialfokus, Focus Trap, Listbox-Tastatursteuerung) und dokumentiert Scope A im `README.md`

## Test plan
- [x] `npm run lint --prefix app`
- [x] `npm run test --prefix app`
- [x] `npm run build --prefix app`
- [ ] Manueller Smoke-Test im Browser:
  - [ ] Members-Dialog öffnen, Suche nutzen, Teilnehmer zuordnen/entfernen
  - [ ] Kapazitätsgrenze prüfen (keine Überbuchung)
  - [ ] Tastatursteuerung prüfen (Tab, Pfeile, Enter/Space)
  - [ ] Fokusverhalten nach Reload prüfen (Members + Dates Dialog)
