### PR TITLE
#46 Trainerin kann Kurstermin absagen: Absage-Flow hardening + Impact/Konsistenz-Fixes

### DIFF
--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -27,6 +27,24 @@ export type CreateCourseRequest = {
 
 export type UpdateCourseRequest = Partial<CreateCourseRequest>;
 
+export type CancelCourseDateRequest = {
+  rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
+  notifyAlreadyCancelledParticipants?: boolean;
+};
+
+export type CancelCourseDateResponse = {
+  success: boolean;
+  courseId: number;
+  date: string;
+  affected?: {
+    bookedParticipants: string[];
+    swappedInParticipants: string[];
+    waitlistParticipants: string[];
+    alreadyCancelledParticipants: string[];
+    outgoingSwapsFromCancelledParticipants: string[];
+  };
+};
+
 export type DeleteCourseResponse = {
   success: boolean;
   courseId: string;
@@ -112,6 +130,18 @@ export async function updateCourse(courseId: number | string, request: UpdateCou
 export async function deleteCourse(courseId: number | string): Promise<DeleteCourseResponse> {
   const response = await axios.delete<DeleteCourseResponse>(
     `/courses/${encodeURIComponent(String(courseId))}`,
+  );
+  return response.data;
+}
+
+export async function cancelCourseDate(
+  courseId: number | string,
+  date: string,
+  request: CancelCourseDateRequest,
+): Promise<CancelCourseDateResponse> {
+  const response = await axios.post<CancelCourseDateResponse>(
+    `/courses/${encodeURIComponent(String(courseId))}/dates/${encodeURIComponent(date)}/cancel`,
+    request,
   );
   return response.data;
 }

--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -36,6 +36,7 @@ export type CancelCourseDateResponse = {
   success: boolean;
   courseId: number;
   date: string;
+  operationWarnings?: string[];
   affected?: {
     bookedParticipants: string[];
     swappedInParticipants: string[];

--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -28,7 +28,11 @@ export type CreateCourseRequest = {
 export type UpdateCourseRequest = Partial<CreateCourseRequest>;
 
 export type CancelCourseDateRequest = {
+  rollbackSuccessfulSwapsFromCancelledParticipants?: boolean;
+  rollbackPendingWaitlistSwapsFromOriginDate?: boolean;
+  // backward compatible field kept for older clients/lambdas
   rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
+  // deprecated; backend now always notifies already-cancelled participants
   notifyAlreadyCancelledParticipants?: boolean;
 };
 

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -366,4 +366,54 @@ describe("CourseDatesDialog", () => {
     const allowedCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-02-10/i });
     expect(allowedCell).not.toBeDisabled();
   });
+
+  it("zeigt Hinweis statt Fehler bei teilweisem Erfolg mit operationWarnings", async () => {
+    mockedCancelCourseDate.mockResolvedValue({
+      success: true,
+      courseId: 1,
+      date: "2026-01-06",
+      operationWarnings: ["participant_lookup_failed"],
+    });
+    const onClose = vi.fn();
+    const onSaved = vi.fn().mockResolvedValue(undefined);
+    render(
+      <CourseDatesDialog
+        course={makeCourse({ status: "active", participants: ["luna"] })}
+        overrides={[
+          {
+            courseId: 1,
+            date: "2026-01-06",
+            participants: ["luna"],
+            swapped: [],
+            waitlist: [],
+          },
+        ]}
+        swaps={[]}
+        canManageCourses
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    await user.click(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i }));
+    await user.click(dialogQueries.getByRole("button", { name: /absage überprüfen/i }));
+    await user.click(dialogQueries.getByRole("button", { name: /termin jetzt absagen/i }));
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledTimes(1);
+      expect(onClose).not.toHaveBeenCalled();
+      expect(
+        screen.getByText(/termin wurde abgesagt, aber es gab hinweise bei nebenoperationen/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /einzelne teilnehmerprofile konnten fuer den mailversand nicht geladen werden|some participant profiles could not be loaded for mail delivery/i,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -3,13 +3,15 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 import type { Course } from "shared/types";
 import CourseDatesDialog from "./CourseDatesDialog";
-import { updateCourse } from "../api/courses";
+import { cancelCourseDate, updateCourse } from "../api/courses";
 
 vi.mock("../api/courses", () => ({
   updateCourse: vi.fn(),
+  cancelCourseDate: vi.fn(),
 }));
 
 const mockedUpdateCourse = updateCourse as unknown as ReturnType<typeof vi.fn>;
+const mockedCancelCourseDate = cancelCourseDate as unknown as ReturnType<typeof vi.fn>;
 
 function makeCourse(overrides: Partial<Course> = {}): Course {
   return {
@@ -48,6 +50,8 @@ describe("CourseDatesDialog", () => {
     render(
       <CourseDatesDialog
         course={null}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -62,6 +66,8 @@ describe("CourseDatesDialog", () => {
     render(
       <CourseDatesDialog
         course={makeCourse()}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={onClose}
         onSaved={vi.fn()}
@@ -80,6 +86,8 @@ describe("CourseDatesDialog", () => {
     render(
       <CourseDatesDialog
         course={makeCourse()}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={onClose}
         onSaved={onSaved}
@@ -125,6 +133,8 @@ describe("CourseDatesDialog", () => {
     render(
       <CourseDatesDialog
         course={makeCourse()}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -158,6 +168,8 @@ describe("CourseDatesDialog", () => {
           planningMode: "rolling_continuous",
           visibilityHorizonWeeks: 10,
         })}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={onClose}
         onSaved={onSaved}
@@ -200,6 +212,8 @@ describe("CourseDatesDialog", () => {
           planningMode: "rolling_continuous",
           visibilityHorizonWeeks: 10,
         })}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -229,6 +243,8 @@ describe("CourseDatesDialog", () => {
           planningMode: "rolling_continuous",
           visibilityHorizonWeeks: 2,
         })}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -247,12 +263,31 @@ describe("CourseDatesDialog", () => {
     expect(farFutureCell).not.toBeDisabled();
   });
 
-  it("ist bei aktivem Kurs read-only mit Kalenderansicht", async () => {
-    mockedUpdateCourse.mockResolvedValue({});
+  it("zeigt bei aktivem Kursblock nur den Absage-Flow", async () => {
+    mockedCancelCourseDate.mockResolvedValue({ success: true, courseId: 1, date: "2026-01-06" });
     const onClose = vi.fn();
     render(
       <CourseDatesDialog
-        course={makeCourse({ status: "active" })}
+        course={makeCourse({ status: "active", participants: ["luna", "maya"] })}
+        overrides={[
+          {
+            courseId: 1,
+            date: "2026-01-06",
+            participants: ["luna"],
+            swapped: ["nora"],
+            waitlist: ["maya"],
+          },
+        ]}
+        swaps={[
+          {
+            user: "maya",
+            fromCourseId: 1,
+            fromDate: "2026-01-06",
+            toCourseId: 2,
+            toDate: "2026-01-09",
+            status: "pending",
+          },
+        ]}
         canManageCourses
         onClose={onClose}
         onSaved={vi.fn()}
@@ -266,18 +301,37 @@ describe("CourseDatesDialog", () => {
 
     expect(dialogQueries.getByText(/kurs ist aktiv\. terminplanung ist gesperrt/i)).toBeInTheDocument();
     expect(dialogQueries.queryByRole("button", { name: /termine übernehmen/i })).not.toBeInTheDocument();
-    expect(dialogQueries.getByRole("button", { name: /^schließen$/i })).toBeInTheDocument();
+    expect(dialogQueries.queryByRole("button", { name: /kalender für ausnahmetermin öffnen/i })).not.toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeDisabled();
+    expect(dialogQueries.getByRole("button", { name: /^abbrechen$/i })).toBeInTheDocument();
+    expect(dialogQueries.getByText(/ausgewählter termin:/i)).toBeInTheDocument();
+    expect(dialogQueries.getByText(/keiner ausgewählt/i)).toBeInTheDocument();
 
-    await user.click(dialogQueries.getByRole("button", { name: /kalender für zeitraum öffnen/i }));
-    const rangeDateButton = dialogQueries.getByRole("button", { name: /datum 2026-01-06/i });
-    expect(rangeDateButton).toBeDisabled();
+    expect(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i })).toBeInTheDocument();
+    await user.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+    expect(dialogQueries.queryByRole("button", { name: /absage datum 2026-01-06/i })).not.toBeInTheDocument();
+    await user.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+    await user.click(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i }));
+    expect(dialogQueries.queryByRole("button", { name: /absage datum 2026-01-06/i })).not.toBeInTheDocument();
+    expect(dialogQueries.getByText(formatDateForDisplay("2026-01-06"))).toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeEnabled();
+    await user.click(dialogQueries.getByRole("button", { name: /absage überprüfen/i }));
+    expect(dialogQueries.getByRole("group", { name: /auswirkungsprüfung terminabsage/i })).toBeInTheDocument();
+    await user.click(dialogQueries.getByRole("button", { name: /termin jetzt absagen/i }));
 
-    await user.click(dialogQueries.getByRole("button", { name: /kalender für ausnahmetermin öffnen/i }));
-    const excludedDateButton = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-01-13/i });
-    expect(excludedDateButton).toBeDisabled();
+    await waitFor(() => {
+      expect(mockedCancelCourseDate).toHaveBeenCalledWith(
+        1,
+        "2026-01-06",
+        expect.objectContaining({
+          rollbackOutgoingSwapsFromCancelledParticipants: true,
+          notifyAlreadyCancelledParticipants: true,
+        }),
+      );
+    });
 
-    await user.click(dialogQueries.getByRole("button", { name: /^schließen$/i }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await user.click(dialogQueries.getByRole("button", { name: /^abbrechen$/i }));
+    expect(onClose).toHaveBeenCalled();
     expect(mockedUpdateCourse).not.toHaveBeenCalled();
   });
 
@@ -291,6 +345,8 @@ describe("CourseDatesDialog", () => {
           planningMode: "rolling_continuous",
           visibilityHorizonWeeks: 10,
         })}
+        overrides={[]}
+        swaps={[]}
         canManageCourses
         onClose={vi.fn()}
         onSaved={vi.fn()}

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -416,4 +416,57 @@ describe("CourseDatesDialog", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("berechnet Swap-Zähler case-insensitiv", async () => {
+    mockedCancelCourseDate.mockResolvedValue({ success: true, courseId: 1, date: "2026-01-06" });
+    render(
+      <CourseDatesDialog
+        course={makeCourse({ status: "active", participants: ["Luna"] })}
+        overrides={[
+          {
+            courseId: 1,
+            date: "2026-01-06",
+            participants: [],
+            swapped: [],
+            waitlist: [],
+          },
+        ]}
+        swaps={[
+          {
+            user: "luna",
+            fromCourseId: 1,
+            fromDate: "2026-01-06",
+            toCourseId: 2,
+            toDate: "2099-01-09",
+            status: "active",
+          },
+          {
+            user: "luna",
+            fromCourseId: 1,
+            fromDate: "2026-01-06",
+            toCourseId: 3,
+            toDate: "2099-01-10",
+            status: "pending",
+          },
+        ]}
+        canManageCourses
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    await user.click(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i }));
+    await user.click(dialogQueries.getByRole("button", { name: /absage überprüfen/i }));
+
+    expect(
+      dialogQueries.getByText(/erfolgreiche tauschs in andere termine zurückrollen\s*\(1\)/i),
+    ).toBeInTheDocument();
+    expect(
+      dialogQueries.getByText(/tauschanfragen auf wartelisten in andere termine zurückrollen\s*\(1\)/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -324,8 +324,8 @@ describe("CourseDatesDialog", () => {
         1,
         "2026-01-06",
         expect.objectContaining({
-          rollbackOutgoingSwapsFromCancelledParticipants: false,
-          notifyAlreadyCancelledParticipants: true,
+          rollbackSuccessfulSwapsFromCancelledParticipants: false,
+          rollbackPendingWaitlistSwapsFromOriginDate: true,
         }),
       );
     });

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -324,7 +324,7 @@ describe("CourseDatesDialog", () => {
         1,
         "2026-01-06",
         expect.objectContaining({
-          rollbackOutgoingSwapsFromCancelledParticipants: true,
+          rollbackOutgoingSwapsFromCancelledParticipants: false,
           notifyAlreadyCancelledParticipants: true,
         }),
       );

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -23,6 +23,7 @@ import {
   shiftMonthKey,
   type CourseDatesEditorState,
 } from "./courseDatesDialogUtils";
+import { resolveWarningMessages } from "../i18n";
 
 type CourseDatesDialogProps = {
   course: Course | null;
@@ -70,6 +71,7 @@ export default function CourseDatesDialog({
   const [datesState, setDatesState] = useState<CourseDatesEditorState | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [formNotices, setFormNotices] = useState<string[]>([]);
   const [selectedCancellationDate, setSelectedCancellationDate] = useState<string | null>(null);
   const [impactDialogOpen, setImpactDialogOpen] = useState(false);
   const [rollbackOutgoingSwaps, setRollbackOutgoingSwaps] = useState(false);
@@ -80,6 +82,7 @@ export default function CourseDatesDialog({
     if (!course) {
       setDatesState(null);
       setFormError(null);
+      setFormNotices([]);
       return;
     }
     const nextState = createDatesState(course);
@@ -88,6 +91,7 @@ export default function CourseDatesDialog({
     }
     setDatesState(nextState);
     setFormError(null);
+    setFormNotices([]);
     setSelectedCancellationDate(null);
     setImpactDialogOpen(false);
     setRollbackOutgoingSwaps(false);
@@ -347,6 +351,7 @@ export default function CourseDatesDialog({
         : prev,
     );
     setFormError(null);
+    setFormNotices([]);
   };
 
   const setSeriesRangeDate = (isoDate: string) => {
@@ -376,6 +381,7 @@ export default function CourseDatesDialog({
       };
     });
     setFormError(null);
+    setFormNotices([]);
   };
 
   const shiftRangeCalendarMonth = (monthDelta: number) => {
@@ -466,15 +472,25 @@ export default function CourseDatesDialog({
     if (!course || !selectedCancellationDate) return;
     setSaving(true);
     setFormError(null);
+    setFormNotices([]);
     try {
-      await cancelCourseDate(course.id, selectedCancellationDate, {
+      const response = await cancelCourseDate(course.id, selectedCancellationDate, {
         rollbackOutgoingSwapsFromCancelledParticipants: rollbackOutgoingSwaps,
         notifyAlreadyCancelledParticipants,
       });
       setImpactDialogOpen(false);
       setSelectedCancellationDate(null);
-      onClose();
       await onSaved();
+      if (response.operationWarnings && response.operationWarnings.length > 0) {
+        const localizedWarnings = resolveWarningMessages(response.operationWarnings, displayLocale);
+        setFormNotices(
+          localizedWarnings.length > 0
+            ? localizedWarnings
+            : ["Termin wurde abgesagt, aber es gab Hinweise bei Nebenoperationen."],
+        );
+        return;
+      }
+      onClose();
     } catch (err) {
       console.error("Failed to cancel course date", err);
       setFormError(err instanceof Error ? err.message : "Termin konnte nicht abgesagt werden.");
@@ -504,6 +520,7 @@ export default function CourseDatesDialog({
 
     setSaving(true);
     setFormError(null);
+    setFormNotices([]);
     try {
       if (datesState.planningMode === "rolling_continuous") {
         await updateCourse(datesState.courseId, {
@@ -918,6 +935,18 @@ export default function CourseDatesDialog({
           )}
 
         </div>
+        {formNotices.length > 0 && (
+          <div style={{ color: "#8a6d1d", margin: 0 }}>
+            <p style={{ margin: 0 }}>
+              Termin wurde abgesagt, aber es gab Hinweise bei Nebenoperationen:
+            </p>
+            <ul style={{ margin: "6px 0 0 18px", padding: 0 }}>
+              {formNotices.map((notice) => (
+                <li key={notice}>{notice}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
         {isActiveCancellationMode && impactDialogOpen && cancellationImpact && (
           <div className="course-editor-subsection" role="group" aria-label="Auswirkungsprüfung Terminabsage">

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -74,8 +74,8 @@ export default function CourseDatesDialog({
   const [formNotices, setFormNotices] = useState<string[]>([]);
   const [selectedCancellationDate, setSelectedCancellationDate] = useState<string | null>(null);
   const [impactDialogOpen, setImpactDialogOpen] = useState(false);
-  const [rollbackOutgoingSwaps, setRollbackOutgoingSwaps] = useState(false);
-  const [notifyAlreadyCancelledParticipants, setNotifyAlreadyCancelledParticipants] = useState(true);
+  const [rollbackSuccessfulSwaps, setRollbackSuccessfulSwaps] = useState(false);
+  const [rollbackPendingWaitlistSwaps, setRollbackPendingWaitlistSwaps] = useState(true);
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -94,8 +94,8 @@ export default function CourseDatesDialog({
     setFormNotices([]);
     setSelectedCancellationDate(null);
     setImpactDialogOpen(false);
-    setRollbackOutgoingSwaps(false);
-    setNotifyAlreadyCancelledParticipants(true);
+    setRollbackSuccessfulSwaps(false);
+    setRollbackPendingWaitlistSwaps(true);
   }, [course]);
 
   useLayoutEffect(() => {
@@ -277,12 +277,19 @@ export default function CourseDatesDialog({
           cancelledSet.has(swap.user),
       )
       .map((swap) => swap.user);
+    const pendingSwapsWithOriginOnCancelledDate = swaps.filter(
+      (swap) =>
+        swap.fromCourseId === course.id &&
+        swap.fromDate === selectedCancellationDate &&
+        swap.status === "pending",
+    );
     return {
       bookedParticipants,
       swappedInParticipants,
       waitlistParticipants,
       alreadyCancelledParticipants,
       outgoingSwapsFromCancelledParticipants: dedupeAndSortUsers(outgoingSwapsFromCancelledParticipants),
+      pendingSwapsWithOriginCount: pendingSwapsWithOriginOnCancelledDate.length,
     };
   }, [course, overrides, selectedCancellationDate, swaps]);
 
@@ -475,8 +482,8 @@ export default function CourseDatesDialog({
     setFormNotices([]);
     try {
       const response = await cancelCourseDate(course.id, selectedCancellationDate, {
-        rollbackOutgoingSwapsFromCancelledParticipants: rollbackOutgoingSwaps,
-        notifyAlreadyCancelledParticipants,
+        rollbackSuccessfulSwapsFromCancelledParticipants: rollbackSuccessfulSwaps,
+        rollbackPendingWaitlistSwapsFromOriginDate: rollbackPendingWaitlistSwaps,
       });
       setImpactDialogOpen(false);
       setSelectedCancellationDate(null);
@@ -963,22 +970,30 @@ export default function CourseDatesDialog({
             <label className="course-editor-note" style={{ display: "block" }}>
               <input
                 type="checkbox"
-                checked={rollbackOutgoingSwaps}
-                onChange={(event) => setRollbackOutgoingSwaps(event.target.checked)}
+                checked={rollbackSuccessfulSwaps}
+                onChange={(event) => setRollbackSuccessfulSwaps(event.target.checked)}
                 disabled={saving}
               />{" "}
-              Ausgehende Tauschanfragen bereits abgesagter Teilnehmer für diesen Ursprungstermin zurückrollen
+              Erfolgreiche Tauschs in andere Termine zurückrollen
               ({cancellationImpact.outgoingSwapsFromCancelledParticipants.length})
             </label>
+            <p className="course-editor-note" style={{ marginTop: 0 }}>
+              Nur relevant für zukünftige, bereits erfolgreiche Tauschs von bereits abgemeldeten Teilnehmern.
+            </p>
             <label className="course-editor-note" style={{ display: "block" }}>
               <input
                 type="checkbox"
-                checked={notifyAlreadyCancelledParticipants}
-                onChange={(event) => setNotifyAlreadyCancelledParticipants(event.target.checked)}
+                checked={rollbackPendingWaitlistSwaps}
+                onChange={(event) => setRollbackPendingWaitlistSwaps(event.target.checked)}
                 disabled={saving}
               />{" "}
-              Bereits abgesagte Teilnehmer zusätzlich informieren
+              Tauschanfragen auf Wartelisten in andere Termine zurückrollen
+              ({cancellationImpact.pendingSwapsWithOriginCount})
             </label>
+            <p className="course-editor-note" style={{ marginTop: 0 }}>
+              Bei Haken werden alle offenen Wartelisten-Tauschanfragen mit diesem Ursprungstermin zurückgerollt und
+              Ziel-Wartelisten bereinigt.
+            </p>
             <div className="modal-actions">
               <button type="button" className="modal-action-btn" onClick={closeImpactDialog} disabled={saving}>
                 Zurück

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from "react";
 import { Calendar } from "lucide-react";
-import type { Course } from "shared/types";
-import { updateCourse } from "../api/courses";
+import type { Course, CourseDateOverride, Swap } from "shared/types";
+import { cancelCourseDate, updateCourse } from "../api/courses";
 import CourseModalFrame from "./CourseModalFrame";
 import {
   DEFAULT_ROLLING_HORIZON_WEEKS,
@@ -26,6 +26,8 @@ import {
 
 type CourseDatesDialogProps = {
   course: Course | null;
+  overrides: CourseDateOverride[];
+  swaps: Swap[];
   canManageCourses: boolean;
   onClose: () => void;
   onSaved: () => Promise<void> | void;
@@ -53,10 +55,25 @@ function focusFirstElement(node: HTMLElement): void {
   node.focus();
 }
 
-export default function CourseDatesDialog({ course, canManageCourses, onClose, onSaved }: CourseDatesDialogProps) {
+function dedupeAndSortUsers(values: string[]): string[] {
+  return Array.from(new Set(values.filter((entry) => entry.trim().length > 0))).sort((a, b) => a.localeCompare(b));
+}
+
+export default function CourseDatesDialog({
+  course,
+  overrides,
+  swaps,
+  canManageCourses,
+  onClose,
+  onSaved,
+}: CourseDatesDialogProps) {
   const [datesState, setDatesState] = useState<CourseDatesEditorState | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [selectedCancellationDate, setSelectedCancellationDate] = useState<string | null>(null);
+  const [impactDialogOpen, setImpactDialogOpen] = useState(false);
+  const [rollbackOutgoingSwaps, setRollbackOutgoingSwaps] = useState(true);
+  const [notifyAlreadyCancelledParticipants, setNotifyAlreadyCancelledParticipants] = useState(true);
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -65,8 +82,16 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
       setFormError(null);
       return;
     }
-    setDatesState(createDatesState(course));
+    const nextState = createDatesState(course);
+    if (course.status === "active" && nextState.planningMode === "bounded_series") {
+      nextState.rangeDatePickerOpen = true;
+    }
+    setDatesState(nextState);
     setFormError(null);
+    setSelectedCancellationDate(null);
+    setImpactDialogOpen(false);
+    setRollbackOutgoingSwaps(true);
+    setNotifyAlreadyCancelledParticipants(true);
   }, [course]);
 
   useLayoutEffect(() => {
@@ -123,6 +148,7 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
     datesState.visibilityHorizonWeeks >= DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS;
   const isActiveReadOnly =
     course?.status === "active" && datesState?.planningMode === "bounded_series";
+  const isActiveCancellationMode = isActiveReadOnly;
 
   const canSaveDatesConfig =
     canManageCourses &&
@@ -137,6 +163,11 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
   const datesPreview = useMemo(() => {
     if (!datesState) return [];
     return generatePreviewDates(datesState);
+  }, [datesState]);
+
+  const fullSeriesDatesForActive = useMemo(() => {
+    if (!datesState || datesState.planningMode !== "bounded_series") return [];
+    return generatePreviewDates({ ...datesState, excludedDates: [] });
   }, [datesState]);
 
   const displayLocale =
@@ -218,6 +249,38 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
     () => datesPreview.map((entry) => formatIsoDateForDisplay(entry, displayLocale)),
     [datesPreview, displayLocale],
   );
+  const formattedFullSeriesDates = useMemo(
+    () => fullSeriesDatesForActive.map((entry) => formatIsoDateForDisplay(entry, displayLocale)),
+    [fullSeriesDatesForActive, displayLocale],
+  );
+
+  const cancellationImpact = useMemo(() => {
+    if (!course || !selectedCancellationDate) return null;
+    const overrideForDate =
+      overrides.find((entry) => entry.courseId === course.id && entry.date === selectedCancellationDate) ?? null;
+    const bookedParticipants = [...(overrideForDate?.participants ?? course.participants)];
+    const swappedInParticipants = [...(overrideForDate?.swapped ?? [])];
+    const waitlistParticipants = [...(overrideForDate?.waitlist ?? [])];
+    const bookedSet = new Set(bookedParticipants);
+    const alreadyCancelledParticipants = course.participants.filter((userId) => !bookedSet.has(userId));
+    const cancelledSet = new Set(alreadyCancelledParticipants);
+    const outgoingSwapsFromCancelledParticipants = swaps
+      .filter(
+        (swap) =>
+          swap.fromCourseId === course.id &&
+          swap.fromDate === selectedCancellationDate &&
+          swap.status === "pending" &&
+          cancelledSet.has(swap.user),
+      )
+      .map((swap) => swap.user);
+    return {
+      bookedParticipants,
+      swappedInParticipants,
+      waitlistParticipants,
+      alreadyCancelledParticipants,
+      outgoingSwapsFromCancelledParticipants: dedupeAndSortUsers(outgoingSwapsFromCancelledParticipants),
+    };
+  }, [course, overrides, selectedCancellationDate, swaps]);
 
   const toggleRangeDatePicker = () => {
     if (saving) return;
@@ -373,6 +436,53 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
     setFormError(null);
   };
 
+  const toggleCancellationDate = (isoDate: string) => {
+    if (saving) return;
+    if (!fullSeriesDatesForActive.includes(isoDate)) return;
+    if (datesState?.excludedDates.includes(isoDate)) return;
+    setSelectedCancellationDate((prev) => (prev === isoDate ? null : isoDate));
+    setDatesState((prev) =>
+      prev
+        ? {
+            ...prev,
+            rangeDatePickerOpen: false,
+          }
+        : prev,
+    );
+    setFormError(null);
+  };
+
+  const openImpactDialog = () => {
+    if (!selectedCancellationDate || !cancellationImpact) return;
+    setImpactDialogOpen(true);
+  };
+
+  const closeImpactDialog = () => {
+    if (saving) return;
+    setImpactDialogOpen(false);
+  };
+
+  const submitCancellation = async () => {
+    if (!course || !selectedCancellationDate) return;
+    setSaving(true);
+    setFormError(null);
+    try {
+      await cancelCourseDate(course.id, selectedCancellationDate, {
+        rollbackOutgoingSwapsFromCancelledParticipants: rollbackOutgoingSwaps,
+        notifyAlreadyCancelledParticipants,
+      });
+      setImpactDialogOpen(false);
+      setSelectedCancellationDate(null);
+      onClose();
+      await onSaved();
+    } catch (err) {
+      console.error("Failed to cancel course date", err);
+      setFormError(err instanceof Error ? err.message : "Termin konnte nicht abgesagt werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const saveDatesConfig = async () => {
     if (!datesState || !canManageCourses || isActiveReadOnly) return;
     if (datesState.planningMode === "bounded_series") {
@@ -444,11 +554,127 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
         </p>
         {isActiveReadOnly && (
           <p className="course-editor-note">
-            Kurs ist aktiv. Terminplanung ist gesperrt. Änderungen erfolgen über Terminabsage.
+            Kurs ist aktiv. Terminplanung ist gesperrt.
           </p>
         )}
         <div className="dialog-stack">
-          {datesState.planningMode === "bounded_series" ? (
+          <div className="course-editor-subsection">
+            <strong className="course-editor-list-title">
+              Vorschau Termine ({isActiveCancellationMode ? fullSeriesDatesForActive.length : datesPreview.length})
+            </strong>
+            {(isActiveCancellationMode ? fullSeriesDatesForActive.length : datesPreview.length) === 0 ? (
+              <p className="course-editor-note">Keine Termine im gewählten Zeitraum.</p>
+            ) : (
+              <p className="course-editor-comma-list">
+                {(isActiveCancellationMode ? formattedFullSeriesDates : formattedPreviewDates).join(", ")}
+              </p>
+            )}
+          </div>
+
+          {isActiveCancellationMode ? (
+            <div className="course-editor-subsection">
+              <strong className="course-editor-list-title">Terminkalender zur Übersicht und Absage</strong>
+              <p className="course-editor-note">
+                Es werden alle geplanten Serientermine angezeigt. Ausgeschlossene Termine sind markiert und nicht
+                auswählbar.
+              </p>
+              <div className="course-editor-inline-row">
+                <button
+                  type="button"
+                  className="modal-action-btn course-editor-icon-btn"
+                  onClick={toggleRangeDatePicker}
+                  disabled={saving}
+                  title={datesState.rangeDatePickerOpen ? "Kalender ausblenden" : "Kalender öffnen"}
+                  aria-label="Kalender für Terminabsage öffnen"
+                >
+                  <Calendar size={16} aria-hidden="true" />
+                </button>
+                <span className="course-editor-note">Wähle genau einen Termin zur Absage.</span>
+              </div>
+              {datesState.rangeDatePickerOpen && (
+                <div className="course-editor-calendar-block" role="group" aria-label="Kalender Terminabsage">
+                  <div className="course-editor-calendar-nav">
+                    <button
+                      type="button"
+                      className="modal-action-btn course-editor-inline-action"
+                      onClick={() => shiftRangeCalendarMonth(-1)}
+                      disabled={saving}
+                    >
+                      Vorheriger Monat
+                    </button>
+                    <strong>{rangeCalendarMonthLabel}</strong>
+                    <button
+                      type="button"
+                      className="modal-action-btn course-editor-inline-action"
+                      onClick={() => shiftRangeCalendarMonth(1)}
+                      disabled={saving}
+                    >
+                      Nächster Monat
+                    </button>
+                  </div>
+                  <div className="course-editor-calendar-weekdays" aria-hidden="true">
+                    {["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"].map((label) => (
+                      <span key={label}>{label}</span>
+                    ))}
+                  </div>
+                  <div className="course-editor-calendar-grid">
+                    {rangeCalendarCells.map((cell) => {
+                      const isCancelledDate = datesState.excludedDates.includes(cell.isoDate);
+                      const isSelectable = cell.isSeriesDate && !isCancelledDate;
+                      const isSelected = selectedCancellationDate === cell.isoDate;
+                      const cellClassName = [
+                        "course-editor-calendar-cell",
+                        cell.inCurrentMonth ? "" : "is-outside-month",
+                        cell.isSeriesDate ? "is-series-date" : "",
+                        isCancelledDate ? "is-excluded-date" : "",
+                        isSelected ? "is-range-start" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ");
+                      return (
+                        <button
+                          key={`cancel-${cell.isoDate}`}
+                          type="button"
+                          className={cellClassName}
+                          aria-label={`Absage Datum ${cell.isoDate}`}
+                          onClick={() => toggleCancellationDate(cell.isoDate)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              toggleCancellationDate(cell.isoDate);
+                            }
+                          }}
+                          disabled={!isSelectable || saving}
+                          title={
+                            isCancelledDate
+                              ? "Termin ist bereits ausgeschlossen"
+                              : isSelectable
+                                ? "Termin für Absage auswählen"
+                                : "Nur Serientermine auswählbar"
+                          }
+                        >
+                          {cell.dayOfMonth}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="course-editor-calendar-legend">
+                    <span><em className="legend-dot series" /> geplanter Termin</span>
+                    <span><em className="legend-dot excluded" /> ausgeschlossen</span>
+                    <span><em className="legend-dot boundary" /> ausgewählt</span>
+                  </div>
+                </div>
+              )}
+              <p className="course-editor-note">
+                Ausgewählter Termin:{" "}
+                <strong>
+                  {selectedCancellationDate
+                    ? formatIsoDateForDisplay(selectedCancellationDate, displayLocale)
+                    : "Keiner ausgewählt"}
+                </strong>
+              </p>
+            </div>
+          ) : datesState.planningMode === "bounded_series" ? (
             <div className="course-editor-subsection">
               <strong className="course-editor-list-title">Zeitraum</strong>
               <p className="course-editor-note">
@@ -571,7 +797,8 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
             </div>
           )}
 
-          <div className="course-editor-subsection">
+          {!isActiveCancellationMode && (
+            <div className="course-editor-subsection">
             <strong className="course-editor-list-title">Ausgeschlossene Termin</strong>
             <div className="course-editor-inline-row">
               <button
@@ -677,31 +904,77 @@ export default function CourseDatesDialog({ course, canManageCourses, onClose, o
                   </div>
                 </div>
               )}
-          </div>
+            </div>
+          )}
 
-          <div className="course-editor-subsection">
-            {datesState.excludedDates.length === 0 ? (
-              <p className="course-editor-note">Keine ausgeschlossenen Termine.</p>
-            ) : (
-              <p className="course-editor-comma-list">{formattedExcludedDates.join(", ")}</p>
-            )}
-          </div>
+          {!isActiveCancellationMode && (
+            <div className="course-editor-subsection">
+              {datesState.excludedDates.length === 0 ? (
+                <p className="course-editor-note">Keine ausgeschlossenen Termine.</p>
+              ) : (
+                <p className="course-editor-comma-list">{formattedExcludedDates.join(", ")}</p>
+              )}
+            </div>
+          )}
 
-          <div className="course-editor-subsection">
-            <strong className="course-editor-list-title">Vorschau Termine ({datesPreview.length})</strong>
-            {datesPreview.length === 0 ? (
-              <p className="course-editor-note">Keine Termine im gewählten Zeitraum.</p>
-            ) : (
-              <p className="course-editor-comma-list">{formattedPreviewDates.join(", ")}</p>
-            )}
-          </div>
         </div>
         {formError && <p style={{ color: "crimson", margin: 0 }}>{formError}</p>}
+        {isActiveCancellationMode && impactDialogOpen && cancellationImpact && (
+          <div className="course-editor-subsection" role="group" aria-label="Auswirkungsprüfung Terminabsage">
+            <strong className="course-editor-list-title">
+              Auswirkungen für {selectedCancellationDate ? formatIsoDateForDisplay(selectedCancellationDate, displayLocale) : ""}
+            </strong>
+            <p className="course-editor-note">Bitte prüfe die betroffenen Gruppen vor dem Absagen.</p>
+            <p className="course-editor-note">
+              Gebucht: <strong>{cancellationImpact.bookedParticipants.length}</strong>
+              {" | "}Reingetauscht: <strong>{cancellationImpact.swappedInParticipants.length}</strong>
+              {" | "}Warteliste: <strong>{cancellationImpact.waitlistParticipants.length}</strong>
+              {" | "}Bereits abgesagt: <strong>{cancellationImpact.alreadyCancelledParticipants.length}</strong>
+            </p>
+            <label className="course-editor-note" style={{ display: "block" }}>
+              <input
+                type="checkbox"
+                checked={rollbackOutgoingSwaps}
+                onChange={(event) => setRollbackOutgoingSwaps(event.target.checked)}
+                disabled={saving}
+              />{" "}
+              Ausgehende Tauschanfragen bereits abgesagter Teilnehmer für diesen Ursprungstermin zurückrollen
+              ({cancellationImpact.outgoingSwapsFromCancelledParticipants.length})
+            </label>
+            <label className="course-editor-note" style={{ display: "block" }}>
+              <input
+                type="checkbox"
+                checked={notifyAlreadyCancelledParticipants}
+                onChange={(event) => setNotifyAlreadyCancelledParticipants(event.target.checked)}
+                disabled={saving}
+              />{" "}
+              Bereits abgesagte Teilnehmer zusätzlich informieren
+            </label>
+            <div className="modal-actions">
+              <button type="button" className="modal-action-btn" onClick={closeImpactDialog} disabled={saving}>
+                Zurück
+              </button>
+              <button type="button" className="btn-primary modal-action-btn" onClick={submitCancellation} disabled={saving}>
+                {saving ? "Sende..." : "Termin jetzt absagen"}
+              </button>
+            </div>
+          </div>
+        )}
         <div className="modal-actions">
-          {isActiveReadOnly ? (
-            <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
-              Schließen
-            </button>
+          {isActiveCancellationMode ? (
+            <>
+              <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                className="btn-primary modal-action-btn"
+                onClick={openImpactDialog}
+                disabled={!selectedCancellationDate || saving || impactDialogOpen || !cancellationImpact}
+              >
+                Absage überprüfen
+              </button>
+            </>
           ) : (
             <>
               <button type="button" className="modal-action-btn" onClick={onClose} disabled={saving}>

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -60,6 +60,11 @@ function dedupeAndSortUsers(values: string[]): string[] {
   return Array.from(new Set(values.filter((entry) => entry.trim().length > 0))).sort((a, b) => a.localeCompare(b));
 }
 
+function isIsoDateInFuture(isoDate: string): boolean {
+  const today = new Date().toISOString().slice(0, 10);
+  return isoDate > today;
+}
+
 export default function CourseDatesDialog({
   course,
   overrides,
@@ -265,16 +270,28 @@ export default function CourseDatesDialog({
     const bookedParticipants = [...(overrideForDate?.participants ?? course.participants)];
     const swappedInParticipants = [...(overrideForDate?.swapped ?? [])];
     const waitlistParticipants = [...(overrideForDate?.waitlist ?? [])];
-    const bookedSet = new Set(bookedParticipants);
-    const alreadyCancelledParticipants = course.participants.filter((userId) => !bookedSet.has(userId));
-    const cancelledSet = new Set(alreadyCancelledParticipants);
+    const bookedSetNormalized = new Set(bookedParticipants.map((userId) => userId.toLowerCase()));
+    const alreadyCancelledParticipants = course.participants.filter(
+      (userId) => !bookedSetNormalized.has(userId.toLowerCase()),
+    );
+    const cancelledSetNormalized = new Set(alreadyCancelledParticipants.map((userId) => userId.toLowerCase()));
+    const successfulSwapsFromCancelledParticipants = swaps
+      .filter(
+        (swap) =>
+          swap.fromCourseId === course.id &&
+          swap.fromDate === selectedCancellationDate &&
+          swap.status === "active" &&
+          isIsoDateInFuture(swap.toDate) &&
+          cancelledSetNormalized.has(swap.user.toLowerCase()),
+      )
+      .map((swap) => swap.user);
     const outgoingSwapsFromCancelledParticipants = swaps
       .filter(
         (swap) =>
           swap.fromCourseId === course.id &&
           swap.fromDate === selectedCancellationDate &&
           swap.status === "pending" &&
-          cancelledSet.has(swap.user),
+          cancelledSetNormalized.has(swap.user.toLowerCase()),
       )
       .map((swap) => swap.user);
     const pendingSwapsWithOriginOnCancelledDate = swaps.filter(
@@ -288,6 +305,7 @@ export default function CourseDatesDialog({
       swappedInParticipants,
       waitlistParticipants,
       alreadyCancelledParticipants,
+      successfulSwapsFromCancelledParticipants: dedupeAndSortUsers(successfulSwapsFromCancelledParticipants),
       outgoingSwapsFromCancelledParticipants: dedupeAndSortUsers(outgoingSwapsFromCancelledParticipants),
       pendingSwapsWithOriginCount: pendingSwapsWithOriginOnCancelledDate.length,
     };
@@ -975,7 +993,7 @@ export default function CourseDatesDialog({
                 disabled={saving}
               />{" "}
               Erfolgreiche Tauschs in andere Termine zurückrollen
-              ({cancellationImpact.outgoingSwapsFromCancelledParticipants.length})
+              ({cancellationImpact.successfulSwapsFromCancelledParticipants.length})
             </label>
             <p className="course-editor-note" style={{ marginTop: 0 }}>
               Nur relevant für zukünftige, bereits erfolgreiche Tauschs von bereits abgemeldeten Teilnehmern.

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -72,7 +72,7 @@ export default function CourseDatesDialog({
   const [formError, setFormError] = useState<string | null>(null);
   const [selectedCancellationDate, setSelectedCancellationDate] = useState<string | null>(null);
   const [impactDialogOpen, setImpactDialogOpen] = useState(false);
-  const [rollbackOutgoingSwaps, setRollbackOutgoingSwaps] = useState(true);
+  const [rollbackOutgoingSwaps, setRollbackOutgoingSwaps] = useState(false);
   const [notifyAlreadyCancelledParticipants, setNotifyAlreadyCancelledParticipants] = useState(true);
   const modalRef = useRef<HTMLDivElement | null>(null);
 
@@ -90,7 +90,7 @@ export default function CourseDatesDialog({
     setFormError(null);
     setSelectedCancellationDate(null);
     setImpactDialogOpen(false);
-    setRollbackOutgoingSwaps(true);
+    setRollbackOutgoingSwaps(false);
     setNotifyAlreadyCancelledParticipants(true);
   }, [course]);
 

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import CourseList from "./CourseList";
 import { createCourse, deleteCourse, getCourses, updateCourse } from "../api/courses";
 import { getOverrides } from "../api/overrides";
-import { getSwaps } from "../api/swaps";
+import { getSwaps, getSwapsByStatus } from "../api/swaps";
 import { getParticipants } from "../api/participants";
 import type { User, Tenant, UserTenantMembership, Course } from "shared/types";
 import { canSeeCourse } from "shared/permissions";
@@ -33,6 +33,7 @@ const mockedUpdateCourse = updateCourse as unknown as ReturnType<typeof vi.fn>;
 const mockedDeleteCourse = deleteCourse as unknown as ReturnType<typeof vi.fn>;
 const mockedGetOverrides = getOverrides as unknown as ReturnType<typeof vi.fn>;
 const mockedGetSwaps = getSwaps as unknown as ReturnType<typeof vi.fn>;
+const mockedGetSwapsByStatus = getSwapsByStatus as unknown as ReturnType<typeof vi.fn>;
 const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
 const mockedCanSeeCourse = canSeeCourse as unknown as ReturnType<typeof vi.fn>;
 
@@ -70,12 +71,14 @@ describe("CourseList", () => {
     mockedGetCourses.mockReset();
     mockedGetOverrides.mockReset();
     mockedGetSwaps.mockReset();
+    mockedGetSwapsByStatus.mockReset();
     mockedCreateCourse.mockReset();
     mockedUpdateCourse.mockReset();
     mockedDeleteCourse.mockReset();
     mockedGetParticipants.mockReset();
     mockedGetParticipants.mockResolvedValue([]);
     mockedCanSeeCourse.mockImplementation(() => true);
+    mockedGetSwapsByStatus.mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -18,6 +18,7 @@ import {
   UserTenantMembership,
 } from "shared/types";
 import { getSwaps } from "../api/swaps";
+import { getSwapsByStatus } from "../api/swaps";
 import { getOverrides } from "../api/overrides";
 import { getCourseDates } from "../lib/dates";
 import {
@@ -173,6 +174,18 @@ function toEditorState(course: Course): CourseEditorState {
   };
 }
 
+function dedupeSwaps(values: Swap[]): Swap[] {
+  const seen = new Set<string>();
+  const result: Swap[] = [];
+  for (const swap of values) {
+    const key = `${swap.user}#${swap.fromCourseId}#${swap.fromDate}#${swap.toCourseId}#${swap.toDate}#${swap.status}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(swap);
+  }
+  return result;
+}
+
 export default function CourseList({
   currentUser,
   tenant,
@@ -228,10 +241,16 @@ export default function CourseList({
         user: currentUser.nickname,
       });
       setLoading(true);
+      const swapsPromise = canSeeCourseManagement
+        ? Promise.all([getSwapsByStatus("pending"), getSwapsByStatus("active")]).then(([pending, active]) =>
+            dedupeSwaps([...pending, ...active]),
+          )
+        : getSwaps(currentUser.nickname);
+
       const [courseData, overrideData, swapsData] = await Promise.all([
         getCourses(),
         getOverrides(),
-        getSwaps(currentUser.nickname),
+        swapsPromise,
       ]);
 
       console.log("Data fetched:", {
@@ -250,7 +269,7 @@ export default function CourseList({
     } finally {
       setLoading(false);
     }
-  }, [currentUser.nickname]);
+  }, [canSeeCourseManagement, currentUser.nickname]);
 
   useEffect(() => {
     fetchData();

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -761,6 +761,8 @@ export default function CourseList({
 
       <CourseDatesDialog
         course={datesTargetCourse ?? null}
+        overrides={filteredOverrides}
+        swaps={swaps}
         canManageCourses={canManageCourses}
         onClose={closeDatesModal}
         onSaved={fetchData}

--- a/app/src/i18n/cancelWarnings.ts
+++ b/app/src/i18n/cancelWarnings.ts
@@ -1,0 +1,46 @@
+export type CancelWarningCode =
+  | "waitlist_cleanup_failed"
+  | "participant_lookup_failed"
+  | "participant_mail_failed"
+  | "studio_report_failed";
+
+const WARNING_MESSAGES: Record<string, Record<CancelWarningCode, string>> = {
+  de: {
+    waitlist_cleanup_failed:
+      "Wartelisten konnten in einzelnen Zielterminen nicht vollstaendig bereinigt werden.",
+    participant_lookup_failed:
+      "Einzelne Teilnehmerprofile konnten fuer den Mailversand nicht geladen werden.",
+    participant_mail_failed:
+      "Einzelne Teilnehmermails konnten nicht versendet werden.",
+    studio_report_failed:
+      "Die Studio-Benachrichtigung konnte nicht versendet werden.",
+  },
+  en: {
+    waitlist_cleanup_failed:
+      "Waitlists could not be fully cleaned up for some target dates.",
+    participant_lookup_failed:
+      "Some participant profiles could not be loaded for mail delivery.",
+    participant_mail_failed:
+      "Some participant emails could not be sent.",
+    studio_report_failed:
+      "The studio notification could not be sent.",
+  },
+};
+
+export function resolveWarningMessages(
+  warningCodes: string[] | undefined,
+  locale: string,
+): string[] {
+  if (!warningCodes || warningCodes.length === 0) return [];
+  const normalizedLocale = locale.toLowerCase();
+  const localeKey = normalizedLocale.startsWith("de")
+    ? "de"
+    : normalizedLocale.startsWith("en")
+      ? "en"
+      : "de";
+  const localeMessages = WARNING_MESSAGES[localeKey] ?? WARNING_MESSAGES.de;
+  const dedupedCodes = Array.from(new Set(warningCodes));
+  return dedupedCodes
+    .map((code) => localeMessages[code as CancelWarningCode])
+    .filter((entry): entry is string => Boolean(entry));
+}

--- a/app/src/i18n/index.ts
+++ b/app/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export { resolveWarningMessages } from "./cancelWarnings";
+export type { CancelWarningCode } from "./cancelWarnings";

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -473,6 +473,8 @@ describe("cancelCourseDate Lambda", () => {
 
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(200);
+    const payload = JSON.parse(result.body);
+    expect(payload.operationWarnings).toContain("participant_lookup_failed");
     expect(sesSend).toHaveBeenCalledTimes(1); // only studio report mail
   });
 });

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -477,5 +477,36 @@ describe("cancelCourseDate Lambda", () => {
     expect(payload.operationWarnings).toContain("participant_lookup_failed");
     expect(sesSend).toHaveBeenCalledTimes(1); // only studio report mail
   });
+
+  test("always writes an empty override for the cancelled date", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({ Item: undefined }) // no existing override for cancelled date
+      .mockResolvedValueOnce({ Items: [] }) // no related swaps
+      .mockResolvedValueOnce({}) // update course excludedDates
+      .mockResolvedValueOnce({}) // write cancelled-date override
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+
+    const putCalls = (PutItemCommand as unknown as jest.Mock).mock.calls.map((call) => call[0]);
+    const cancelledOverrideWrite = putCalls.find(
+      (input) => input?.TableName === "test-overrides" && input?.Item?.courseId_date?.S === "1_2099-01-06",
+    );
+    expect(cancelledOverrideWrite).toBeDefined();
+    expect(cancelledOverrideWrite.Item.participants.L).toEqual([]);
+    expect(cancelledOverrideWrite.Item.swapped.L).toEqual([]);
+    expect(cancelledOverrideWrite.Item.waitlist.L).toEqual([]);
+  });
 });
 

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -1,0 +1,134 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import {
+  DeleteItemCommand,
+  GetItemCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    DeleteItemCommand: jest.fn((input) => input),
+    GetItemCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    ScanCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+jest.mock("@aws-sdk/client-ses", () => {
+  const sesSend = jest.fn();
+  return {
+    SESClient: jest.fn(() => ({ send: sesSend })),
+    SendEmailCommand: jest.fn((input) => input),
+    sesSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+const { sesSend } = jest.requireMock("@aws-sdk/client-ses");
+
+function makeEvent(): APIGatewayProxyEvent {
+  return ({
+    body: JSON.stringify({
+      rollbackOutgoingSwapsFromCancelledParticipants: true,
+      notifyAlreadyCancelledParticipants: true,
+    }),
+    headers: {},
+    pathParameters: { courseId: "1", date: "2026-01-06" },
+    requestContext: {
+      authorizer: {
+        jwt: { claims: { nickname: "admin1" } },
+      },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  } as unknown) as APIGatewayProxyEvent;
+}
+
+describe("cancelCourseDate Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...OLD_ENV,
+      COURSES_TABLE: "test-courses",
+      MEMBERSHIPS_TABLE: "test-memberships",
+      OVERRIDES_TABLE: "test-overrides",
+      SWAPS_TABLE: "test-swaps",
+      PARTICIPANTS_TABLE: "test-participants",
+      SES_SOURCE_EMAIL: "studio@example.com",
+    };
+    mockSend.mockReset();
+    sesSend.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("cancels date and returns impact groups", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }, { S: "maya" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2026-01-06" },
+          participants: { L: [{ S: "luna" }] },
+          swapped: { L: [{ S: "nora" }] },
+          waitlist: { L: [{ S: "maya" }] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            user_swapId: { S: "maya#2026-01-06_1_2026-01-09_2" },
+            user: { S: "maya" },
+            fromCourseId: { S: "1" },
+            fromDate: { S: "2026-01-06" },
+            toCourseId: { S: "2" },
+            toDate: { S: "2026-01-09" },
+            status: { S: "pending" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "nora@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "maya@example.com" } } });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const payload = JSON.parse(result.body);
+    expect(payload.success).toBe(true);
+    expect(payload.affected).toEqual(
+      expect.objectContaining({
+        bookedParticipants: ["luna"],
+        swappedInParticipants: ["nora"],
+        waitlistParticipants: ["maya"],
+        alreadyCancelledParticipants: ["maya"],
+      }),
+    );
+
+    expect(ScanCommand).toHaveBeenCalled();
+    expect(DeleteItemCommand).toHaveBeenCalledTimes(1);
+    expect(PutItemCommand).toHaveBeenCalledTimes(2);
+    expect(GetItemCommand).toHaveBeenCalled();
+    expect(sesSend).toHaveBeenCalledTimes(3);
+  });
+});
+

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -375,8 +375,8 @@ describe("cancelCourseDate Lambda", () => {
 
     const reportCall = sesSend.mock.calls[sesSend.mock.calls.length - 1]?.[0];
     const reportHtml = reportCall?.Message?.Body?.Html?.Data ?? "";
-    expect(reportHtml).toContain("Warteliste betroffen: Maya");
-    expect(reportHtml).toContain("Abgesagt mit aktivem Swap: Luna");
+    expect(reportHtml).toContain("Warteliste am abgesagten Termin: Maya");
+    expect(reportHtml).toContain("Bereits abgemeldet mit aktivem Swap: Luna");
   });
 
   test("removes users from target override waitlist when deleting pending outgoing swaps", async () => {

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -3,6 +3,7 @@ import {
   DeleteItemCommand,
   GetItemCommand,
   PutItemCommand,
+  QueryCommand,
   ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import { handler } from "./index";
@@ -14,6 +15,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
     DeleteItemCommand: jest.fn((input) => input),
     GetItemCommand: jest.fn((input) => input),
     PutItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
     ScanCommand: jest.fn((input) => input),
     mockSend,
   };
@@ -146,6 +148,7 @@ describe("cancelCourseDate Lambda", () => {
     expect(DeleteItemCommand).toHaveBeenCalledTimes(1);
     expect(PutItemCommand).toHaveBeenCalledTimes(2);
     expect(GetItemCommand).toHaveBeenCalled();
+    expect(QueryCommand).not.toHaveBeenCalled();
     expect(sesSend).toHaveBeenCalledTimes(3);
   });
 
@@ -195,6 +198,49 @@ describe("cancelCourseDate Lambda", () => {
     expect(DeleteItemCommand).not.toHaveBeenCalled();
     expect(PutItemCommand).toHaveBeenCalledTimes(2);
     expect(sesSend).toHaveBeenCalledTimes(3);
+  });
+
+  test("resolves participant profile case-insensitively via normalized lookup", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "Rue" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "Rue" }] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            userId: { S: "rue" },
+            userIdNormalized: { S: "rue" },
+            email: { S: "rue@example.com" },
+          },
+        ],
+      });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(GetItemCommand).toHaveBeenCalled();
+    expect(QueryCommand).toHaveBeenCalledTimes(1);
+    expect(sesSend).toHaveBeenCalledTimes(1); // user mail
   });
 });
 

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -279,5 +279,37 @@ describe("cancelCourseDate Lambda", () => {
     expect(GetItemCommand).toHaveBeenCalled();
     expect(sesSend).not.toHaveBeenCalled();
   });
+
+  test("sends cancellation mail to waitlist participants on cancelled date", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "luna" }] },
+          swapped: { L: [] },
+          waitlist: { L: [{ S: "zoe" }] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "zoe@example.com" } } });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(sesSend).toHaveBeenCalledTimes(2);
+  });
 });
 

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -38,7 +38,23 @@ function makeEvent(): APIGatewayProxyEvent {
       notifyAlreadyCancelledParticipants: true,
     }),
     headers: {},
-    pathParameters: { courseId: "1", date: "2026-01-06" },
+    pathParameters: { courseId: "1", date: "2099-01-06" },
+    requestContext: {
+      authorizer: {
+        jwt: { claims: { nickname: "admin1" } },
+      },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  } as unknown) as APIGatewayProxyEvent;
+}
+
+function makeEventNoRollback(): APIGatewayProxyEvent {
+  return ({
+    body: JSON.stringify({
+      rollbackOutgoingSwapsFromCancelledParticipants: false,
+      notifyAlreadyCancelledParticipants: true,
+    }),
+    headers: {},
+    pathParameters: { courseId: "1", date: "2099-01-06" },
     requestContext: {
       authorizer: {
         jwt: { claims: { nickname: "admin1" } },
@@ -52,6 +68,7 @@ describe("cancelCourseDate Lambda", () => {
 
   beforeEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
     process.env = {
       ...OLD_ENV,
       COURSES_TABLE: "test-courses",
@@ -97,9 +114,9 @@ describe("cancelCourseDate Lambda", () => {
             user_swapId: { S: "maya#2026-01-06_1_2026-01-09_2" },
             user: { S: "maya" },
             fromCourseId: { S: "1" },
-            fromDate: { S: "2026-01-06" },
+            fromDate: { S: "2099-01-06" },
             toCourseId: { S: "2" },
-            toDate: { S: "2026-01-09" },
+            toDate: { S: "2099-01-09" },
             status: { S: "pending" },
           },
         ],
@@ -121,6 +138,7 @@ describe("cancelCourseDate Lambda", () => {
         swappedInParticipants: ["nora"],
         waitlistParticipants: ["maya"],
         alreadyCancelledParticipants: ["maya"],
+        outgoingSwapsFromCancelledParticipants: ["maya"],
       }),
     );
 
@@ -128,6 +146,54 @@ describe("cancelCourseDate Lambda", () => {
     expect(DeleteItemCommand).toHaveBeenCalledTimes(1);
     expect(PutItemCommand).toHaveBeenCalledTimes(2);
     expect(GetItemCommand).toHaveBeenCalled();
+    expect(sesSend).toHaveBeenCalledTimes(3);
+  });
+
+  test("keeps outgoing pending swaps from already-cancelled participants when rollback is false", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }, { S: "maya" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "luna" }] },
+          swapped: { L: [{ S: "nora" }] },
+          waitlist: { L: [{ S: "maya" }] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            user_swapId: { S: "maya#2099-01-06_1_2099-01-09_2" },
+            user: { S: "maya" },
+            fromCourseId: { S: "1" },
+            fromDate: { S: "2099-01-06" },
+            toCourseId: { S: "2" },
+            toDate: { S: "2099-01-09" },
+            status: { S: "pending" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "nora@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "maya@example.com" } } });
+
+    const result = await handler(makeEventNoRollback());
+    expect(result.statusCode).toBe(200);
+    expect(DeleteItemCommand).not.toHaveBeenCalled();
+    expect(PutItemCommand).toHaveBeenCalledTimes(2);
     expect(sesSend).toHaveBeenCalledTimes(3);
   });
 });

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -242,5 +242,42 @@ describe("cancelCourseDate Lambda", () => {
     expect(QueryCommand).toHaveBeenCalledTimes(1);
     expect(sesSend).toHaveBeenCalledTimes(1); // user mail
   });
+
+  test("does not send cancellation mails to invited-only participants", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "Aria" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "Aria" }] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Item: {
+          email: { S: "aria@example.com" },
+          inviteSentAt: { S: "2026-05-01T10:00:00.000Z" },
+        },
+      });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(GetItemCommand).toHaveBeenCalled();
+    expect(sesSend).not.toHaveBeenCalled();
+  });
 });
 

--- a/backend/src/lambdas/cancelCourseDate/index.test.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.test.ts
@@ -126,6 +126,7 @@ describe("cancelCourseDate Lambda", () => {
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } })
       .mockResolvedValueOnce({ Item: { email: { S: "nora@example.com" } } })
       .mockResolvedValueOnce({ Item: { email: { S: "maya@example.com" } } });
@@ -310,6 +311,169 @@ describe("cancelCourseDate Lambda", () => {
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(200);
     expect(sesSend).toHaveBeenCalledTimes(2);
+  });
+
+  test("studio report includes waitlist and cancelled users with active swaps", async () => {
+    process.env.STUDIO_NOTIFICATION_EMAILS = "studio@example.com";
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "4" },
+          name: { S: "YogaMi" },
+          participants: { L: [{ S: "Luna" }, { S: "Skye" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "4_2026-05-13" },
+          participants: { L: [{ S: "kai" }, { S: "Skye" }] },
+          swapped: { L: [{ S: "kai" }] },
+          waitlist: { L: [{ S: "Maya" }] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            user_swapId: { S: "Luna#2026-05-13_4_2026-05-14_5" },
+            user: { S: "Luna" },
+            fromCourseId: { S: "4" },
+            fromDate: { S: "2026-05-13" },
+            toCourseId: { S: "5" },
+            toDate: { S: "2026-05-14" },
+            status: { S: "active" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { email: { S: "kai@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "skye@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "maya@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } });
+
+    const event = ({
+      body: JSON.stringify({
+        rollbackOutgoingSwapsFromCancelledParticipants: true,
+        notifyAlreadyCancelledParticipants: true,
+      }),
+      headers: {},
+      pathParameters: { courseId: "4", date: "2026-05-13" },
+      requestContext: {
+        authorizer: {
+          jwt: { claims: { nickname: "admin" } },
+        },
+      },
+    } as unknown) as APIGatewayProxyEvent;
+
+    const result = await handler(event);
+    expect(result.statusCode).toBe(200);
+
+    const reportCall = sesSend.mock.calls[sesSend.mock.calls.length - 1]?.[0];
+    const reportHtml = reportCall?.Message?.Body?.Html?.Data ?? "";
+    expect(reportHtml).toContain("Warteliste betroffen: Maya");
+    expect(reportHtml).toContain("Abgesagt mit aktivem Swap: Luna");
+  });
+
+  test("removes users from target override waitlist when deleting pending outgoing swaps", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }, { S: "maya" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "luna" }] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            user_swapId: { S: "luna#2099-01-06_1_2099-01-09_2" },
+            user: { S: "luna" },
+            fromCourseId: { S: "1" },
+            fromDate: { S: "2099-01-06" },
+            toCourseId: { S: "2" },
+            toDate: { S: "2099-01-09" },
+            status: { S: "pending" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "2_2099-01-09" },
+          courseId: { S: "2" },
+          date: { S: "2099-01-09" },
+          participants: { L: [{ S: "zoe" }] },
+          swapped: { L: [] },
+          waitlist: { L: [{ S: "luna" }, { S: "mia" }] },
+        },
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { email: { S: "luna@example.com" } } })
+      .mockResolvedValueOnce({ Item: { email: { S: "maya@example.com" } } });
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+
+    const putCalls = (PutItemCommand as unknown as jest.Mock).mock.calls.map((call) => call[0]);
+    const targetOverrideUpdate = putCalls.find(
+      (input) => input?.TableName === "test-overrides" && input?.Item?.courseId_date?.S === "2_2099-01-09",
+    );
+    expect(targetOverrideUpdate).toBeDefined();
+    expect(targetOverrideUpdate.Item.waitlist.L).toEqual([{ S: "mia" }]);
+  });
+
+  test("continues successfully when participant lookup fails for one recipient", async () => {
+    process.env.STUDIO_NOTIFICATION_EMAILS = "studio@example.com";
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId: { S: "1" },
+          name: { S: "Kurs A" },
+          participants: { L: [{ S: "luna" }] },
+          excludedDates: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          courseId_date: { S: "1_2099-01-06" },
+          participants: { L: [{ S: "luna" }] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("participants lookup transient error"))
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(sesSend).toHaveBeenCalledTimes(1); // only studio report mail
   });
 });
 

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -83,7 +83,6 @@ async function resolveParticipantEmail(
           ":userIdNormalized": { S: requestedUserId.toLowerCase() },
         },
         Limit: 1,
-        ConsistentRead: true,
       }),
     );
   } catch (error) {
@@ -337,6 +336,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     let mailSkippedNoProfileCount = 0;
     let mailSkippedNoEmailCount = 0;
     let mailFailedCount = 0;
+    let normalizedLookupUsedCount = 0;
     if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
       for (const userId of notifyUsers) {
         const { email, resolvedUserId } = await resolveParticipantEmail(participantsTable, tenantId, userId);
@@ -351,6 +351,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           continue;
         }
         if (resolvedUserId && resolvedUserId !== userId) {
+          normalizedLookupUsedCount += 1;
           console.info("cancelCourseDate participant email resolved via normalized lookup", {
             tenantId,
             courseId,
@@ -395,6 +396,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         mailSkippedNoEmailCount,
         mailFailedCount,
         requestedRecipients: notifyUserList.length,
+        normalizedLookupUsedCount,
       });
     } else {
       console.info("cancelCourseDate mail skipped entirely", {

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -291,6 +291,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     });
 
     let deletedSwapsCount = 0;
+    const waitlistCleanupByOverride = new Map<string, Set<string>>();
     for (const swapItem of toDeleteSwaps) {
       if (!swapItem.user_swapId?.S) {
         console.warn("cancelCourseDate skip swap delete without key", {
@@ -311,12 +312,70 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         }),
       );
       deletedSwapsCount += 1;
+      const swapStatus = swapItem.status?.S ?? "";
+      const targetCourseId = swapItem.toCourseId?.S ?? "";
+      const targetDate = swapItem.toDate?.S ?? "";
+      const swapUser = swapItem.user?.S ?? "";
+      if (
+        swapStatus === "pending" &&
+        targetCourseId &&
+        targetDate &&
+        swapUser
+      ) {
+        const targetOverrideKey = `${targetCourseId}_${targetDate}`;
+        const existingUsers = waitlistCleanupByOverride.get(targetOverrideKey) ?? new Set<string>();
+        existingUsers.add(swapUser);
+        waitlistCleanupByOverride.set(targetOverrideKey, existingUsers);
+      }
+    }
+    let waitlistCleanupOverridesTouched = 0;
+    let waitlistCleanupUsersRemoved = 0;
+    for (const [targetOverrideKey, usersToRemove] of waitlistCleanupByOverride.entries()) {
+      try {
+        const targetOverrideResp = await client.send(
+          new GetItemCommand({
+            TableName: overridesTable,
+            Key: {
+              tenantId: { S: tenantId },
+              courseId_date: { S: targetOverrideKey },
+            },
+            ConsistentRead: true,
+          }),
+        );
+        if (!targetOverrideResp.Item) continue;
+        const waitlistBefore = asStringList(targetOverrideResp.Item.waitlist);
+        const waitlistAfter = waitlistBefore.filter((userId) => !usersToRemove.has(userId));
+        if (waitlistAfter.length === waitlistBefore.length) continue;
+        waitlistCleanupOverridesTouched += 1;
+        waitlistCleanupUsersRemoved += waitlistBefore.length - waitlistAfter.length;
+        await client.send(
+          new PutItemCommand({
+            TableName: overridesTable,
+            Item: {
+              ...targetOverrideResp.Item,
+              waitlist: { L: waitlistAfter.map((userId) => ({ S: userId })) },
+              actorUserId: { S: actorUserId },
+            },
+          }),
+        );
+      } catch (waitlistCleanupError) {
+        console.warn("cancelCourseDate waitlist cleanup warning", {
+          tenantId,
+          courseId,
+          date,
+          targetOverrideKey,
+          usersToRemove: Array.from(usersToRemove),
+          error: waitlistCleanupError,
+        });
+      }
     }
     console.info("cancelCourseDate swap cleanup done", {
       tenantId,
       courseId,
       date,
       deletedSwapsCount,
+      waitlistCleanupOverridesTouched,
+      waitlistCleanupUsersRemoved,
     });
 
     const excludedDates = new Set(asStringList(courseResp.Item.excludedDates));
@@ -370,11 +429,32 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     let normalizedLookupUsedCount = 0;
     if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
       for (const userId of notifyUsers) {
-        const { email, resolvedUserId, status, lookupSource } = await resolveParticipantEmail(
-          participantsTable,
-          tenantId,
-          userId,
-        );
+        let email: string | undefined;
+        let resolvedUserId: string | undefined;
+        let status: "no_login" | "invited" | "active" | undefined;
+        let lookupSource: "exact" | "normalized" | undefined;
+        try {
+          const lookupResult = await resolveParticipantEmail(
+            participantsTable,
+            tenantId,
+            userId,
+          );
+          email = lookupResult.email;
+          resolvedUserId = lookupResult.resolvedUserId;
+          status = lookupResult.status;
+          lookupSource = lookupResult.lookupSource;
+        } catch (lookupError) {
+          mailSkippedNoProfileCount += 1;
+          console.warn("cancelCourseDate participant lookup warning", {
+            tenantId,
+            courseId,
+            date,
+            requestedUserId: userId,
+            error: lookupError,
+          });
+          continue;
+        }
+        const recipientName = (resolvedUserId || userId || "Teilnehmer").trim();
         console.info("cancelCourseDate participant notification candidate", {
           tenantId,
           courseId,
@@ -425,7 +505,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
                 Subject: { Data: `Terminabsage: ${courseName} (${date})` },
                 Body: {
                   Html: {
-                    Data: `<p>Der Termin <strong>${date}</strong> im Kurs <strong>${courseName}</strong> wurde abgesagt.</p>`,
+                    Data: `<p>Hallo ${recipientName},</p><p>der Termin <strong>${date}</strong> im Kurs <strong>${courseName}</strong> wurde abgesagt.</p>`,
                   },
                 },
               },
@@ -496,6 +576,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           !outgoingSwapsFromCancelledParticipants.includes(userId) &&
           !activeSwapsWithOriginOnCancelledDate.some((swap) => swap.userId === userId),
       );
+      const cancelledWithActiveSwap = alreadyCancelledParticipants.filter((userId) =>
+        activeSwapsWithOriginOnCancelledDate.some((swap) => swap.userId === userId),
+      );
 
       const reportHtml = `
         <h3>Terminabsage Report</h3>
@@ -504,7 +587,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         <p>Actor: <strong>${actorUserId}</strong></p>
         <p>Regulär betroffen: ${dedupeUsers(bookedParticipants).join(", ") || "-"}</p>
         <p>Reingetauscht betroffen: ${dedupeUsers(swappedInParticipants).join(", ") || "-"}</p>
+        <p>Warteliste betroffen: ${dedupeUsers(waitlistParticipants).join(", ") || "-"}</p>
         <p>Aktive Swaps (Ursprung abgesagter Termin): ${activeSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
+        <p>Abgesagt mit aktivem Swap: ${dedupeUsers(cancelledWithActiveSwap).join(", ") || "-"}</p>
         <p>Abgesagt ohne Swap: ${dedupeUsers(cancelledWithoutSwap).join(", ") || "-"}</p>
         <p>Abgesagt mit pending Swaps: ${dedupeUsers(outgoingSwapsFromCancelledParticipants).join(", ") || "-"}</p>
         <p>Pending Swaps mit anderem Ursprung (Ziel abgesagter Termin): ${pendingSwapsToCancelledDateWithOtherOrigin.map((s) => `${s.userId} <- ${s.fromCourseId}/${s.fromDate} (originCancelled=${s.fromOriginCancelled})`).join("; ") || "-"}</p>

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -19,6 +19,11 @@ type CancelBody = {
   rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
   notifyAlreadyCancelledParticipants?: boolean;
 };
+type CancelCourseDateWarningCode =
+  | "waitlist_cleanup_failed"
+  | "participant_lookup_failed"
+  | "participant_mail_failed"
+  | "studio_report_failed";
 
 function parseBody(event: APIGatewayProxyEvent): CancelBody {
   if (!event.body) return {};
@@ -291,6 +296,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     });
 
     let deletedSwapsCount = 0;
+    const warningCodes = new Set<CancelCourseDateWarningCode>();
     const waitlistCleanupByOverride = new Map<string, Set<string>>();
     for (const swapItem of toDeleteSwaps) {
       if (!swapItem.user_swapId?.S) {
@@ -359,6 +365,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           }),
         );
       } catch (waitlistCleanupError) {
+        warningCodes.add("waitlist_cleanup_failed");
         console.warn("cancelCourseDate waitlist cleanup warning", {
           tenantId,
           courseId,
@@ -444,6 +451,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           status = lookupResult.status;
           lookupSource = lookupResult.lookupSource;
         } catch (lookupError) {
+          warningCodes.add("participant_lookup_failed");
           mailSkippedNoProfileCount += 1;
           console.warn("cancelCourseDate participant lookup warning", {
             tenantId,
@@ -520,6 +528,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
             email,
           });
         } catch (mailError) {
+          warningCodes.add("participant_mail_failed");
           mailFailedCount += 1;
           console.warn("cancelCourseDate mail warning", { tenantId, userId, date, error: mailError });
         }
@@ -616,6 +625,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           recipients: studioNotificationEmails,
         });
       } catch (reportError) {
+        warningCodes.add("studio_report_failed");
         console.warn("cancelCourseDate studio report mail warning", {
           tenantId,
           courseId,
@@ -639,6 +649,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         success: true,
         courseId: Number(courseId),
         date,
+        operationWarnings: Array.from(warningCodes),
         affected: {
           bookedParticipants,
           swappedInParticipants,

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -16,6 +16,8 @@ const ses = new SESClient({});
 const PARTICIPANTS_NORMALIZED_INDEX = "GSI_UserIdNormalized";
 
 type CancelBody = {
+  rollbackSuccessfulSwapsFromCancelledParticipants?: boolean;
+  rollbackPendingWaitlistSwapsFromOriginDate?: boolean;
   rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
   notifyAlreadyCancelledParticipants?: boolean;
 };
@@ -166,8 +168,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   const body = parseBody(event);
-  const rollbackOutgoing = body.rollbackOutgoingSwapsFromCancelledParticipants === true;
-  const notifyAlreadyCancelled = body.notifyAlreadyCancelledParticipants !== false;
+  const rollbackSuccessfulSwaps =
+    body.rollbackSuccessfulSwapsFromCancelledParticipants ??
+    (body.rollbackOutgoingSwapsFromCancelledParticipants === true);
+  const rollbackPendingWaitlistSwaps =
+    body.rollbackPendingWaitlistSwapsFromOriginDate ??
+    body.rollbackOutgoingSwapsFromCancelledParticipants ??
+    true;
 
   try {
     console.info("cancelCourseDate start", {
@@ -175,8 +182,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       actorUserId,
       courseId,
       date,
-      rollbackOutgoing,
-      notifyAlreadyCancelled,
+      rollbackSuccessfulSwaps,
+      rollbackPendingWaitlistSwaps,
     });
 
     const actorMembershipResp = await client.send(
@@ -277,11 +284,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       if (item.toCourseId?.S === courseId && item.toDate?.S === date) return true;
       if (item.fromCourseId?.S === courseId && item.fromDate?.S === date) {
         const swapUser = item.user?.S ?? "";
-        if (item.status?.S !== "pending") return false;
-        if (!alreadyCancelledSet.has(swapUser)) return true;
+        if (item.status?.S === "pending") {
+          return rollbackPendingWaitlistSwaps;
+        }
+        if (item.status?.S !== "active") return false;
+        if (!alreadyCancelledSet.has(swapUser)) return false;
         const toDate = item.toDate?.S ?? "";
         if (!toDate || !isIsoDateInFuture(toDate)) return false;
-        return rollbackOutgoing;
+        return rollbackSuccessfulSwaps;
       }
       return false;
     });
@@ -413,10 +423,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }),
     );
 
-    const notifyUsers = new Set([...bookedParticipants, ...swappedInParticipants, ...waitlistParticipants]);
-    if (notifyAlreadyCancelled) {
-      alreadyCancelledParticipants.forEach((userId) => notifyUsers.add(userId));
-    }
+    const notifyUsers = new Set([
+      ...bookedParticipants,
+      ...swappedInParticipants,
+      ...waitlistParticipants,
+      ...alreadyCancelledParticipants,
+    ]);
     const notifyUserList = dedupeUsers(Array.from(notifyUsers));
     console.info("cancelCourseDate notification plan", {
       tenantId,
@@ -595,13 +607,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         <p>Kurs: <strong>${courseName}</strong> (${courseId})</p>
         <p>Termin: <strong>${date}</strong></p>
         <p>Actor: <strong>${actorUserId}</strong></p>
-        <p>Regulär betroffen: ${dedupeUsers(bookedParticipants).join(", ") || "-"}</p>
-        <p>Reingetauscht betroffen: ${dedupeUsers(swappedInParticipants).join(", ") || "-"}</p>
-        <p>Warteliste betroffen: ${dedupeUsers(waitlistParticipants).join(", ") || "-"}</p>
+        <p>Regulär geplant: ${dedupeUsers(bookedParticipants).join(", ") || "-"}</p>
+        <p>Davon reingetauscht: ${dedupeUsers(swappedInParticipants).join(", ") || "-"}</p>
+        <p>Warteliste am abgesagten Termin: ${dedupeUsers(waitlistParticipants).join(", ") || "-"}</p>
         <p>Aktive Swaps (Ursprung abgesagter Termin): ${activeSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
-        <p>Abgesagt mit aktivem Swap: ${dedupeUsers(cancelledWithActiveSwap).join(", ") || "-"}</p>
-        <p>Abgesagt ohne Swap: ${dedupeUsers(cancelledWithoutSwap).join(", ") || "-"}</p>
-        <p>Abgesagt mit pending Swaps: ${dedupeUsers(outgoingSwapsFromCancelledParticipants).join(", ") || "-"}</p>
+        <p>Bereits abgemeldet mit aktivem Swap: ${dedupeUsers(cancelledWithActiveSwap).join(", ") || "-"}</p>
+        <p>Bereits abgemeldet ohne Swap: ${dedupeUsers(cancelledWithoutSwap).join(", ") || "-"}</p>
+        <p>Bereits abgemeldet mit pending Swap: ${dedupeUsers(outgoingSwapsFromCancelledParticipants).join(", ") || "-"}</p>
+        <p>Rollback erfolgreiche Tauschs: ${rollbackSuccessfulSwaps ? "ja" : "nein"}</p>
+        <p>Rollback pending Wartelisten-Tauschs: ${rollbackPendingWaitlistSwaps ? "ja" : "nein"}</p>
         <p>Pending Swaps mit anderem Ursprung (Ziel abgesagter Termin): ${pendingSwapsToCancelledDateWithOtherOrigin.map((s) => `${s.userId} <- ${s.fromCourseId}/${s.fromDate} (originCancelled=${s.fromOriginCancelled})`).join("; ") || "-"}</p>
         <p>Pending Swaps mit Ursprung abgesagter Termin: ${pendingSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
         <hr />

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -3,6 +3,7 @@ import {
   DeleteItemCommand,
   GetItemCommand,
   PutItemCommand,
+  QueryCommand,
   ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
@@ -11,6 +12,7 @@ import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
 const ses = new SESClient({});
+const PARTICIPANTS_NORMALIZED_INDEX = "GSI_UserIdNormalized";
 
 type CancelBody = {
   rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
@@ -47,6 +49,60 @@ function parseCsvEmails(raw: string | undefined): string[] {
 function isIsoDateInFuture(isoDate: string): boolean {
   const today = new Date().toISOString().slice(0, 10);
   return isoDate > today;
+}
+
+async function resolveParticipantEmail(
+  participantsTable: string,
+  tenantId: string,
+  requestedUserId: string,
+): Promise<{ email?: string; resolvedUserId?: string }> {
+  const exactProfileResp = await client.send(
+    new GetItemCommand({
+      TableName: participantsTable,
+      Key: {
+        tenantId: { S: tenantId },
+        userId: { S: requestedUserId },
+      },
+      ConsistentRead: true,
+    }),
+  );
+  const exactEmail = exactProfileResp.Item?.email?.S?.trim();
+  if (exactProfileResp.Item && exactEmail) {
+    return { email: exactEmail, resolvedUserId: requestedUserId };
+  }
+
+  let normalizedLookupResp;
+  try {
+    normalizedLookupResp = await client.send(
+      new QueryCommand({
+        TableName: participantsTable,
+        IndexName: PARTICIPANTS_NORMALIZED_INDEX,
+        KeyConditionExpression: "tenantId = :tenantId AND userIdNormalized = :userIdNormalized",
+        ExpressionAttributeValues: {
+          ":tenantId": { S: tenantId },
+          ":userIdNormalized": { S: requestedUserId.toLowerCase() },
+        },
+        Limit: 1,
+        ConsistentRead: true,
+      }),
+    );
+  } catch (error) {
+    console.warn("cancelCourseDate normalized participant lookup failed", {
+      tenantId,
+      requestedUserId,
+      indexName: PARTICIPANTS_NORMALIZED_INDEX,
+      error,
+    });
+    return {};
+  }
+  const normalizedItem = normalizedLookupResp.Items?.[0];
+  const normalizedEmail = normalizedItem?.email?.S?.trim();
+  const normalizedUserId = normalizedItem?.userId?.S?.trim();
+  if (normalizedItem && normalizedEmail) {
+    return { email: normalizedEmail, resolvedUserId: normalizedUserId || requestedUserId };
+  }
+
+  return {};
 }
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
@@ -283,17 +339,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     let mailFailedCount = 0;
     if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
       for (const userId of notifyUsers) {
-        const participantResp = await client.send(
-          new GetItemCommand({
-            TableName: participantsTable,
-            Key: {
-              tenantId: { S: tenantId },
-              userId: { S: userId },
-            },
-            ConsistentRead: true,
-          }),
-        );
-        if (!participantResp.Item) {
+        const { email, resolvedUserId } = await resolveParticipantEmail(participantsTable, tenantId, userId);
+        if (!email) {
           mailSkippedNoProfileCount += 1;
           console.warn("cancelCourseDate skip mail: participant profile missing", {
             tenantId,
@@ -303,16 +350,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           });
           continue;
         }
-        const email = participantResp.Item?.email?.S?.trim();
-        if (!email) {
-          mailSkippedNoEmailCount += 1;
-          console.warn("cancelCourseDate skip mail: missing email", {
+        if (resolvedUserId && resolvedUserId !== userId) {
+          console.info("cancelCourseDate participant email resolved via normalized lookup", {
             tenantId,
             courseId,
             date,
-            userId,
+            requestedUserId: userId,
+            resolvedUserId,
           });
-          continue;
         }
         try {
           await ses.send(

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -347,7 +347,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }),
     );
 
-    const notifyUsers = new Set([...bookedParticipants, ...swappedInParticipants]);
+    const notifyUsers = new Set([...bookedParticipants, ...swappedInParticipants, ...waitlistParticipants]);
     if (notifyAlreadyCancelled) {
       alreadyCancelledParticipants.forEach((userId) => notifyUsers.add(userId));
     }

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { dynamoClient } from "../shared/dynamoClient";
+import { deriveParticipantStatus } from "../shared/participantStatus";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
@@ -55,7 +56,12 @@ async function resolveParticipantEmail(
   participantsTable: string,
   tenantId: string,
   requestedUserId: string,
-): Promise<{ email?: string; resolvedUserId?: string }> {
+): Promise<{
+  email?: string;
+  resolvedUserId?: string;
+  status?: "no_login" | "invited" | "active";
+  lookupSource?: "exact" | "normalized";
+}> {
   const exactProfileResp = await client.send(
     new GetItemCommand({
       TableName: participantsTable,
@@ -67,8 +73,20 @@ async function resolveParticipantEmail(
     }),
   );
   const exactEmail = exactProfileResp.Item?.email?.S?.trim();
+  const exactStatus = exactProfileResp.Item
+    ? deriveParticipantStatus({
+        authUserId: exactProfileResp.Item.authUserId?.S,
+        inviteSentAt: exactProfileResp.Item.inviteSentAt?.S,
+        inviteCompletedAt: exactProfileResp.Item.inviteCompletedAt?.S,
+      })
+    : undefined;
   if (exactProfileResp.Item && exactEmail) {
-    return { email: exactEmail, resolvedUserId: requestedUserId };
+    return {
+      email: exactEmail,
+      resolvedUserId: requestedUserId,
+      status: exactStatus,
+      lookupSource: "exact",
+    };
   }
 
   let normalizedLookupResp;
@@ -97,8 +115,20 @@ async function resolveParticipantEmail(
   const normalizedItem = normalizedLookupResp.Items?.[0];
   const normalizedEmail = normalizedItem?.email?.S?.trim();
   const normalizedUserId = normalizedItem?.userId?.S?.trim();
+  const normalizedStatus = normalizedItem
+    ? deriveParticipantStatus({
+        authUserId: normalizedItem.authUserId?.S,
+        inviteSentAt: normalizedItem.inviteSentAt?.S,
+        inviteCompletedAt: normalizedItem.inviteCompletedAt?.S,
+      })
+    : undefined;
   if (normalizedItem && normalizedEmail) {
-    return { email: normalizedEmail, resolvedUserId: normalizedUserId || requestedUserId };
+    return {
+      email: normalizedEmail,
+      resolvedUserId: normalizedUserId || requestedUserId,
+      status: normalizedStatus,
+      lookupSource: "normalized",
+    };
   }
 
   return {};
@@ -335,11 +365,26 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     let mailSentCount = 0;
     let mailSkippedNoProfileCount = 0;
     let mailSkippedNoEmailCount = 0;
+    let mailSkippedInvitedCount = 0;
     let mailFailedCount = 0;
     let normalizedLookupUsedCount = 0;
     if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
       for (const userId of notifyUsers) {
-        const { email, resolvedUserId } = await resolveParticipantEmail(participantsTable, tenantId, userId);
+        const { email, resolvedUserId, status, lookupSource } = await resolveParticipantEmail(
+          participantsTable,
+          tenantId,
+          userId,
+        );
+        console.info("cancelCourseDate participant notification candidate", {
+          tenantId,
+          courseId,
+          date,
+          requestedUserId: userId,
+          resolvedUserId: resolvedUserId ?? null,
+          participantStatus: status ?? null,
+          lookupSource: lookupSource ?? null,
+          hasEmail: Boolean(email),
+        });
         if (!email) {
           mailSkippedNoProfileCount += 1;
           console.warn("cancelCourseDate skip mail: participant profile missing", {
@@ -347,6 +392,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
             courseId,
             date,
             userId,
+          });
+          continue;
+        }
+        if (status === "invited") {
+          mailSkippedInvitedCount += 1;
+          console.info("cancelCourseDate skip mail: participant invited only", {
+            tenantId,
+            courseId,
+            date,
+            requestedUserId: userId,
+            resolvedUserId: resolvedUserId ?? userId,
           });
           continue;
         }
@@ -394,6 +450,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         mailSentCount,
         mailSkippedNoProfileCount,
         mailSkippedNoEmailCount,
+        mailSkippedInvitedCount,
         mailFailedCount,
         requestedRecipients: notifyUserList.length,
         normalizedLookupUsedCount,
@@ -453,7 +510,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         <p>Pending Swaps mit anderem Ursprung (Ziel abgesagter Termin): ${pendingSwapsToCancelledDateWithOtherOrigin.map((s) => `${s.userId} <- ${s.fromCourseId}/${s.fromDate} (originCancelled=${s.fromOriginCancelled})`).join("; ") || "-"}</p>
         <p>Pending Swaps mit Ursprung abgesagter Termin: ${pendingSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
         <hr />
-        <p>Mail Summary: sent=${mailSentCount}, skippedNoProfile=${mailSkippedNoProfileCount}, skippedNoEmail=${mailSkippedNoEmailCount}, failed=${mailFailedCount}</p>
+        <p>Mail Summary: sent=${mailSentCount}, skippedNoProfile=${mailSkippedNoProfileCount}, skippedNoEmail=${mailSkippedNoEmailCount}, skippedInvited=${mailSkippedInvitedCount}, failed=${mailFailedCount}</p>
       `;
       try {
         await ses.send(

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -520,6 +520,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
             email,
           });
         } catch (mailError) {
+          mailFailedCount += 1;
           console.warn("cancelCourseDate mail warning", { tenantId, userId, date, error: mailError });
         }
       }

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -36,6 +36,19 @@ function dedupeUsers(values: string[]): string[] {
   return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
 }
 
+function parseCsvEmails(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function isIsoDateInFuture(isoDate: string): boolean {
+  const today = new Date().toISOString().slice(0, 10);
+  return isoDate > today;
+}
+
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const coursesTable = process.env.COURSES_TABLE;
   const overridesTable = process.env.OVERRIDES_TABLE;
@@ -43,6 +56,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
   const participantsTable = process.env.PARTICIPANTS_TABLE;
   const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "";
+  const studioNotificationEmails = parseCsvEmails(process.env.STUDIO_NOTIFICATION_EMAILS);
   if (!coursesTable || !overridesTable || !swapsTable || !membershipsTable) {
     return {
       statusCode: 500,
@@ -62,7 +76,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   const body = parseBody(event);
-  const rollbackOutgoing = body.rollbackOutgoingSwapsFromCancelledParticipants !== false;
+  const rollbackOutgoing = body.rollbackOutgoingSwapsFromCancelledParticipants === true;
   const notifyAlreadyCancelled = body.notifyAlreadyCancelledParticipants !== false;
 
   try {
@@ -161,6 +175,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         (item) =>
           item.fromCourseId?.S === courseId &&
           item.fromDate?.S === date &&
+          item.toDate?.S &&
+          isIsoDateInFuture(item.toDate.S) &&
           item.user?.S &&
           alreadyCancelledSet.has(item.user.S) &&
           item.status?.S === "pending",
@@ -171,7 +187,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       if (item.toCourseId?.S === courseId && item.toDate?.S === date) return true;
       if (item.fromCourseId?.S === courseId && item.fromDate?.S === date) {
         const swapUser = item.user?.S ?? "";
+        if (item.status?.S !== "pending") return false;
         if (!alreadyCancelledSet.has(swapUser)) return true;
+        const toDate = item.toDate?.S ?? "";
+        if (!toDate || !isIsoDateInFuture(toDate)) return false;
         return rollbackOutgoing;
       }
       return false;
@@ -258,11 +277,11 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       sesConfigured: Boolean(sesSourceEmail),
     });
 
+    let mailSentCount = 0;
+    let mailSkippedNoProfileCount = 0;
+    let mailSkippedNoEmailCount = 0;
+    let mailFailedCount = 0;
     if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
-      let mailSentCount = 0;
-      let mailSkippedNoProfileCount = 0;
-      let mailSkippedNoEmailCount = 0;
-      let mailFailedCount = 0;
       for (const userId of notifyUsers) {
         const participantResp = await client.send(
           new GetItemCommand({
@@ -342,6 +361,85 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           : !sesSourceEmail
             ? "ses_source_email_missing"
             : "no_recipients",
+      });
+    }
+
+    if (studioNotificationEmails.length > 0 && sesSourceEmail) {
+      const activeSwapsWithOriginOnCancelledDate = relatedSwaps
+        .filter((item) => item.fromCourseId?.S === courseId && item.fromDate?.S === date && item.status?.S === "active")
+        .map((item) => ({
+          userId: item.user?.S ?? "",
+          toCourseId: item.toCourseId?.S ?? "",
+          toDate: item.toDate?.S ?? "",
+        }));
+      const pendingSwapsWithOriginOnCancelledDate = relatedSwaps
+        .filter((item) => item.fromCourseId?.S === courseId && item.fromDate?.S === date && item.status?.S === "pending")
+        .map((item) => ({
+          userId: item.user?.S ?? "",
+          toCourseId: item.toCourseId?.S ?? "",
+          toDate: item.toDate?.S ?? "",
+        }));
+      const pendingSwapsToCancelledDateWithOtherOrigin = relatedSwaps
+        .filter((item) => item.toCourseId?.S === courseId && item.toDate?.S === date && item.status?.S === "pending")
+        .map((item) => ({
+          userId: item.user?.S ?? "",
+          fromCourseId: item.fromCourseId?.S ?? "",
+          fromDate: item.fromDate?.S ?? "",
+          fromOriginCancelled: alreadyCancelledSet.has(item.user?.S ?? ""),
+        }));
+      const cancelledWithoutSwap = alreadyCancelledParticipants.filter(
+        (userId) =>
+          !outgoingSwapsFromCancelledParticipants.includes(userId) &&
+          !activeSwapsWithOriginOnCancelledDate.some((swap) => swap.userId === userId),
+      );
+
+      const reportHtml = `
+        <h3>Terminabsage Report</h3>
+        <p>Kurs: <strong>${courseName}</strong> (${courseId})</p>
+        <p>Termin: <strong>${date}</strong></p>
+        <p>Actor: <strong>${actorUserId}</strong></p>
+        <p>Regulär betroffen: ${dedupeUsers(bookedParticipants).join(", ") || "-"}</p>
+        <p>Reingetauscht betroffen: ${dedupeUsers(swappedInParticipants).join(", ") || "-"}</p>
+        <p>Aktive Swaps (Ursprung abgesagter Termin): ${activeSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
+        <p>Abgesagt ohne Swap: ${dedupeUsers(cancelledWithoutSwap).join(", ") || "-"}</p>
+        <p>Abgesagt mit pending Swaps: ${dedupeUsers(outgoingSwapsFromCancelledParticipants).join(", ") || "-"}</p>
+        <p>Pending Swaps mit anderem Ursprung (Ziel abgesagter Termin): ${pendingSwapsToCancelledDateWithOtherOrigin.map((s) => `${s.userId} <- ${s.fromCourseId}/${s.fromDate} (originCancelled=${s.fromOriginCancelled})`).join("; ") || "-"}</p>
+        <p>Pending Swaps mit Ursprung abgesagter Termin: ${pendingSwapsWithOriginOnCancelledDate.map((s) => `${s.userId} -> ${s.toCourseId}/${s.toDate}`).join("; ") || "-"}</p>
+        <hr />
+        <p>Mail Summary: sent=${mailSentCount}, skippedNoProfile=${mailSkippedNoProfileCount}, skippedNoEmail=${mailSkippedNoEmailCount}, failed=${mailFailedCount}</p>
+      `;
+      try {
+        await ses.send(
+          new SendEmailCommand({
+            Source: sesSourceEmail,
+            Destination: { ToAddresses: studioNotificationEmails },
+            Message: {
+              Subject: { Data: `Studio-Report Terminabsage: ${courseName} (${date})` },
+              Body: { Html: { Data: reportHtml } },
+            },
+          }),
+        );
+        console.info("cancelCourseDate studio report sent", {
+          tenantId,
+          courseId,
+          date,
+          recipients: studioNotificationEmails,
+        });
+      } catch (reportError) {
+        console.warn("cancelCourseDate studio report mail warning", {
+          tenantId,
+          courseId,
+          date,
+          recipients: studioNotificationEmails,
+          error: reportError,
+        });
+      }
+    } else {
+      console.info("cancelCourseDate studio report skipped", {
+        tenantId,
+        courseId,
+        date,
+        reason: studioNotificationEmails.length === 0 ? "no_report_recipients" : "ses_source_email_missing",
       });
     }
 

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -1,0 +1,369 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  DeleteItemCommand,
+  GetItemCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+const ses = new SESClient({});
+
+type CancelBody = {
+  rollbackOutgoingSwapsFromCancelledParticipants?: boolean;
+  notifyAlreadyCancelledParticipants?: boolean;
+};
+
+function parseBody(event: APIGatewayProxyEvent): CancelBody {
+  if (!event.body) return {};
+  try {
+    const parsed = JSON.parse(event.body);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as CancelBody;
+  } catch {
+    return {};
+  }
+}
+
+function asStringList(value: { L?: Array<{ S?: string }> } | undefined): string[] {
+  return (value?.L ?? []).map((entry) => entry.S ?? "").filter(Boolean);
+}
+
+function dedupeUsers(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const coursesTable = process.env.COURSES_TABLE;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const swapsTable = process.env.SWAPS_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  const participantsTable = process.env.PARTICIPANTS_TABLE;
+  const sesSourceEmail = process.env.SES_SOURCE_EMAIL || "";
+  if (!coursesTable || !overridesTable || !swapsTable || !membershipsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Required env vars are missing for cancelCourseDate" }),
+    };
+  }
+
+  const courseId = event.pathParameters?.courseId?.trim();
+  const date = event.pathParameters?.date?.trim();
+  if (!courseId || !date) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId or date in path" }) };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  const body = parseBody(event);
+  const rollbackOutgoing = body.rollbackOutgoingSwapsFromCancelledParticipants !== false;
+  const notifyAlreadyCancelled = body.notifyAlreadyCancelledParticipants !== false;
+
+  try {
+    console.info("cancelCourseDate start", {
+      tenantId,
+      actorUserId,
+      courseId,
+      date,
+      rollbackOutgoing,
+      notifyAlreadyCancelled,
+    });
+
+    const actorMembershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    const actorRole = actorMembershipResp.Item?.role?.S;
+    if (actorRole !== "admin" && actorRole !== "instructor") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const courseResp = await client.send(
+      new GetItemCommand({
+        TableName: coursesTable,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId: { S: courseId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    if (!courseResp.Item) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Course not found" }) };
+    }
+    const courseName = courseResp.Item.name?.S ?? `Kurs ${courseId}`;
+    const staticParticipants = asStringList(courseResp.Item.participants);
+
+    const overrideKey = `${courseId}_${date}`;
+    const overrideResp = await client.send(
+      new GetItemCommand({
+        TableName: overridesTable,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId_date: { S: overrideKey },
+        },
+        ConsistentRead: true,
+      }),
+    );
+
+    const bookedParticipants = overrideResp.Item
+      ? asStringList(overrideResp.Item.participants)
+      : staticParticipants;
+    const swappedInParticipants = overrideResp.Item ? asStringList(overrideResp.Item.swapped) : [];
+    const waitlistParticipants = overrideResp.Item ? asStringList(overrideResp.Item.waitlist) : [];
+    const bookedSet = new Set(bookedParticipants);
+    const alreadyCancelledParticipants = staticParticipants.filter((userId) => !bookedSet.has(userId));
+    const alreadyCancelledSet = new Set(alreadyCancelledParticipants);
+    console.info("cancelCourseDate participant groups", {
+      tenantId,
+      courseId,
+      date,
+      staticParticipantsCount: staticParticipants.length,
+      staticParticipants: dedupeUsers(staticParticipants),
+      bookedParticipantsCount: bookedParticipants.length,
+      bookedParticipants: dedupeUsers(bookedParticipants),
+      swappedInParticipantsCount: swappedInParticipants.length,
+      swappedInParticipants: dedupeUsers(swappedInParticipants),
+      waitlistParticipantsCount: waitlistParticipants.length,
+      waitlistParticipants: dedupeUsers(waitlistParticipants),
+      alreadyCancelledParticipantsCount: alreadyCancelledParticipants.length,
+      alreadyCancelledParticipants: dedupeUsers(alreadyCancelledParticipants),
+      overrideFound: Boolean(overrideResp.Item),
+    });
+
+    const swapsResp = await client.send(
+      new ScanCommand({
+        TableName: swapsTable,
+        FilterExpression:
+          "tenantId = :tenantId AND ((fromCourseId = :courseId AND fromDate = :date) OR (toCourseId = :courseId AND toDate = :date))",
+        ExpressionAttributeValues: {
+          ":tenantId": { S: tenantId },
+          ":courseId": { S: courseId },
+          ":date": { S: date },
+        },
+      }),
+    );
+    const relatedSwaps = swapsResp.Items ?? [];
+    const outgoingSwapsFromCancelledParticipants = relatedSwaps
+      .filter(
+        (item) =>
+          item.fromCourseId?.S === courseId &&
+          item.fromDate?.S === date &&
+          item.user?.S &&
+          alreadyCancelledSet.has(item.user.S) &&
+          item.status?.S === "pending",
+      )
+      .map((item) => item.user!.S!);
+
+    const toDeleteSwaps = relatedSwaps.filter((item) => {
+      if (item.toCourseId?.S === courseId && item.toDate?.S === date) return true;
+      if (item.fromCourseId?.S === courseId && item.fromDate?.S === date) {
+        const swapUser = item.user?.S ?? "";
+        if (!alreadyCancelledSet.has(swapUser)) return true;
+        return rollbackOutgoing;
+      }
+      return false;
+    });
+    console.info("cancelCourseDate swap cleanup plan", {
+      tenantId,
+      courseId,
+      date,
+      relatedSwapsCount: relatedSwaps.length,
+      swapsToDeleteCount: toDeleteSwaps.length,
+      outgoingSwapsFromCancelledParticipantsCount: outgoingSwapsFromCancelledParticipants.length,
+      outgoingSwapsFromCancelledParticipants: dedupeUsers(outgoingSwapsFromCancelledParticipants),
+    });
+
+    let deletedSwapsCount = 0;
+    for (const swapItem of toDeleteSwaps) {
+      if (!swapItem.user_swapId?.S) {
+        console.warn("cancelCourseDate skip swap delete without key", {
+          tenantId,
+          courseId,
+          date,
+          swapUser: swapItem.user?.S ?? null,
+        });
+        continue;
+      }
+      await client.send(
+        new DeleteItemCommand({
+          TableName: swapsTable,
+          Key: {
+            tenantId: { S: tenantId },
+            user_swapId: { S: swapItem.user_swapId.S },
+          },
+        }),
+      );
+      deletedSwapsCount += 1;
+    }
+    console.info("cancelCourseDate swap cleanup done", {
+      tenantId,
+      courseId,
+      date,
+      deletedSwapsCount,
+    });
+
+    const excludedDates = new Set(asStringList(courseResp.Item.excludedDates));
+    excludedDates.add(date);
+    await client.send(
+      new PutItemCommand({
+        TableName: coursesTable,
+        Item: {
+          ...courseResp.Item,
+          excludedDates: { L: Array.from(excludedDates).sort((a, b) => a.localeCompare(b)).map((d) => ({ S: d })) },
+        },
+      }),
+    );
+
+    await client.send(
+      new PutItemCommand({
+        TableName: overridesTable,
+        Item: {
+          tenantId: { S: tenantId },
+          courseId_date: { S: overrideKey },
+          courseId: { S: courseId },
+          date: { S: date },
+          participants: { L: [] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+          actorUserId: { S: actorUserId },
+        },
+      }),
+    );
+
+    const notifyUsers = new Set([...bookedParticipants, ...swappedInParticipants]);
+    if (notifyAlreadyCancelled) {
+      alreadyCancelledParticipants.forEach((userId) => notifyUsers.add(userId));
+    }
+    const notifyUserList = dedupeUsers(Array.from(notifyUsers));
+    console.info("cancelCourseDate notification plan", {
+      tenantId,
+      courseId,
+      date,
+      notifyUsersCount: notifyUserList.length,
+      notifyUsers: notifyUserList,
+      participantsTableConfigured: Boolean(participantsTable),
+      sesConfigured: Boolean(sesSourceEmail),
+    });
+
+    if (participantsTable && sesSourceEmail && notifyUsers.size > 0) {
+      let mailSentCount = 0;
+      let mailSkippedNoProfileCount = 0;
+      let mailSkippedNoEmailCount = 0;
+      let mailFailedCount = 0;
+      for (const userId of notifyUsers) {
+        const participantResp = await client.send(
+          new GetItemCommand({
+            TableName: participantsTable,
+            Key: {
+              tenantId: { S: tenantId },
+              userId: { S: userId },
+            },
+            ConsistentRead: true,
+          }),
+        );
+        if (!participantResp.Item) {
+          mailSkippedNoProfileCount += 1;
+          console.warn("cancelCourseDate skip mail: participant profile missing", {
+            tenantId,
+            courseId,
+            date,
+            userId,
+          });
+          continue;
+        }
+        const email = participantResp.Item?.email?.S?.trim();
+        if (!email) {
+          mailSkippedNoEmailCount += 1;
+          console.warn("cancelCourseDate skip mail: missing email", {
+            tenantId,
+            courseId,
+            date,
+            userId,
+          });
+          continue;
+        }
+        try {
+          await ses.send(
+            new SendEmailCommand({
+              Source: sesSourceEmail,
+              Destination: { ToAddresses: [email] },
+              Message: {
+                Subject: { Data: `Terminabsage: ${courseName} (${date})` },
+                Body: {
+                  Html: {
+                    Data: `<p>Der Termin <strong>${date}</strong> im Kurs <strong>${courseName}</strong> wurde abgesagt.</p>`,
+                  },
+                },
+              },
+            }),
+          );
+          mailSentCount += 1;
+          console.info("cancelCourseDate mail sent", {
+            tenantId,
+            courseId,
+            date,
+            userId,
+            email,
+          });
+        } catch (mailError) {
+          mailFailedCount += 1;
+          console.warn("cancelCourseDate mail warning", { tenantId, userId, date, error: mailError });
+        }
+      }
+      console.info("cancelCourseDate mail summary", {
+        tenantId,
+        courseId,
+        date,
+        mailSentCount,
+        mailSkippedNoProfileCount,
+        mailSkippedNoEmailCount,
+        mailFailedCount,
+        requestedRecipients: notifyUserList.length,
+      });
+    } else {
+      console.info("cancelCourseDate mail skipped entirely", {
+        tenantId,
+        courseId,
+        date,
+        reason: !participantsTable
+          ? "participants_table_missing"
+          : !sesSourceEmail
+            ? "ses_source_email_missing"
+            : "no_recipients",
+      });
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        success: true,
+        courseId: Number(courseId),
+        date,
+        affected: {
+          bookedParticipants,
+          swappedInParticipants,
+          waitlistParticipants,
+          alreadyCancelledParticipants,
+          outgoingSwapsFromCancelledParticipants,
+        },
+      }),
+    };
+  } catch (error) {
+    console.error("cancelCourseDate failed", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to cancel course date" }) };
+  }
+};
+

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -319,7 +319,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
             email,
           });
         } catch (mailError) {
-          mailFailedCount += 1;
           console.warn("cancelCourseDate mail warning", { tenantId, userId, date, error: mailError });
         }
       }

--- a/backend/src/lambdas/processPromotions/index.ts
+++ b/backend/src/lambdas/processPromotions/index.ts
@@ -9,6 +9,28 @@ const client = dynamoClient;
 // Hardcodierter Zeitpuffer (in Minuten) vor Kursbeginn für Nachrücken
 const PROMOTION_TIME_BUFFER_MINUTES = 30;
 
+function normalized(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function includesUserCaseInsensitive(values: string[] | undefined, user: string): boolean {
+  if (!values) return false;
+  const target = normalized(user);
+  return values.some((entry) => normalized(entry) === target);
+}
+
+function removeUserCaseInsensitive(values: string[] | undefined, user: string): string[] {
+  if (!values) return [];
+  const target = normalized(user);
+  return values.filter((entry) => normalized(entry) !== target);
+}
+
+function addUserUniqueCaseInsensitive(values: string[] | undefined, user: string): string[] {
+  const base = values ?? [];
+  if (includesUserCaseInsensitive(base, user)) return base;
+  return [...base, user];
+}
+
 // Hilfsfunktion: Prüft, ob ein Kursbeginn mindestens PROMOTION_TIME_BUFFER_MINUTES in der Zukunft liegt
 function isCourseInFuture(courseDate: string, courseTime: string, now: Date): boolean {
   try {
@@ -215,7 +237,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
         // Wähle promotedUser: Priorisiere currentUser oder erste Person
         let promotedUser: string | undefined;
-        if (currentUser && override.waitlist?.includes(currentUser)) {
+        if (currentUser && includesUserCaseInsensitive(override.waitlist, currentUser)) {
           promotedUser = currentUser;
         } else {
           promotedUser = override.waitlist?.[0];
@@ -224,17 +246,21 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
         console.log('promotedUser:', promotedUser, 'override.courseId:', override.courseId, 'override.date:', override.date, 'override.waitlist:', override.waitlist);
         const correspondingSwap = pendingSwaps.find(
-          (s) => s.user === promotedUser && s.toCourseId === override.courseId && s.toDate === override.date
+          (s) =>
+            normalized(s.user) === normalized(promotedUser) &&
+            s.toCourseId === override.courseId &&
+            s.toDate === override.date
         );
         console.log('Find in pendingSwaps:', pendingSwaps, 'correspondingSwap:', correspondingSwap);
         if (!correspondingSwap) continue;
 
+        const promotedSwapUser = correspondingSwap.user;
         changed = true;
         promotedSwaps.push(correspondingSwap);
 
         // 5) Swap auf 'active' setzen
         const swapId = `${correspondingSwap.fromDate}_${correspondingSwap.fromCourseId}_${correspondingSwap.toDate}_${correspondingSwap.toCourseId}`;
-        const user_swapId = `${promotedUser}#${swapId}`;
+        const user_swapId = `${promotedSwapUser}#${swapId}`;
         const updateSwapCommand = new UpdateItemCommand({
           TableName: process.env.SWAPS_TABLE,
           Key: {
@@ -255,9 +281,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         console.log(`[processPromotions] Swap updated to active: ${swapId}`);
 
         // 6) Ziel-Override aktualisieren
-        const newParticipants = [...override.participants, promotedUser].filter((p, i, arr) => arr.indexOf(p) === i); // Entferne Duplikate
-        const newSwapped = [...(override.swapped || []), promotedUser].filter((p, i, arr) => arr.indexOf(p) === i);
-        const newWaitlist = override.waitlist?.filter((u) => u !== promotedUser) || [];
+        const newParticipants = addUserUniqueCaseInsensitive(override.participants, promotedSwapUser);
+        const newSwapped = addUserUniqueCaseInsensitive(override.swapped, promotedSwapUser);
+        const newWaitlist = removeUserCaseInsensitive(override.waitlist, promotedSwapUser);
         console.log('Updating target override:', {
           courseId: override.courseId,
           date: override.date,
@@ -276,11 +302,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           (o) => o.courseId === correspondingSwap.fromCourseId && o.date === correspondingSwap.fromDate
         );
         if (originOverride) {
-          const newOriginParticipants = originOverride.participants.includes(promotedUser)
-            ? originOverride.participants.filter((p) => p !== promotedUser)
-            : originOverride.participants;
-          const newOriginSwapped = (originOverride.swapped ?? []).filter((p) => p !== promotedUser);
-          const newOriginWaitlist = (originOverride.waitlist ?? []).filter((u) => u !== promotedUser);
+          const newOriginParticipants = removeUserCaseInsensitive(originOverride.participants, promotedSwapUser);
+          const newOriginSwapped = removeUserCaseInsensitive(originOverride.swapped, promotedSwapUser);
+          const newOriginWaitlist = removeUserCaseInsensitive(originOverride.waitlist, promotedSwapUser);
           console.log('Updating origin override:', {
             courseId: correspondingSwap.fromCourseId,
             date: correspondingSwap.fromDate,
@@ -295,11 +319,11 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           });
         } else {
           const originCourse = courses.find((c) => c.id === correspondingSwap.fromCourseId);
-          if (originCourse && originCourse.participants.includes(promotedUser)) {
+          if (originCourse && includesUserCaseInsensitive(originCourse.participants, promotedSwapUser)) {
             const newOriginOverride: CourseDateOverride = {
               courseId: correspondingSwap.fromCourseId,
               date: correspondingSwap.fromDate,
-              participants: originCourse.participants.filter((p) => p !== promotedUser),
+              participants: removeUserCaseInsensitive(originCourse.participants, promotedSwapUser),
               swapped: [],
               waitlist: [],
             };
@@ -311,14 +335,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         // 8) Andere pending Swaps des Users stornieren
         const pendingOriginSwaps = pendingSwaps.filter(
           (s) =>
-            s.user === promotedUser &&
+            normalized(s.user) === normalized(promotedSwapUser) &&
             s.fromCourseId === correspondingSwap.fromCourseId &&
             s.fromDate === correspondingSwap.fromDate &&
             (s.toCourseId !== correspondingSwap.toCourseId || s.toDate !== correspondingSwap.toDate)
         );
         for (const originSwap of pendingOriginSwaps) {
           const originSwapId = `${originSwap.fromDate}_${originSwap.fromCourseId}_${originSwap.toDate}_${originSwap.toCourseId}`;
-          const originUser_swapId = `${promotedUser}#${originSwapId}`;
+          const originUser_swapId = `${originSwap.user}#${originSwapId}`;
           const deleteCommand = new DeleteItemCommand({
             TableName: process.env.SWAPS_TABLE,
             Key: {
@@ -326,14 +350,14 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
               user_swapId: { S: originUser_swapId },
             },
           });
-          console.log('Deleting swap:', { originSwapId, user: promotedUser });
+          console.log('Deleting swap:', { originSwapId, user: originSwap.user });
           await client.send(deleteCommand);
 
           const targetOriginOverride = allOverrides.find(
             (o) => o.courseId === originSwap.toCourseId && o.date === originSwap.toDate
           );
           if (targetOriginOverride) {
-            const newTargetWaitlist = (targetOriginOverride.waitlist || []).filter((u) => u !== promotedUser);
+            const newTargetWaitlist = removeUserCaseInsensitive(targetOriginOverride.waitlist, promotedSwapUser);
             console.log('Updating target waitlist for cancelled swap:', {
               courseId: originSwap.toCourseId,
               date: originSwap.toDate,
@@ -350,7 +374,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         }
 
         console.log(
-          `[processPromotions] ${promotedUser} nachgerückt von ${correspondingSwap.fromCourseId}/${correspondingSwap.fromDate} → ${override.courseId}/${override.date}`
+          `[processPromotions] ${promotedSwapUser} nachgerückt von ${correspondingSwap.fromCourseId}/${correspondingSwap.fromDate} → ${override.courseId}/${override.date}`
         );
       }
 

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -163,6 +163,31 @@ locals {
       s3_actions   = []
       s3_resources = []
     },
+    "cancel_course_date" = {
+      name             = "cancel-course-date"
+      file_name        = "cancelCourseDate.zip"
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn, module.participants_table.table_arn]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:Scan"]
+      tables = {
+        "COURSES_TABLE"      = module.courses_table.table_name
+        "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name
+        "OVERRIDES_TABLE"    = module.course_overrides_table.table_name
+        "SWAPS_TABLE"        = module.swaps_table.table_name
+        "PARTICIPANTS_TABLE" = module.participants_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
+      additional_policies = [
+        {
+          Effect   = "Allow"
+          Action   = ["ses:SendEmail"]
+          Resource = "*"
+        }
+      ]
+      environment = {
+        SES_SOURCE_EMAIL = var.ses_source_email
+      }
+    },
     "delete_course" = {
       name             = "delete-course"
       file_name        = "deleteCourse.zip"
@@ -404,6 +429,7 @@ locals {
     "GET /courses"                               = "get_courses"
     "POST /courses"                              = "create_course"
     "PUT /courses/{courseId}"                    = "update_course"
+    "POST /courses/{courseId}/dates/{date}/cancel" = "cancel_course_date"
     "DELETE /courses/{courseId}"                 = "delete_course"
     "GET /participants"                          = "get_participants"
     "POST /participants"                         = "create_participants"
@@ -437,6 +463,7 @@ module "yogaswap_api" {
     "POST /participants/{userId}/password-reset",
     "POST /courses",
     "PUT /courses/{courseId}",
+    "POST /courses/{courseId}/dates/{date}/cancel",
     "DELETE /courses/{courseId}",
     "GET /tenant-context",
   ]

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -167,7 +167,7 @@ locals {
       name             = "cancel-course-date"
       file_name        = "cancelCourseDate.zip"
       table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn, module.participants_table.table_arn]
-      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:Scan"]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:Scan", "dynamodb:Query"]
       tables = {
         "COURSES_TABLE"      = module.courses_table.table_name
         "MEMBERSHIPS_TABLE"  = module.memberships_table.table_name

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -185,7 +185,8 @@ locals {
         }
       ]
       environment = {
-        SES_SOURCE_EMAIL = var.ses_source_email
+        SES_SOURCE_EMAIL         = var.ses_source_email
+        STUDIO_NOTIFICATION_EMAILS = var.studio_notification_emails
       }
     },
     "delete_course" = {

--- a/projects/yogaswap/variables.tf
+++ b/projects/yogaswap/variables.tf
@@ -17,6 +17,12 @@ variable "ses_source_email" {
   default     = "yogaswap@example.com"
 }
 
+variable "studio_notification_emails" {
+  description = "Comma-separated Empfänger für Studio-Benachrichtigungen (z. B. Terminabsagen)"
+  type        = string
+  default     = ""
+}
+
 variable "cloudfront_aliases" {
   description = "CloudFront Alternate Domain Names (CNAMEs), z.B. [\"app.yogaswap.de\"]"
   type        = list(string)


### PR DESCRIPTION
## Summary
- härtet den Absage-Flow für aktive Kurstermine in `cancelCourseDate` (robuste Rollback-Semantik, leeres Override sicherstellen, differenzierte Empfänger- und Fehlerbehandlung mit `operationWarnings`)
- verbessert den Frontend-Dialog für Terminabsagen (`CourseDatesDialog`) mit korrekten Impact-Zählern, granularen Rollback-Optionen und i18n-fähigen Warnhinweisen bei Teil-Erfolg
- behebt Datenkonsistenz-Probleme bei gemischter Groß-/Kleinschreibung (`Nia`/`nia`) in `processPromotions` und lädt für Kursmanagement-Ansichten vollständige Swap-Daten in `CourseList`

## Test plan
- [x] `npm run test --prefix app -- CourseDatesDialog.test.tsx CourseList.test.tsx`
- [x] `npm test --prefix backend -- processPromotions/index.test.ts`
- [x] Lint auf geänderten Dateien ohne neue Fehler
- [ ] manuelle AWS/E2E-Validierung für 2-3 Absage-Szenarien (CloudWatch + Studio-Mail)

Made with [Cursor](https://cursor.com)