### PR TITLE
#157 Absage-Flow für aktive rolling_continuous Kurse freischalten

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -537,6 +537,11 @@ a:focus-visible {
   background: #e0f2fe;
 }
 
+.course-editor-calendar-cell.is-locked-date {
+  background: #fef3c7;
+  border-color: #f59e0b;
+}
+
 .course-editor-calendar-cell.is-range-start,
 .course-editor-calendar-cell.is-range-end {
   background: #bfdbfe;
@@ -587,6 +592,10 @@ a:focus-visible {
 
 .legend-dot.boundary {
   background: #60a5fa;
+}
+
+.legend-dot.lock {
+  background: #f59e0b;
 }
 
 .course-editor-comma-list {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -280,7 +280,11 @@ a:focus-visible {
 .modal-backdrop {
   position: fixed; inset: 0;
   background: rgba(0,0,0,0.4);
-  display: grid; place-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 16px 12px;
   z-index: 1000;
 }
 .modal {
@@ -289,6 +293,8 @@ a:focus-visible {
   box-shadow: 0 10px 30px rgba(0,0,0,0.2);
   text-align: left;
   position: relative;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
 }
 .modal:focus {
   outline: 3px solid #93c5fd;

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -470,6 +470,74 @@ describe("CourseDatesDialog", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("bleibt bei Fehlern beim Ausschluss-Speichern offen und zeigt Fehlermeldung", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
+    mockedUpdateCourse.mockRejectedValue(new Error("Speichern fehlgeschlagen"));
+    const onClose = vi.fn();
+    const onSaved = vi.fn().mockResolvedValue(undefined);
+    render(
+      <CourseDatesDialog
+        course={makeCourse({
+          status: "active",
+          planningMode: "rolling_continuous",
+          visibilityHorizonWeeks: 10,
+        })}
+        overrides={[]}
+        swaps={[]}
+        canManageCourses
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /nächster monat/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /absage datum 2026-02-10/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /ausschluss übernehmen/i }));
+    await vi.runAllTimersAsync();
+
+    expect(mockedUpdateCourse).toHaveBeenCalledTimes(1);
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(dialogQueries.getByText(/speichern fehlgeschlagen/i)).toBeInTheDocument();
+  });
+
+  it("wechselt den Primärbutton im aktiven rolling Modus zwischen Ausschluss und Absage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
+    render(
+      <CourseDatesDialog
+        course={makeCourse({
+          status: "active",
+          planningMode: "rolling_continuous",
+          visibilityHorizonWeeks: 10,
+        })}
+        overrides={[]}
+        swaps={[]}
+        canManageCourses
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+
+    fireEvent.click(dialogQueries.getByRole("button", { name: /nächster monat/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /absage datum 2026-02-10/i }));
+    expect(dialogQueries.getByRole("button", { name: /ausschluss übernehmen/i })).toBeInTheDocument();
+
+    fireEvent.click(dialogQueries.getByRole("button", { name: /vorheriger monat/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i }));
+    expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeInTheDocument();
+  });
+
   it("zeigt Hinweis statt Fehler bei teilweisem Erfolg mit operationWarnings", async () => {
     mockedCancelCourseDate.mockResolvedValue({
       success: true,

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -434,6 +434,42 @@ describe("CourseDatesDialog", () => {
     expect(dialogQueries.getByText(/hinzugefügt: 1, zurückgenommen: 0/i)).toBeInTheDocument();
   });
 
+  it("schließt im aktiven rolling Kurs nach Ausschluss-Übernahme den Dialog", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
+    mockedUpdateCourse.mockResolvedValue({});
+    const onClose = vi.fn();
+    const onSaved = vi.fn().mockResolvedValue(undefined);
+    render(
+      <CourseDatesDialog
+        course={makeCourse({
+          status: "active",
+          planningMode: "rolling_continuous",
+          visibilityHorizonWeeks: 10,
+        })}
+        overrides={[]}
+        swaps={[]}
+        canManageCourses
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /nächster monat/i }));
+    fireEvent.click(dialogQueries.getByRole("button", { name: /absage datum 2026-02-10/i }));
+
+    fireEvent.click(dialogQueries.getByRole("button", { name: /ausschluss übernehmen/i }));
+    await vi.runAllTimersAsync();
+
+    expect(mockedUpdateCourse).toHaveBeenCalledTimes(1);
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("zeigt Hinweis statt Fehler bei teilweisem Erfolg mit operationWarnings", async () => {
     mockedCancelCourseDate.mockResolvedValue({
       success: true,

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -203,7 +203,7 @@ describe("CourseDatesDialog", () => {
     });
   });
 
-  it("sperrt excludedDates im rolling Schutzfenster", async () => {
+  it("erlaubt im rolling Planungsmodus excludedDates auch im bisherigen Schutzfenster", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
     render(
@@ -225,13 +225,12 @@ describe("CourseDatesDialog", () => {
     const dialogQueries = within(dialog);
     fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für ausnahmetermin öffnen/i }));
 
-    const lockedCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-01-06/i });
-    expect(lockedCell).toBeDisabled();
-    expect(lockedCell).toHaveAttribute("title", expect.stringMatching(/nur absage möglich/i));
+    const nearCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-01-06/i });
+    expect(nearCell).not.toBeDisabled();
 
     fireEvent.click(dialogQueries.getByRole("button", { name: /nächster monat/i }));
-    const allowedCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-02-10/i });
-    expect(allowedCell).not.toBeDisabled();
+    const laterCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-02-10/i });
+    expect(laterCell).not.toBeDisabled();
   });
 
   it("erlaubt rolling excludedDates auch außerhalb des Sichtfensters", () => {
@@ -304,8 +303,8 @@ describe("CourseDatesDialog", () => {
     expect(dialogQueries.queryByRole("button", { name: /kalender für ausnahmetermin öffnen/i })).not.toBeInTheDocument();
     expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeDisabled();
     expect(dialogQueries.getByRole("button", { name: /^abbrechen$/i })).toBeInTheDocument();
-    expect(dialogQueries.getByText(/ausgewählter termin:/i)).toBeInTheDocument();
-    expect(dialogQueries.getByText(/keiner ausgewählt/i)).toBeInTheDocument();
+    expect(dialogQueries.getByText(/ausgewählte aktion:/i)).toBeInTheDocument();
+    expect(dialogQueries.getByText(/keine auswahl/i)).toBeInTheDocument();
 
     expect(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i })).toBeInTheDocument();
     await user.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
@@ -313,7 +312,7 @@ describe("CourseDatesDialog", () => {
     await user.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
     await user.click(dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i }));
     expect(dialogQueries.queryByRole("button", { name: /absage datum 2026-01-06/i })).not.toBeInTheDocument();
-    expect(dialogQueries.getByText(formatDateForDisplay("2026-01-06"))).toBeInTheDocument();
+    expect(dialogQueries.getByText(new RegExp(`Absage\\s+·\\s+${formatDateForDisplay("2026-01-06")}`, "i"))).toBeInTheDocument();
     expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeEnabled();
     await user.click(dialogQueries.getByRole("button", { name: /absage überprüfen/i }));
     expect(dialogQueries.getByRole("group", { name: /auswirkungsprüfung terminabsage/i })).toBeInTheDocument();
@@ -335,7 +334,7 @@ describe("CourseDatesDialog", () => {
     expect(mockedUpdateCourse).not.toHaveBeenCalled();
   });
 
-  it("erlaubt bei aktivem rolling Kurs weiterhin ExcludedDates außerhalb Schutzfenster", async () => {
+  it("zeigt bei aktivem rolling Kurs nur einen Kalender mit dynamischer Aktion", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
     render(
@@ -357,14 +356,82 @@ describe("CourseDatesDialog", () => {
     const dialog = dialogs[dialogs.length - 1];
     const dialogQueries = within(dialog);
 
-    // Save action remains available for rolling active courses.
-    expect(dialogQueries.getByRole("button", { name: /termine übernehmen/i })).toBeInTheDocument();
-    expect(dialogQueries.queryByRole("button", { name: /^schließen$/i })).not.toBeInTheDocument();
+    expect(dialogQueries.queryByRole("button", { name: /termine übernehmen/i })).not.toBeInTheDocument();
+    expect(dialogQueries.queryByRole("button", { name: /kalender für ausnahmetermin öffnen/i })).not.toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeDisabled();
+  });
 
-    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für ausnahmetermin öffnen/i }));
+  it("erlaubt im rolling Lockfenster weiterhin Absage für nicht ausgeschlossene Termine", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
+    render(
+      <CourseDatesDialog
+        course={makeCourse({
+          status: "active",
+          planningMode: "rolling_continuous",
+          visibilityHorizonWeeks: 10,
+          excludedDates: ["2026-01-13"],
+        })}
+        overrides={[]}
+        swaps={[]}
+        canManageCourses
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+
+    // Ausgeschlossener Termin ist weiterhin blockiert
+    const excludedCell = dialogQueries.getByRole("button", { name: /absage datum 2026-01-13/i });
+    expect(excludedCell).toBeDisabled();
+
+    // Passender Termin im Lockfenster bleibt für Absage auswählbar
+    const cancellableCell = dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i });
+    expect(cancellableCell).toBeEnabled();
+    expect(cancellableCell).toHaveAttribute("title", expect.stringMatching(/nur absage möglich|termin für absage auswählen/i));
+    fireEvent.click(cancellableCell);
+    expect(dialogQueries.getByText(new RegExp(`Absage\\s+·\\s+${formatDateForDisplay("2026-01-06")}`, "i"))).toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: /absage überprüfen/i })).toBeEnabled();
+  });
+
+  it("lässt im aktiven rolling Kurs außerhalb Lockfenster Ausschluss über denselben Kalender zu", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T09:00:00.000Z"));
+    render(
+      <CourseDatesDialog
+        course={makeCourse({
+          status: "active",
+          planningMode: "rolling_continuous",
+          visibilityHorizonWeeks: 10,
+        })}
+        overrides={[]}
+        swaps={[]}
+        canManageCourses
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog", { name: /kurstermine bearbeiten/i });
+    const dialog = dialogs[dialogs.length - 1];
+    const dialogQueries = within(dialog);
+    fireEvent.click(dialogQueries.getByRole("button", { name: /kalender für terminabsage öffnen/i }));
+
+    const nearLocked = dialogQueries.getByRole("button", { name: /absage datum 2026-01-06/i });
+    expect(nearLocked).not.toBeDisabled();
+    expect(nearLocked).toHaveAttribute("title", expect.stringMatching(/nur absage möglich/i));
+
     fireEvent.click(dialogQueries.getByRole("button", { name: /nächster monat/i }));
-    const allowedCell = dialogQueries.getByRole("button", { name: /ausnahme datum 2026-02-10/i });
-    expect(allowedCell).not.toBeDisabled();
+    const farAllowed = dialogQueries.getByRole("button", { name: /absage datum 2026-02-10/i });
+    expect(farAllowed).not.toBeDisabled();
+    expect(farAllowed).toHaveAttribute("title", expect.stringMatching(/termin ausschließen/i));
+    fireEvent.click(farAllowed);
+    expect(dialogQueries.getByText(/Ausschlüsse in Bearbeitung/i)).toBeInTheDocument();
+    expect(dialogQueries.getByText(/hinzugefügt: 1, zurückgenommen: 0/i)).toBeInTheDocument();
   });
 
   it("zeigt Hinweis statt Fehler bei teilweisem Erfolg mit operationWarnings", async () => {

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -670,6 +670,7 @@ export default function CourseDatesDialog({
       initialExcludedDatesRef.current = [...datesState.excludedDates];
       setActiveCalendarAction(null);
       await onSaved();
+      onClose();
     } catch (err) {
       console.error("Failed to update course dates configuration", err);
       setFormError(err instanceof Error ? err.message : "Terminkonfiguration konnte nicht gespeichert werden.");

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -34,6 +34,10 @@ type CourseDatesDialogProps = {
   onSaved: () => Promise<void> | void;
 };
 
+type ActiveCalendarAction =
+  | { type: "cancel"; isoDate: string }
+  | { type: "exclude"; isoDate: string };
+
 const FOCUSABLE_SELECTOR = [
   "button:not([disabled])",
   "input:not([disabled])",
@@ -65,6 +69,8 @@ function isIsoDateInFuture(isoDate: string): boolean {
   return isoDate > today;
 }
 
+const ROLLING_MANAGEMENT_PREVIEW_WEEKS = 156;
+
 export default function CourseDatesDialog({
   course,
   overrides,
@@ -78,10 +84,12 @@ export default function CourseDatesDialog({
   const [formError, setFormError] = useState<string | null>(null);
   const [formNotices, setFormNotices] = useState<string[]>([]);
   const [selectedCancellationDate, setSelectedCancellationDate] = useState<string | null>(null);
+  const [activeCalendarAction, setActiveCalendarAction] = useState<ActiveCalendarAction | null>(null);
   const [impactDialogOpen, setImpactDialogOpen] = useState(false);
   const [rollbackSuccessfulSwaps, setRollbackSuccessfulSwaps] = useState(false);
   const [rollbackPendingWaitlistSwaps, setRollbackPendingWaitlistSwaps] = useState(true);
   const modalRef = useRef<HTMLDivElement | null>(null);
+  const initialExcludedDatesRef = useRef<string[]>([]);
 
   useEffect(() => {
     if (!course) {
@@ -91,6 +99,7 @@ export default function CourseDatesDialog({
       return;
     }
     const nextState = createDatesState(course);
+    initialExcludedDatesRef.current = [...nextState.excludedDates];
     if (course.status === "active" && nextState.planningMode === "bounded_series") {
       nextState.rangeDatePickerOpen = true;
     }
@@ -98,6 +107,7 @@ export default function CourseDatesDialog({
     setFormError(null);
     setFormNotices([]);
     setSelectedCancellationDate(null);
+    setActiveCalendarAction(null);
     setImpactDialogOpen(false);
     setRollbackSuccessfulSwaps(false);
     setRollbackPendingWaitlistSwaps(true);
@@ -155,9 +165,11 @@ export default function CourseDatesDialog({
     !!datesState &&
     Number.isInteger(datesState.visibilityHorizonWeeks) &&
     datesState.visibilityHorizonWeeks >= DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS;
+  const isActiveCancellationMode = course?.status === "active";
+  const isRollingActiveMode = isActiveCancellationMode && datesState?.planningMode === "rolling_continuous";
   const isActiveReadOnly =
-    course?.status === "active" && datesState?.planningMode === "bounded_series";
-  const isActiveCancellationMode = isActiveReadOnly;
+    isActiveCancellationMode && datesState?.planningMode === "bounded_series";
+  const showExcludedDatesEditor = !isActiveCancellationMode;
 
   const canSaveDatesConfig =
     canManageCourses &&
@@ -171,13 +183,43 @@ export default function CourseDatesDialog({
 
   const datesPreview = useMemo(() => {
     if (!datesState) return [];
+    if (isRollingActiveMode) {
+      return generatePreviewDates({
+        ...datesState,
+        visibilityHorizonWeeks: ROLLING_MANAGEMENT_PREVIEW_WEEKS,
+      });
+    }
     return generatePreviewDates(datesState);
-  }, [datesState]);
+  }, [datesState, isRollingActiveMode]);
 
-  const fullSeriesDatesForActive = useMemo(() => {
-    if (!datesState || datesState.planningMode !== "bounded_series") return [];
+  const fullPlannedDatesForActiveCancellation = useMemo(() => {
+    if (!datesState || !isActiveCancellationMode) return [];
+    if (isRollingActiveMode) {
+      return generatePreviewDates({
+        ...datesState,
+        excludedDates: [],
+        visibilityHorizonWeeks: ROLLING_MANAGEMENT_PREVIEW_WEEKS,
+      });
+    }
     return generatePreviewDates({ ...datesState, excludedDates: [] });
-  }, [datesState]);
+  }, [datesState, isActiveCancellationMode, isRollingActiveMode]);
+
+  const activePreviewDates = useMemo(() => {
+    if (!datesState || !isActiveCancellationMode) return [];
+    return generatePreviewDates(datesState);
+  }, [datesState, isActiveCancellationMode]);
+  const rollingExcludeDraftSummary = useMemo(() => {
+    if (!datesState || !isRollingActiveMode) return null;
+    const initialExcludedSet = new Set(initialExcludedDatesRef.current);
+    const currentExcludedSet = new Set(datesState.excludedDates);
+    const addedDates = datesState.excludedDates.filter((entry) => !initialExcludedSet.has(entry));
+    const removedDates = initialExcludedDatesRef.current.filter((entry) => !currentExcludedSet.has(entry));
+    return {
+      addedDates,
+      removedDates,
+      hasChanges: addedDates.length > 0 || removedDates.length > 0,
+    };
+  }, [datesState, isRollingActiveMode]);
 
   const displayLocale =
     typeof navigator !== "undefined" && typeof navigator.language === "string" && navigator.language
@@ -195,31 +237,35 @@ export default function CourseDatesDialog({
     };
   }, [datesState]);
 
-  const rangeCalendarCells = useMemo(() => {
-    if (!datesState || !effectiveRange) return [];
-    return buildSeriesCalendarCells(
-      datesState.rangeCalendarMonth,
-      datesState.weekday,
-      effectiveRange.start,
-      effectiveRange.end,
-      datesState.excludedDates,
-    );
-  }, [datesState, effectiveRange]);
-
-  const rangeCalendarMonthLabel = useMemo(() => {
-    if (!datesState) return "";
-    return formatMonthLabel(datesState.rangeCalendarMonth, displayLocale);
-  }, [datesState, displayLocale]);
-
   const rollingExcludeLockRange = useMemo(() => {
-    if (!datesState || datesState.planningMode !== "rolling_continuous") return null;
+    if (!datesState || datesState.planningMode !== "rolling_continuous" || !isActiveCancellationMode) return null;
     return getRollingExcludeLockRangeIso(DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS);
-  }, [datesState]);
+  }, [datesState, isActiveCancellationMode]);
 
   const rollingExcludeSelectionRange = useMemo(() => {
     if (!datesState || datesState.planningMode !== "rolling_continuous") return null;
     return getRollingExcludeSelectionRangeIso();
   }, [datesState]);
+
+  const rangeCalendarCells = useMemo(() => {
+    if (!datesState || !effectiveRange) return [];
+    const calendarRange =
+      isRollingActiveMode && datesState.planningMode === "rolling_continuous" && rollingExcludeSelectionRange
+        ? rollingExcludeSelectionRange
+        : effectiveRange;
+    return buildSeriesCalendarCells(
+      datesState.rangeCalendarMonth,
+      datesState.weekday,
+      calendarRange.start,
+      calendarRange.end,
+      datesState.excludedDates,
+    );
+  }, [datesState, effectiveRange, isRollingActiveMode, rollingExcludeSelectionRange]);
+
+  const rangeCalendarMonthLabel = useMemo(() => {
+    if (!datesState) return "";
+    return formatMonthLabel(datesState.rangeCalendarMonth, displayLocale);
+  }, [datesState, displayLocale]);
 
   const excludedCalendarCells = useMemo(() => {
     if (!datesState) return [];
@@ -258,11 +304,6 @@ export default function CourseDatesDialog({
     () => datesPreview.map((entry) => formatIsoDateForDisplay(entry, displayLocale)),
     [datesPreview, displayLocale],
   );
-  const formattedFullSeriesDates = useMemo(
-    () => fullSeriesDatesForActive.map((entry) => formatIsoDateForDisplay(entry, displayLocale)),
-    [fullSeriesDatesForActive, displayLocale],
-  );
-
   const cancellationImpact = useMemo(() => {
     if (!course || !selectedCancellationDate) return null;
     const overrideForDate =
@@ -448,6 +489,7 @@ export default function CourseDatesDialog({
       const isSeriesWeekday =
         !!date && !!weekdayIndex && weekdayIndex >= 1 && weekdayIndex <= 7 && date.getUTCDay() === weekdayIndex % 7;
       const rollingLocked =
+        isActiveCancellationMode &&
         prev.planningMode === "rolling_continuous" &&
         !!rollingExcludeLockRange &&
         compareIsoDate(isoDate, rollingExcludeLockRange.start) >= 0 &&
@@ -469,21 +511,49 @@ export default function CourseDatesDialog({
 
   const toggleCancellationDate = (isoDate: string) => {
     if (saving) return;
-    if (!fullSeriesDatesForActive.includes(isoDate)) return;
-    if (datesState?.excludedDates.includes(isoDate)) return;
-    setSelectedCancellationDate((prev) => (prev === isoDate ? null : isoDate));
-    setDatesState((prev) =>
-      prev
-        ? {
-            ...prev,
-            rangeDatePickerOpen: false,
-          }
-        : prev,
-    );
+    if (!fullPlannedDatesForActiveCancellation.includes(isoDate)) return;
+    const rollingLocked =
+      datesState?.planningMode === "rolling_continuous" &&
+      !!rollingExcludeLockRange &&
+      compareIsoDate(isoDate, rollingExcludeLockRange.start) >= 0 &&
+      compareIsoDate(isoDate, rollingExcludeLockRange.end) <= 0;
+    const isExcluded = datesState?.excludedDates.includes(isoDate) ?? false;
+    if (rollingLocked || datesState?.planningMode === "bounded_series") {
+      if (isExcluded) return;
+      setSelectedCancellationDate((prev) => (prev === isoDate ? null : isoDate));
+      setActiveCalendarAction((prev) =>
+        prev?.type === "cancel" && prev.isoDate === isoDate ? null : { type: "cancel", isoDate },
+      );
+      setDatesState((prev) =>
+        prev
+          ? {
+              ...prev,
+              rangeDatePickerOpen: false,
+            }
+          : prev,
+      );
+    } else {
+      const currentState = datesState;
+      if (!currentState) return;
+      setSelectedCancellationDate(null);
+      const nextExcludedDates = isExcluded
+        ? currentState.excludedDates.filter((entry) => entry !== isoDate)
+        : dedupeAndSortDates([...currentState.excludedDates, isoDate]);
+      setDatesState((prev) =>
+        prev
+          ? {
+              ...prev,
+              excludedDates: nextExcludedDates,
+            }
+          : prev,
+      );
+      setActiveCalendarAction({ type: "exclude", isoDate });
+    }
     setFormError(null);
   };
 
   const openImpactDialog = () => {
+    if (activeCalendarAction?.type !== "cancel") return;
     if (!selectedCancellationDate || !cancellationImpact) return;
     setImpactDialogOpen(true);
   };
@@ -579,6 +649,35 @@ export default function CourseDatesDialog({
 
   if (!course || !datesState) return null;
 
+  const handleActivePrimaryAction = async () => {
+    if (!activeCalendarAction) return;
+    if (activeCalendarAction.type === "cancel") {
+      openImpactDialog();
+      return;
+    }
+    if (!datesState || !canManageCourses) return;
+    setSaving(true);
+    setFormError(null);
+    setFormNotices([]);
+    try {
+      await updateCourse(datesState.courseId, {
+        planningMode: "rolling_continuous",
+        visibilityMode: "rolling_horizon",
+        visibilityHorizonWeeks: datesState.visibilityHorizonWeeks,
+        excludedDates: datesState.excludedDates,
+        includedDates: [],
+      });
+      initialExcludedDatesRef.current = [...datesState.excludedDates];
+      setActiveCalendarAction(null);
+      await onSaved();
+    } catch (err) {
+      console.error("Failed to update course dates configuration", err);
+      setFormError(err instanceof Error ? err.message : "Terminkonfiguration konnte nicht gespeichert werden.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <CourseModalFrame
       ariaLabel="Kurstermine bearbeiten"
@@ -602,20 +701,52 @@ export default function CourseDatesDialog({
         <div className="dialog-stack">
           <div className="course-editor-subsection">
             <strong className="course-editor-list-title">
-              Vorschau Termine ({isActiveCancellationMode ? fullSeriesDatesForActive.length : datesPreview.length})
+              Vorschau Termine ({isActiveCancellationMode ? activePreviewDates.length : datesPreview.length})
             </strong>
-            {(isActiveCancellationMode ? fullSeriesDatesForActive.length : datesPreview.length) === 0 ? (
+            {(isActiveCancellationMode ? activePreviewDates.length : datesPreview.length) === 0 ? (
               <p className="course-editor-note">Keine Termine im gewählten Zeitraum.</p>
             ) : (
               <p className="course-editor-comma-list">
-                {(isActiveCancellationMode ? formattedFullSeriesDates : formattedPreviewDates).join(", ")}
+                {(isActiveCancellationMode
+                  ? activePreviewDates.map((entry) => formatIsoDateForDisplay(entry, displayLocale))
+                  : formattedPreviewDates).join(", ")}
               </p>
             )}
           </div>
 
+          {isRollingActiveMode && (
+            <div className="course-editor-subsection">
+              <strong className="course-editor-list-title">Sichtfenster</strong>
+              <p className="course-editor-note">
+                Von heute ({formattedEffectiveRangeStart}) bis {formattedEffectiveRangeEnd}
+              </p>
+              <div className="course-editor-inline-row">
+                <label htmlFor="rolling-horizon-weeks" className="course-editor-note">
+                  Sichtbarkeit in Wochen
+                </label>
+                <input
+                  id="rolling-horizon-weeks"
+                  type="number"
+                  min={DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS}
+                  step={1}
+                  value={datesState.visibilityHorizonWeeks}
+                  onChange={(event) => setRollingHorizonWeeks(event.target.value)}
+                  aria-label="Sichtfenster Wochen"
+                  disabled={saving}
+                  className="dialog-field"
+                  style={{ width: 96 }}
+                />
+              </div>
+            </div>
+          )}
+
           {isActiveCancellationMode ? (
             <div className="course-editor-subsection">
-              <strong className="course-editor-list-title">Terminkalender zur Übersicht und Absage</strong>
+              <strong className="course-editor-list-title">
+                {isRollingActiveMode
+                  ? "Terminkalender zur Übersicht, Absage und zum Ausschluss von Terminen"
+                  : "Terminkalender zur Übersicht und Absage"}
+              </strong>
               <p className="course-editor-note">
                 Es werden alle geplanten Serientermine angezeigt. Ausgeschlossene Termine sind markiert und nicht
                 auswählbar.
@@ -662,12 +793,21 @@ export default function CourseDatesDialog({
                   <div className="course-editor-calendar-grid">
                     {rangeCalendarCells.map((cell) => {
                       const isCancelledDate = datesState.excludedDates.includes(cell.isoDate);
-                      const isSelectable = cell.isSeriesDate && !isCancelledDate;
-                      const isSelected = selectedCancellationDate === cell.isoDate;
+                      const rollingLocked =
+                        datesState.planningMode === "rolling_continuous" &&
+                        !!rollingExcludeLockRange &&
+                        compareIsoDate(cell.isoDate, rollingExcludeLockRange.start) >= 0 &&
+                        compareIsoDate(cell.isoDate, rollingExcludeLockRange.end) <= 0;
+                      const isSelectable =
+                        cell.isSeriesDate &&
+                        (!isCancelledDate || (isRollingActiveMode && !rollingLocked));
+                      const isSelected = selectedCancellationDate === cell.isoDate || activeCalendarAction?.isoDate === cell.isoDate;
                       const cellClassName = [
                         "course-editor-calendar-cell",
                         cell.inCurrentMonth ? "" : "is-outside-month",
                         cell.isSeriesDate ? "is-series-date" : "",
+                        rollingLocked ? "is-locked-date" : "",
+                        isSelectable && !rollingLocked ? "is-in-range" : "",
                         isCancelledDate ? "is-excluded-date" : "",
                         isSelected ? "is-range-start" : "",
                       ]
@@ -689,9 +829,17 @@ export default function CourseDatesDialog({
                           disabled={!isSelectable || saving}
                           title={
                             isCancelledDate
-                              ? "Termin ist bereits ausgeschlossen"
+                              ? (
+                                  isRollingActiveMode && !rollingLocked
+                                    ? "Ausschluss rückgängig machen"
+                                    : "Termin ist bereits ausgeschlossen oder abgesagt"
+                                )
                               : isSelectable
-                                ? "Termin für Absage auswählen"
+                                ? (rollingLocked
+                                  ? "Nur Absage möglich"
+                                  : (datesState.planningMode === "rolling_continuous"
+                                    ? "Termin ausschließen"
+                                    : "Termin für Absage auswählen"))
                                 : "Nur Serientermine auswählbar"
                           }
                         >
@@ -702,17 +850,21 @@ export default function CourseDatesDialog({
                   </div>
                   <div className="course-editor-calendar-legend">
                     <span><em className="legend-dot series" /> geplanter Termin</span>
+                    <span><em className="legend-dot range" /> ausschließbar</span>
+                    {isRollingActiveMode && <span><em className="legend-dot lock" /> nur Absage (gesperrt für Ausschluss)</span>}
                     <span><em className="legend-dot excluded" /> ausgeschlossen</span>
                     <span><em className="legend-dot boundary" /> ausgewählt</span>
                   </div>
                 </div>
               )}
               <p className="course-editor-note">
-                Ausgewählter Termin:{" "}
+                Ausgewählte Aktion:{" "}
                 <strong>
-                  {selectedCancellationDate
-                    ? formatIsoDateForDisplay(selectedCancellationDate, displayLocale)
-                    : "Keiner ausgewählt"}
+                  {activeCalendarAction?.type === "cancel"
+                    ? `Absage · ${formatIsoDateForDisplay(activeCalendarAction.isoDate, displayLocale)}`
+                    : isRollingActiveMode && rollingExcludeDraftSummary?.hasChanges
+                      ? `Ausschlüsse in Bearbeitung · hinzugefügt: ${rollingExcludeDraftSummary.addedDates.length}, zurückgenommen: ${rollingExcludeDraftSummary.removedDates.length}`
+                      : "Keine Auswahl"}
                 </strong>
               </p>
             </div>
@@ -839,7 +991,7 @@ export default function CourseDatesDialog({
             </div>
           )}
 
-          {!isActiveCancellationMode && (
+          {showExcludedDatesEditor && (
             <div className="course-editor-subsection">
             <strong className="course-editor-list-title">Ausgeschlossene Termin</strong>
             <div className="course-editor-inline-row">
@@ -855,7 +1007,9 @@ export default function CourseDatesDialog({
               </button>
               <span className="course-editor-note">
                 {datesState.planningMode === "rolling_continuous"
-                  ? `Ausnahmen sind langfristig planbar; innerhalb der nächsten ${DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS} Wochen nur Absage.`
+                  ? isRollingActiveMode
+                    ? `Innerhalb der nächsten ${DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS} Wochen nur Absage; danach auch Ausschließen möglich.`
+                    : "Im Planungsmodus können alle Serientermine als Ausnahme gesetzt werden."
                   : "Nur Serientermine im Zeitraum sind wählbar."}
               </span>
             </div>
@@ -949,7 +1103,7 @@ export default function CourseDatesDialog({
             </div>
           )}
 
-          {!isActiveCancellationMode && (
+          {showExcludedDatesEditor && (
             <div className="course-editor-subsection">
               {datesState.excludedDates.length === 0 ? (
                 <p className="course-editor-note">Keine ausgeschlossenen Termine.</p>
@@ -1031,10 +1185,19 @@ export default function CourseDatesDialog({
               <button
                 type="button"
                 className="btn-primary modal-action-btn"
-                onClick={openImpactDialog}
-                disabled={!selectedCancellationDate || saving || impactDialogOpen || !cancellationImpact}
+                onClick={handleActivePrimaryAction}
+                disabled={
+                  !activeCalendarAction ||
+                  saving ||
+                  impactDialogOpen ||
+                  (activeCalendarAction.type === "cancel" && !cancellationImpact)
+                }
               >
-                Absage überprüfen
+                {saving
+                  ? "Speichere..."
+                  : activeCalendarAction?.type === "exclude"
+                    ? "Ausschluss übernehmen"
+                    : "Absage überprüfen"}
               </button>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- aktiviert den Absage-Flow auch für aktive `rolling_continuous` Kurse im selben Kalender inklusive klarer Status-/Aktionslogik für Absage vs. Ausschluss
- erweitert den aktiven Rolling-Managementbereich (inkl. Klickbarkeit außerhalb des Mitgliedersichtfensters), entfernt Auto-Save beim Klick und speichert Ausschlussänderungen explizit per Primäraktion
- verbessert UX-Stabilität mit scrollbarem Modal, konsistenter Dialog-Schließlogik nach Ausschluss-Übernahme und zusätzlichen Regressionstests für Fehlerfall/Primärbutton-Verhalten

## Test plan
- [x] `npm --prefix app test -- CourseDatesDialog.test.tsx`
- [x] `npm --prefix app test -- CourseModalFrame.test.tsx CourseDatesDialog.test.tsx`
- [x] `ReadLints` für geänderte Frontend-Dateien ohne neue Fehler
- [ ] Manuell: aktiver rolling Kurs – mehrere Ausschlüsse markieren/zurücknehmen und einmalig übernehmen
- [ ] Manuell: aktiver rolling Kurs – Absage im Lockfenster auswählen und Impact-Dialog prüfen
- [ ] Manuell: Kalender geöffnet + kleiner Viewport → Dialog scrollbar, Action-Buttons erreichbar


Made with [Cursor](https://cursor.com)