### PR TITLE
Harden delegation frontend tests and a11y guards (#142)

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import App from "./App";
 import { getActingForUserId, setActingForUserId, setActorUserId } from "./api/delegation";
+import { canManageParticipants } from "shared/permissions";
 
 const courseListMock = vi.fn<(props: unknown) => void>();
 
@@ -78,6 +79,7 @@ describe("App delegation mode", () => {
     cleanup();
     vi.clearAllMocks();
     courseListMock.mockClear();
+    vi.mocked(canManageParticipants).mockReturnValue(true);
     setActingForUserId(null);
     setActorUserId(null);
   });
@@ -180,5 +182,137 @@ describe("App delegation mode", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /logout/i }));
     expect(getActingForUserId()).toBeNull();
+  });
+
+  it("does not show delegation entry when user cannot delegate", async () => {
+    const { fetchAuthSession } = await import("aws-amplify/auth");
+    const { getTenantContext } = await import("./api/tenantContext");
+    const { canManageParticipants } = await import("shared/permissions");
+
+    vi.mocked(fetchAuthSession).mockResolvedValue({
+      tokens: {
+        idToken: {
+          payload: {
+            nickname: "admin",
+            email: "admin@example.com",
+            "custom:role": "admin",
+          },
+        },
+      },
+    } as unknown as never);
+
+    vi.mocked(getTenantContext).mockResolvedValue({
+      tenant: { tenantId: "default-tenant", name: "Default" },
+      membership: { tenantId: "default-tenant", userId: "admin", role: "admin" },
+    } as unknown as never);
+
+    vi.mocked(canManageParticipants).mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/hi, admin/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: /^vertretung$/i })).not.toBeInTheDocument();
+  });
+
+  it("allows cancelling delegation confirmation without activating mode", async () => {
+    const { fetchAuthSession } = await import("aws-amplify/auth");
+    const { getTenantContext } = await import("./api/tenantContext");
+    const { getParticipants } = await import("./api/participants");
+
+    vi.mocked(fetchAuthSession).mockResolvedValue({
+      tokens: {
+        idToken: {
+          payload: {
+            nickname: "admin",
+            email: "admin@example.com",
+            "custom:role": "admin",
+          },
+        },
+      },
+    } as unknown as never);
+
+    vi.mocked(getTenantContext).mockResolvedValue({
+      tenant: { tenantId: "default-tenant", name: "Default" },
+      membership: { tenantId: "default-tenant", userId: "admin", role: "admin" },
+    } as unknown as never);
+
+    vi.mocked(getParticipants).mockResolvedValue([
+      { userId: "maya", status: "active", role: "participant", tenantId: "default-tenant" },
+    ] as unknown as never);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/hi, admin/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: /^vertretung$/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /maya/i }));
+    await userEvent.click(screen.getByRole("button", { name: /abbrechen/i }));
+
+    expect(screen.queryByText(/vertretung aktiv:/i)).not.toBeInTheDocument();
+    expect(getActingForUserId()).toBeNull();
+  });
+
+  it("supports switching delegation from one participant to another", async () => {
+    const { fetchAuthSession } = await import("aws-amplify/auth");
+    const { getTenantContext } = await import("./api/tenantContext");
+    const { getParticipants } = await import("./api/participants");
+
+    vi.mocked(fetchAuthSession).mockResolvedValue({
+      tokens: {
+        idToken: {
+          payload: {
+            nickname: "admin",
+            email: "admin@example.com",
+            "custom:role": "admin",
+          },
+        },
+      },
+    } as unknown as never);
+
+    vi.mocked(getTenantContext).mockResolvedValue({
+      tenant: { tenantId: "default-tenant", name: "Default" },
+      membership: { tenantId: "default-tenant", userId: "admin", role: "admin" },
+    } as unknown as never);
+
+    vi.mocked(getParticipants).mockResolvedValue([
+      { userId: "maya", status: "active", role: "participant", tenantId: "default-tenant" },
+      { userId: "luca", status: "invited", role: "participant", tenantId: "default-tenant" },
+    ] as unknown as never);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/hi, admin/i)).toBeInTheDocument();
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: /^vertretung$/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /maya/i }));
+    await userEvent.click(screen.getByRole("button", { name: /bestätigen/i }));
+    expect(screen.getByText(/im auftrag von/i)).toHaveTextContent(/maya/i);
+    expect(getActingForUserId()).toBe("maya");
+
+    await userEvent.click(screen.getByRole("button", { name: /^vertretung$/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /luca/i }));
+    await userEvent.click(screen.getByRole("button", { name: /bestätigen/i }));
+
+    expect(screen.getByText(/im auftrag von/i)).toHaveTextContent(/luca/i);
+    expect(getActingForUserId()).toBe("luca");
   });
 });

