### PR TITLE
#148 Bugfix: Teilnehmer-Sync in zukünftige Overrides bei aktivem Kurs

### DIFF
--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -409,4 +409,67 @@ describe("updateCourse Lambda", () => {
     );
     expect(JSON.parse(result.body).status).toBe("inactive");
   });
+
+  test("syncs added participants into relevant future overrides for active courses", async () => {
+    const futureDateIso = "2099-01-06";
+    const pastDateIso = "2020-01-01";
+
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          participants: { L: [{ S: "luna" }] },
+          time: { S: "18:00" },
+          seriesStartDate: { S: "2099-01-01" },
+          seriesEndDate: { S: "2099-12-31" },
+          visibleFrom: { S: "2099-01-01" },
+          visibleUntil: { S: "2099-12-31" },
+        },
+      })
+      .mockResolvedValueOnce({}) // course update
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            courseId_date: { S: `1_${futureDateIso}` },
+            courseId: { S: "1" },
+            date: { S: futureDateIso },
+            participants: { L: [{ S: "luna" }] },
+            swapped: { L: [] },
+            waitlist: { L: [] },
+          },
+          {
+            tenantId: { S: "default-tenant" },
+            courseId_date: { S: `1_${pastDateIso}` },
+            courseId: { S: "1" },
+            date: { S: pastDateIso },
+            participants: { L: [{ S: "luna" }] },
+            swapped: { L: [] },
+            waitlist: { L: [] },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({}); // future override update
+
+    const result = await handler(
+      makeEvent({
+        participants: ["luna", "maya"],
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(QueryCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "test-overrides",
+      }),
+    );
+
+    const overrideWrites = (PutItemCommand as unknown as jest.Mock).mock.calls
+      .map((call) => call[0])
+      .filter((input) => input?.TableName === "test-overrides");
+    expect(overrideWrites).toHaveLength(1);
+    expect(overrideWrites[0].Item.courseId_date.S).toBe(`1_${futureDateIso}`);
+    expect(overrideWrites[0].Item.participants.L).toEqual([{ S: "luna" }, { S: "maya" }]);
+  });
 });

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -17,6 +17,7 @@ const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 const ROLLING_EXCLUDE_LOCK_WEEKS = 5;
 const MIN_ROLLING_HORIZON_WEEKS = ROLLING_EXCLUDE_LOCK_WEEKS;
+const OVERRIDE_SYNC_TIME_BUFFER_MINUTES = 30;
 
 type UpdateCourseBody = {
   name?: string;
@@ -75,6 +76,18 @@ function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
   if (Number.isNaN(date.getTime())) return false;
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   return date >= startOfToday;
+}
+
+function isCourseInFutureWithBuffer(courseDate: string, courseTime: string, now: Date): boolean {
+  try {
+    const [year, month, day] = courseDate.split("-").map(Number);
+    const [hours, minutes] = courseTime.split(":").map(Number);
+    const courseStart = new Date(year, month - 1, day, hours, minutes);
+    const bufferTime = new Date(now.getTime() + OVERRIDE_SYNC_TIME_BUFFER_MINUTES * 60 * 1000);
+    return courseStart >= bufferTime;
+  } catch {
+    return false;
+  }
 }
 
 function toIsoDateOnlyLocal(date: Date): string {
@@ -569,6 +582,53 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         Item: updateItem,
       }),
     );
+
+    if (participants && effectiveStatus === "active") {
+      const previousParticipants =
+        item.participants?.L?.map((entry) => entry.S ?? "").filter((entry) => entry.length > 0) ?? [];
+      const previousParticipantsSet = new Set(previousParticipants.map((entry) => entry.toLowerCase()));
+      const addedParticipants = participants.filter(
+        (entry) => !previousParticipantsSet.has(entry.toLowerCase()),
+      );
+      if (addedParticipants.length > 0) {
+        const overridesResp = await client.send(
+          new QueryCommand({
+            TableName: overridesTable,
+            KeyConditionExpression:
+              "tenantId = :tenantId AND begins_with(courseId_date, :coursePrefix)",
+            ExpressionAttributeValues: {
+              ":tenantId": { S: tenantId },
+              ":coursePrefix": { S: `${courseId}_` },
+            },
+          }),
+        );
+        const now = new Date();
+        for (const overrideItem of overridesResp.Items ?? []) {
+          const overrideDate = overrideItem.date?.S;
+          if (!overrideDate) continue;
+          if (!isCourseInFutureWithBuffer(overrideDate, nextTime, now)) continue;
+          const currentOverrideParticipants =
+            overrideItem.participants?.L?.map((entry) => entry.S ?? "").filter((entry) => entry.length > 0) ?? [];
+          const currentOverrideSet = new Set(currentOverrideParticipants.map((entry) => entry.toLowerCase()));
+          const participantsToAdd = addedParticipants.filter(
+            (entry) => !currentOverrideSet.has(entry.toLowerCase()),
+          );
+          if (participantsToAdd.length === 0) continue;
+          await client.send(
+            new PutItemCommand({
+              TableName: overridesTable,
+              Item: {
+                ...overrideItem,
+                participants: {
+                  L: [...currentOverrideParticipants, ...participantsToAdd].map((entry) => ({ S: entry })),
+                },
+                actorUserId: { S: actorUserId },
+              },
+            }),
+          );
+        }
+      }
+    }
 
     return {
       statusCode: 200,


### PR DESCRIPTION
## Summary
- behebt den Bug, dass beim Hinzufügen von Teilnehmern zu einem aktiven Kurs bestehende zukünftige Overrides nicht mitgezogen wurden
- synchronisiert nur neu hinzugefügte Teilnehmer in zeitlich relevante kommende Overrides
- lässt vergangene Overrides unverändert und verhindert Duplikate bei gemischter Schreibweise

## Test plan
- [x] `npm test --prefix backend -- updateCourse/index.test.ts`
- [x] manueller Smoke-Test im UI (Hinzufügen zu aktivem Kurs, Override geprüft)

Made with [Cursor](https://cursor.com)