--- a/app/src/components/CourseMembersDialog.test.tsx
+++ b/app/src/components/CourseMembersDialog.test.tsx
@@ -202,4 +202,29 @@ describe("CourseMembersDialog", () => {
       expect(screen.getByRole("button", { name: /teilnehmer zum entfernen markieren alice/i })).toBeInTheDocument();
     });
   });
+
+  it("keeps listbox connected to keyboard hint via aria-describedby", async () => {
+    mockedGetParticipants.mockResolvedValue([
+      { userId: "alice", status: "active", role: "participant", tenantId: "default-tenant" },
+    ]);
+    render(
+      <CourseMembersDialog
+        open
+        saving={false}
+        courseId={7}
+        courseName="Yoga Flow"
+        capacity={5}
+        initialParticipants={[]}
+        modalRef={createRef<HTMLDivElement>()}
+        onKeyDown={vi.fn()}
+        onClose={vi.fn()}
+        onSaveParticipants={vi.fn()}
+      />,
+    );
+
+    const listbox = await screen.findByRole("listbox", { name: /teilnehmerliste/i });
+    const hint = screen.getByText(/tastatur: tab zur liste/i);
+    expect(listbox).toHaveAttribute("aria-describedby", "course-members-list-hint");
+    expect(hint).toHaveAttribute("id", "course-members-list-hint");
+  });
 });

--- a/app/src/components/DelegationPickerDialog.test.tsx
+++ b/app/src/components/DelegationPickerDialog.test.tsx
@@ -95,6 +95,31 @@ describe("DelegationPickerDialog", () => {
     expect(onSelectUser).toHaveBeenCalledWith("luca");
   });
 
+  it("keeps active option within list bounds on arrow navigation", () => {
+    render(
+      <DelegationPickerDialog
+        open
+        search=""
+        candidates={[
+          { userId: "maya", status: "active", role: "participant", tenantId: "default-tenant" },
+          { userId: "luca", status: "invited", role: "participant", tenantId: "default-tenant" },
+        ]}
+        onSearchChange={vi.fn()}
+        onSelectUser={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: /vertretungsteilnehmerliste/i });
+    listbox.focus();
+    fireEvent.keyDown(listbox, { key: "ArrowUp" });
+    expect(listbox).toHaveAttribute("aria-activedescendant", "delegation-option-maya");
+
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    expect(listbox).toHaveAttribute("aria-activedescendant", "delegation-option-luca");
+  });
+
   it("closes on Escape and selects on click", async () => {
     const onClose = vi.fn();
     const onSelectUser = vi.fn();


### PR DESCRIPTION
## Summary
- add robust App delegation tests for denied delegation entry, confirm-cancel flow, and switching delegation from one participant to another
- extend `DelegationPickerDialog` tests with keyboard boundary navigation assertions
- add a CourseMembersDialog a11y guard test to ensure listbox/hint wiring via `aria-describedby`
- keep test setup stable by resetting delegation permission mocks in `beforeEach`

## Test plan
- [x] `npm --prefix app test -- App.test.tsx DelegationPickerDialog.test.tsx CourseMembersDialog.test.tsx`
- [x] `npm --prefix app test -- App.test.tsx DelegationPickerDialog.test.tsx CourseMembersDialog.test.tsx` (re-run after mock reset fix)

Made with [Cursor](https://cursor.com)