### PR TITLE
#122 Phase 1: CourseUid Dual-Write, APIs und Backfill (#123 #124)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "seed:build": "npm run build && node dist/seed/index.js",
     "seed:tenants": "ts-node src/scripts/seed_tenants.ts",
     "backfill:participants": "ts-node src/scripts/backfill_participant_profiles.ts",
+    "backfill:course-uids": "ts-node src/scripts/backfill_course_uids.ts",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "jest",
     "lint": "eslint ."

--- a/backend/src/lambdas/createCourse/index.test.ts
+++ b/backend/src/lambdas/createCourse/index.test.ts
@@ -29,6 +29,8 @@ function makeEvent(body: unknown, headers?: Record<string, string>): APIGatewayP
 
 describe("createCourse Lambda", () => {
   const OLD_ENV = process.env;
+  const COURSE_UID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
   beforeEach(() => {
     jest.resetModules();
@@ -111,6 +113,7 @@ describe("createCourse Lambda", () => {
       expect.objectContaining({
         id: 5,
         courseId: "5",
+        courseUid: expect.stringMatching(COURSE_UID_REGEX),
         name: "Morgen Flow",
         weekday: "Mon",
         time: "08:30",
@@ -141,6 +144,7 @@ describe("createCourse Lambda", () => {
         Item: expect.objectContaining({
           tenantId: { S: "studio-a" },
           courseId: { S: "5" },
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           id: { N: "5" },
           status: { S: "draft" },
         }),

--- a/backend/src/lambdas/createCourse/index.ts
+++ b/backend/src/lambdas/createCourse/index.ts
@@ -3,6 +3,7 @@ import { GetItemCommand, PutItemCommand, QueryCommand } from "@aws-sdk/client-dy
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
 import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
+import { generateCourseUid } from "../shared/courseUid";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
@@ -196,6 +197,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }, 0);
     const nextId = maxId + 1;
     const nextCourseId = String(nextId);
+    const newCourseUid = generateCourseUid();
     const visibleDates = deriveVisibleDates({
       planningMode,
       visibilityMode,
@@ -231,6 +233,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const item: Record<string, any> = {
       tenantId: { S: tenantId },
       courseId: { S: nextCourseId },
+      courseUid: { S: newCourseUid },
       id: { N: String(nextId) },
       name: { S: name },
       weekday: { S: weekday },
@@ -269,6 +272,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       body: JSON.stringify({
         id: nextId,
         courseId: nextCourseId,
+        courseUid: newCourseUid,
         name,
         weekday,
         time,

--- a/backend/src/lambdas/createOverride/index.test.ts
+++ b/backend/src/lambdas/createOverride/index.test.ts
@@ -1,5 +1,5 @@
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { handler } from './index';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 
@@ -9,10 +9,14 @@ const dynamoMock = mockClient(DynamoDBClient);
 beforeEach(() => {
   dynamoMock.reset();
   process.env.OVERRIDES_TABLE = 'yogaswap-backend-demo-courseOverrides-table';
+  process.env.COURSES_TABLE = 'yogaswap-backend-demo-courses-table';
 });
 
 describe('createOverride Lambda', () => {
   it('should create a new override successfully', async () => {
+    dynamoMock.on(GetItemCommand).resolves({
+      Item: { courseUid: { S: 'course-uid-abc' } },
+    });
     dynamoMock.on(PutItemCommand).resolves({});
 
     const event: Partial<APIGatewayProxyEvent> = {
@@ -30,15 +34,16 @@ describe('createOverride Lambda', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ message: 'Override created' });
 
-    // Es wird genau ein PutItemCommand erwartet
-    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.commandCalls(GetItemCommand)).toHaveLength(1);
+    expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(1);
 
-    expect(dynamoMock.call(0).args[0].input).toMatchObject({
+    expect(dynamoMock.commandCalls(PutItemCommand)[0].args[0].input).toMatchObject({
       TableName: 'yogaswap-backend-demo-courseOverrides-table',
       Item: {
         tenantId: { S: 'default-tenant' },
         courseId_date: { S: '1_2025-10-01' },
         courseId: { S: '1' },
+        courseUid: { S: 'course-uid-abc' },
         date: { S: '2025-10-01' },
         participants: { L: [{ S: 'Luna' }] },
         swapped: { L: [] },
@@ -80,6 +85,9 @@ describe('createOverride Lambda', () => {
   });
 
   it('should handle DynamoDB errors gracefully', async () => {
+    dynamoMock.on(GetItemCommand).resolves({
+      Item: { courseUid: { S: 'course-uid-abc' } },
+    });
     dynamoMock.on(PutItemCommand).rejects(new Error('DynamoDB failure'));
 
     const event: Partial<APIGatewayProxyEvent> = {
@@ -96,6 +104,6 @@ describe('createOverride Lambda', () => {
 
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body)).toEqual({ error: 'Failed to create override' });
-    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(1);
   });
 });

--- a/backend/src/lambdas/createOverride/index.ts
+++ b/backend/src/lambdas/createOverride/index.ts
@@ -3,6 +3,7 @@ import { PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
+import { fetchCourseUidByLegacyCourseId } from '../shared/courseUid';
 
 const client = dynamoClient;
 
@@ -16,9 +17,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   });
   if (delegationErrorResponse) return delegationErrorResponse;
   const tableName = process.env.OVERRIDES_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
   const override = JSON.parse(event.body || '{}');
 
   try {
+    if (!coursesTable) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'COURSES_TABLE env var is not set' }) };
+    }
     if (!override.courseId || !override.date) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Missing courseId or date' }) };
     }
@@ -39,16 +44,20 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const courseId_date = `${override.courseId}_${override.date}`;
+    const legacyCourseId = override.courseId.toString();
+    const courseUid = await fetchCourseUidByLegacyCourseId(client, coursesTable, tenantId, legacyCourseId);
+
     const dynamoItem = {
       tenantId: { S: tenantId },
       courseId_date: { S: courseId_date },
-      courseId: { S: override.courseId.toString() },
+      courseId: { S: legacyCourseId },
       date: { S: override.date },
       participants: { L: participants.map((p: string) => ({ S: p })) },
       swapped: { L: swapped.map((s: string) => ({ S: s })) },
       waitlist: { L: waitlist.map((w: string) => ({ S: w })) },
       actorUserId: userId ? { S: userId } : { NULL: true },
       actingForUserId: actingForUserId ? { S: actingForUserId } : { NULL: true },
+      ...(courseUid ? { courseUid: { S: courseUid } } : {}),
     };
 
     await client.send(new PutItemCommand({ TableName: tableName, Item: dynamoItem }));

--- a/backend/src/lambdas/createSwap/index.test.ts
+++ b/backend/src/lambdas/createSwap/index.test.ts
@@ -6,6 +6,7 @@ jest.mock('@aws-sdk/client-dynamodb', () => {
   return {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     PutItemCommand: jest.fn((input) => input),
+    GetItemCommand: jest.fn((input) => input),
     mockSend,
   };
 });
@@ -17,7 +18,7 @@ describe('createSwap Lambda', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...OLD_ENV, SWAPS_TABLE: 'test-swaps' };
+    process.env = { ...OLD_ENV, SWAPS_TABLE: 'test-swaps', COURSES_TABLE: 'test-courses' };
     mockSend.mockReset();
   });
 
@@ -40,7 +41,10 @@ describe('createSwap Lambda', () => {
   });
 
   test('successfully creates a swap', async () => {
-    mockSend.mockResolvedValueOnce({});
+    mockSend
+      .mockResolvedValueOnce({ Item: { courseUid: { S: 'uid-from' } } })
+      .mockResolvedValueOnce({ Item: { courseUid: { S: 'uid-to' } } })
+      .mockResolvedValueOnce({});
     const event = baseEvent({
       user: 'Nia',
       fromCourseId: 'c1',
@@ -68,6 +72,8 @@ describe('createSwap Lambda', () => {
           tenantId_user: { S: 'default-tenant#Nia' },
           actorUserId: { NULL: true },
           actingForUserId: { NULL: true },
+          fromCourseUid: { S: 'uid-from' },
+          toCourseUid: { S: 'uid-to' },
         }),
       })
     );

--- a/backend/src/lambdas/createSwap/index.ts
+++ b/backend/src/lambdas/createSwap/index.ts
@@ -3,6 +3,7 @@ import { PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
+import { fetchCourseUidByLegacyCourseId } from '../shared/courseUid';
 
 const client = dynamoClient;
 
@@ -17,12 +18,26 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (delegationErrorResponse) return delegationErrorResponse;
 
   const tableName = process.env.SWAPS_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
 
   try {
+    if (!tableName) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'SWAPS_TABLE env var is not set' }) };
+    }
+    if (!coursesTable) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'COURSES_TABLE env var is not set' }) };
+    }
     const swap = event.body ? JSON.parse(event.body) : {};
     if (!swap.user || !swap.fromCourseId || !swap.fromDate || !swap.toCourseId || !swap.toDate || !swap.status) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Missing required fields' }) };
     }
+
+    const fromLegacyId = swap.fromCourseId.toString();
+    const toLegacyId = swap.toCourseId.toString();
+    const [fromCourseUid, toCourseUid] = await Promise.all([
+      fetchCourseUidByLegacyCourseId(client, coursesTable, tenantId, fromLegacyId),
+      fetchCourseUidByLegacyCourseId(client, coursesTable, tenantId, toLegacyId),
+    ]);
 
     const swapId = `${swap.fromDate}_${swap.fromCourseId}_${swap.toDate}_${swap.toCourseId}`;
     const user_swapId = `${swap.user}#${swapId}`;
@@ -32,9 +47,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       user_swapId: { S: user_swapId },
       user: { S: swap.user },
       swapId: { S: swapId },
-      fromCourseId: { S: swap.fromCourseId.toString() },
+      fromCourseId: { S: fromLegacyId },
       fromDate: { S: swap.fromDate },
-      toCourseId: { S: swap.toCourseId.toString() },
+      toCourseId: { S: toLegacyId },
       toDate: { S: swap.toDate },
       status: { S: swap.status },
       fromDate_fromCourseId_status: { S: `${swap.fromDate}_${swap.fromCourseId}_${swap.status}` },
@@ -42,6 +57,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       tenantId_user: { S: tenantId_user },
       actorUserId: userId ? { S: userId } : { NULL: true },
       actingForUserId: actingForUserId ? { S: actingForUserId } : { NULL: true },
+      ...(fromCourseUid ? { fromCourseUid: { S: fromCourseUid } } : {}),
+      ...(toCourseUid ? { toCourseUid: { S: toCourseUid } } : {}),
     };
 
     await client.send(new PutItemCommand({ TableName: tableName, Item: dynamoItem }));

--- a/backend/src/lambdas/getCourses/index.ts
+++ b/backend/src/lambdas/getCourses/index.ts
@@ -68,6 +68,7 @@ export const handler = async (
       return {
         id: Number(item.id?.N ?? item.courseId?.S ?? 0),
         courseId: item.courseId?.S,
+        ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
         name: item.name.S!,
         weekday: item.weekday.S!,
         time: item.time.S!,

--- a/backend/src/lambdas/getOverrides/index.ts
+++ b/backend/src/lambdas/getOverrides/index.ts
@@ -38,6 +38,7 @@ export const handler = async (
     const data = await client.send(command);
     let items: CourseDateOverride[] = (data.Items || []).map((item) => ({
       courseId: Number(item.courseId.S!),
+      ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
       date: item.date.S!,
       participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
       swapped: item.swapped.L ? item.swapped.L.map((s: any) => s.S) : [],

--- a/backend/src/lambdas/getSwaps/index.ts
+++ b/backend/src/lambdas/getSwaps/index.ts
@@ -81,8 +81,10 @@ export const handler = async (
     const items: Swap[] = (data.Items || []).map((item) => ({
       user: item.user.S!,
       fromCourseId: Number(item.fromCourseId?.S ?? item.fromCourseId?.N ?? 0),
+      ...(item.fromCourseUid?.S ? { fromCourseUid: item.fromCourseUid.S } : {}),
       fromDate: item.fromDate.S!,
       toCourseId: Number(item.toCourseId?.S ?? item.toCourseId?.N ?? 0),
+      ...(item.toCourseUid?.S ? { toCourseUid: item.toCourseUid.S } : {}),
       toDate: item.toDate.S!,
       status: item.status.S as Swap["status"],
     }));

--- a/backend/src/lambdas/getSwapsByStatus/index.ts
+++ b/backend/src/lambdas/getSwapsByStatus/index.ts
@@ -45,8 +45,10 @@ export const handler = async (
     const items: Swap[] = (data.Items || []).map((item) => ({
       user: item.user.S!,
       fromCourseId: Number(item.fromCourseId?.S ?? item.fromCourseId?.N ?? 0),
+      ...(item.fromCourseUid?.S ? { fromCourseUid: item.fromCourseUid.S } : {}),
       fromDate: item.fromDate.S!,
       toCourseId: Number(item.toCourseId?.S ?? item.toCourseId?.N ?? 0),
+      ...(item.toCourseUid?.S ? { toCourseUid: item.toCourseUid.S } : {}),
       toDate: item.toDate.S!,
       status: item.status.S as Swap["status"],
     }));

--- a/backend/src/lambdas/shared/courseUid.ts
+++ b/backend/src/lambdas/shared/courseUid.ts
@@ -1,0 +1,31 @@
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { randomUUID } from "node:crypto";
+
+/** Neue stabile technische Kurs-ID (UUID v4). */
+export function generateCourseUid(): string {
+  return randomUUID();
+}
+
+/**
+ * Liest `courseUid` aus dem Kurs-Datensatz (Legacy-Schlüssel: tenantId + courseId).
+ */
+export async function fetchCourseUidByLegacyCourseId(
+  client: DynamoDBClient,
+  coursesTable: string,
+  tenantId: string,
+  legacyCourseId: string,
+): Promise<string | undefined> {
+  const resp = await client.send(
+    new GetItemCommand({
+      TableName: coursesTable,
+      Key: {
+        tenantId: { S: tenantId },
+        courseId: { S: legacyCourseId },
+      },
+      ConsistentRead: true,
+    }),
+  );
+  const uid = resp.Item?.courseUid?.S?.trim();
+  return uid || undefined;
+}

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -38,6 +38,9 @@ function makeEvent(
   } as unknown) as APIGatewayProxyEvent;
 }
 
+const COURSE_UID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function baseCourseItem(status = "draft") {
   return {
     tenantId: { S: "default-tenant" },
@@ -107,6 +110,7 @@ describe("updateCourse Lambda", () => {
     expect(body).toEqual(
       expect.objectContaining({
         courseId: "1",
+        courseUid: expect.stringMatching(COURSE_UID_REGEX),
         name: "Morgenkurs",
         weekday: "Tue",
         time: "08:00",
@@ -118,6 +122,7 @@ describe("updateCourse Lambda", () => {
       expect.objectContaining({
         TableName: "test-courses",
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           participants: { L: [{ S: "luna" }] },
         }),
       }),
@@ -234,6 +239,7 @@ describe("updateCourse Lambda", () => {
     expect(PutItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           planningMode: { S: "rolling_continuous" },
           visibilityMode: { S: "rolling_horizon" },
           visibilityHorizonWeeks: { N: "10" },
@@ -307,6 +313,7 @@ describe("updateCourse Lambda", () => {
     expect(PutItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           participants: { L: [{ S: "alice" }, { S: "bob" }] },
         }),
       }),
@@ -331,6 +338,7 @@ describe("updateCourse Lambda", () => {
     expect(PutItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           excludedDates: { L: [{ S: "2026-02-02" }] },
           includedDates: { L: [{ S: "2026-02-04" }] },
         }),
@@ -377,6 +385,7 @@ describe("updateCourse Lambda", () => {
     expect(PutItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           excludedDates: { L: [{ S: farFutureIso }] },
         }),
       }),
@@ -403,6 +412,7 @@ describe("updateCourse Lambda", () => {
     expect(PutItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         Item: expect.objectContaining({
+          courseUid: { S: expect.stringMatching(COURSE_UID_REGEX) },
           status: { S: "inactive" },
         }),
       }),
@@ -470,6 +480,7 @@ describe("updateCourse Lambda", () => {
       .filter((input) => input?.TableName === "test-overrides");
     expect(overrideWrites).toHaveLength(1);
     expect(overrideWrites[0].Item.courseId_date.S).toBe(`1_${futureDateIso}`);
+    expect(overrideWrites[0].Item.courseUid.S).toMatch(COURSE_UID_REGEX);
     expect(overrideWrites[0].Item.participants.L).toEqual([{ S: "luna" }, { S: "maya" }]);
   });
 });

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -8,6 +8,7 @@ import {
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
 import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
+import { generateCourseUid } from "../shared/courseUid";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
@@ -548,9 +549,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       );
     }
 
+    const existingCourseUid = item.courseUid?.S?.trim();
+    const nextCourseUid = existingCourseUid || generateCourseUid();
+
     const updateItem: Record<string, any> = {
       tenantId: { S: tenantId },
       courseId: { S: courseId },
+      courseUid: { S: nextCourseUid },
       id: { N: String(Number.isFinite(nextId) ? nextId : 0) },
       name: { S: nextName },
       weekday: { S: nextWeekday },
@@ -619,6 +624,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
               TableName: overridesTable,
               Item: {
                 ...overrideItem,
+                courseUid: { S: nextCourseUid },
                 participants: {
                   L: [...currentOverrideParticipants, ...participantsToAdd].map((entry) => ({ S: entry })),
                 },
@@ -635,6 +641,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       body: JSON.stringify({
         id: Number.isFinite(nextId) ? nextId : 0,
         courseId,
+        courseUid: nextCourseUid,
         name: nextName,
         weekday: nextWeekday,
         time: nextTime,

--- a/backend/src/scripts/backfill_course_uids.ts
+++ b/backend/src/scripts/backfill_course_uids.ts
@@ -1,0 +1,197 @@
+/**
+ * Backfill für #124: Setzt `courseUid` auf Kursen und ergänzt Referenzen in Overrides/Swaps.
+ *
+ * Runbook:
+ * - Env: COURSES_TABLE, OVERRIDES_TABLE, SWAPS_TABLE (wie Deploy), AWS_REGION
+ * - Dry-Run: DRY_RUN=1 npm run backfill:course-uids
+ * - Live: npm run backfill:course-uids
+ *
+ * Idempotent: bestehende courseUid wird nicht überschrieben; Override/Swap nur wenn UID fehlt.
+ */
+import {
+  ScanCommand,
+  UpdateItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { dynamoClient } from "../lambdas/shared/dynamoClient";
+import { generateCourseUid } from "../lambdas/shared/courseUid";
+
+const client = dynamoClient;
+
+const COURSES_TABLE = process.env.COURSES_TABLE ?? "";
+const OVERRIDES_TABLE = process.env.OVERRIDES_TABLE ?? "";
+const SWAPS_TABLE = process.env.SWAPS_TABLE ?? "";
+const DRY_RUN = process.env.DRY_RUN === "1" || process.env.DRY_RUN === "true";
+
+async function scanAll(tableName: string): Promise<Record<string, AttributeValue>[]> {
+  const out: Record<string, AttributeValue>[] = [];
+  let lastKey: Record<string, AttributeValue> | undefined;
+  do {
+    const resp = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ExclusiveStartKey: lastKey,
+      }),
+    );
+    out.push(...(resp.Items ?? []));
+    lastKey = resp.LastEvaluatedKey;
+  } while (lastKey);
+  return out;
+}
+
+async function run(): Promise<void> {
+  if (!COURSES_TABLE || !OVERRIDES_TABLE || !SWAPS_TABLE) {
+    throw new Error("Set COURSES_TABLE, OVERRIDES_TABLE, SWAPS_TABLE");
+  }
+  console.log(
+    JSON.stringify({
+      dryRun: DRY_RUN,
+      courses: COURSES_TABLE,
+      overrides: OVERRIDES_TABLE,
+      swaps: SWAPS_TABLE,
+    }),
+  );
+
+  const courseUidByTenantAndLegacyId = new Map<string, string>();
+
+  const courseItems = await scanAll(COURSES_TABLE);
+  let coursesUpdated = 0;
+  for (const item of courseItems) {
+    const tenantId = item.tenantId?.S;
+    const legacyId = item.courseId?.S;
+    if (!tenantId || !legacyId) continue;
+    const existing = item.courseUid?.S?.trim();
+    const mapKey = `${tenantId}#${legacyId}`;
+    if (existing) {
+      courseUidByTenantAndLegacyId.set(mapKey, existing);
+      continue;
+    }
+    const uid = generateCourseUid();
+    courseUidByTenantAndLegacyId.set(mapKey, uid);
+    coursesUpdated += 1;
+    if (!DRY_RUN) {
+      await client.send(
+        new UpdateItemCommand({
+          TableName: COURSES_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            courseId: { S: legacyId },
+          },
+          UpdateExpression: "SET courseUid = :uid",
+          ExpressionAttributeValues: {
+            ":uid": { S: uid },
+          },
+        }),
+      );
+    }
+  }
+
+  const overrideItems = await scanAll(OVERRIDES_TABLE);
+  let overridesUpdated = 0;
+  for (const item of overrideItems) {
+    const tenantId = item.tenantId?.S;
+    const legacyCourseId = item.courseId?.S;
+    if (!tenantId || !legacyCourseId) continue;
+    if (item.courseUid?.S?.trim()) continue;
+    const uid = courseUidByTenantAndLegacyId.get(`${tenantId}#${legacyCourseId}`);
+    const cidDate = item.courseId_date?.S?.trim();
+    if (!cidDate) {
+      console.warn(
+        JSON.stringify({
+          warn: "override_missing_courseId_date",
+          tenantId,
+          legacyCourseId,
+        }),
+      );
+      continue;
+    }
+    if (!uid) {
+      console.warn(
+        JSON.stringify({
+          warn: "override_without_course_uid_mapping",
+          tenantId,
+          legacyCourseId,
+          courseId_date: cidDate,
+        }),
+      );
+      continue;
+    }
+    overridesUpdated += 1;
+    if (!DRY_RUN) {
+      await client.send(
+        new UpdateItemCommand({
+          TableName: OVERRIDES_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            courseId_date: { S: cidDate },
+          },
+          UpdateExpression: "SET courseUid = :uid",
+          ExpressionAttributeValues: {
+            ":uid": { S: uid },
+          },
+        }),
+      );
+    }
+  }
+
+  const swapItems = await scanAll(SWAPS_TABLE);
+  let swapsUpdated = 0;
+  for (const item of swapItems) {
+    const tenantId = item.tenantId?.S;
+    const fromId = item.fromCourseId?.S;
+    const toId = item.toCourseId?.S;
+    if (!tenantId || !fromId || !toId) continue;
+    const userSwapKey = item.user_swapId?.S?.trim();
+    if (!userSwapKey) {
+      continue;
+    }
+    const fromUid =
+      item.fromCourseUid?.S?.trim() ||
+      courseUidByTenantAndLegacyId.get(`${tenantId}#${fromId}`);
+    const toUid =
+      item.toCourseUid?.S?.trim() || courseUidByTenantAndLegacyId.get(`${tenantId}#${toId}`);
+    const needFrom = !item.fromCourseUid?.S?.trim() && !!fromUid;
+    const needTo = !item.toCourseUid?.S?.trim() && !!toUid;
+    if (!needFrom && !needTo) continue;
+    swapsUpdated += 1;
+    if (!DRY_RUN) {
+      const sets: string[] = [];
+      const values: Record<string, AttributeValue> = {};
+      if (needFrom && fromUid) {
+        sets.push("fromCourseUid = :fromUid");
+        values[":fromUid"] = { S: fromUid };
+      }
+      if (needTo && toUid) {
+        sets.push("toCourseUid = :toUid");
+        values[":toUid"] = { S: toUid };
+      }
+      if (sets.length === 0) continue;
+      await client.send(
+        new UpdateItemCommand({
+          TableName: SWAPS_TABLE,
+          Key: {
+            tenantId: { S: tenantId },
+            user_swapId: { S: userSwapKey },
+          },
+          UpdateExpression: `SET ${sets.join(", ")}`,
+          ExpressionAttributeValues: values,
+        }),
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      done: true,
+      coursesUpdated,
+      overridesUpdated,
+      swapsUpdated,
+      dryRun: DRY_RUN,
+    }),
+  );
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/seed/index.ts
+++ b/backend/src/seed/index.ts
@@ -19,6 +19,7 @@ import { DynamoDBClient, PutItemCommand, DescribeTableCommand, ResourceNotFoundE
 import { swaps } from "./swaps";
 import { courseDateOverrides } from "./overrides";
 import { courses } from "./courses";
+import { generateCourseUid } from "../lambdas/shared/courseUid";
 
 import path from "node:path";
 import fs from "node:fs";
@@ -261,6 +262,7 @@ async function seedCourses(tableName: string, items: any[]) {
     const dynamoItem: Record<string, any> = {
       tenantId: { S: DEFAULT_TENANT_ID },
       courseId: { S: courseId },
+      courseUid: { S: generateCourseUid() },
       id: { N: item.id.toString() },
       name: { S: item.name },
       weekday: { S: item.weekday },

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -39,10 +39,11 @@ locals {
     "create_swap" = {
       name             = "create-swap"
       file_name        = "createSwap.zip"
-      table_arns       = [module.swaps_table.table_arn]
-      dynamodb_actions = ["dynamodb:PutItem"]
+      table_arns       = [module.swaps_table.table_arn, module.courses_table.table_arn]
+      dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem"]
       tables = {
-        "SWAPS_TABLE" = module.swaps_table.table_name
+        "SWAPS_TABLE"   = module.swaps_table.table_name
+        "COURSES_TABLE" = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -83,10 +84,11 @@ locals {
     "create_override" = {
       name             = "create-override"
       file_name        = "createOverride.zip"
-      table_arns       = [module.course_overrides_table.table_arn]
-      dynamodb_actions = ["dynamodb:PutItem"]
+      table_arns       = [module.course_overrides_table.table_arn, module.courses_table.table_arn]
+      dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem"]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -10,6 +10,8 @@ export type CourseDateOverride = {
   // Zugehöriger Tenant (wird bei Multi-Tenancy Pflicht, aktuell optional für Migration)
   tenantId?: string;
   courseId: number;
+  /** Stabile technische Kurs-ID (UUID), Dual-Write mit {@link Course.courseUid}. */
+  courseUid?: string;
   date: string; // ISO-String
   participants: string[];
   swapped?: string[]; // aktive Tausch-Teilnehmer
@@ -26,8 +28,12 @@ export type Swap = {
   tenantId?: string;
   user: string;        // der Teilnehmer
   fromCourseId: number;
+  /** Stabile Kurs-ID am Ursprung (Dual-Write). */
+  fromCourseUid?: string;
   fromDate: string;    // ISO des Ursprungstermins
   toCourseId: number;
+  /** Stabile Kurs-ID am Ziel (Dual-Write). */
+  toCourseUid?: string;
   toDate: string;      // ISO des Zieltermins
   status: SwapStatus;
 };
@@ -39,6 +45,11 @@ export type CourseVisibilityMode = "fixed_window" | "rolling_horizon";
 export type Course = {
   // Tenant, zu dem der Kurs gehört
   tenantId?: string;
+  /**
+   * Stabile technische Kurs-ID (UUID). Nach Abschluss der Migration (#122) Primärreferenz für APIs;
+   * `id` / `courseId` bleiben für Legacy und Anzeige nutzbar.
+   */
+  courseUid?: string;
   id: number;
   name: string;
   weekday: string; // z.B. "Mon", "Tue", ...


### PR DESCRIPTION
## Summary
- **`courseUid`** (UUID) als stabile technische ID: Dual-Write bei Kurs anlegen/aktualisieren; fehlende UIDs werden beim Update nachgezogen.
- **Overrides / Swaps**: optional `courseUid` / `fromCourseUid` / `toCourseUid` beim Schreiben (Lookup über Courses-Tabelle); GET-Endpoints liefern die Felder mit.
- **Terraform**: `create_override` und `create_swap` erhalten `COURSES_TABLE` und DynamoDB `GetItem`.
- **Backfill-Skript**: `npm --prefix backend run backfill:course-uids` (Dry-Run mit `DRY_RUN=1`).
- **Seed**: neue Kurse erhalten `courseUid`.

## Deployment / Ops (bereits durchgeführt bei dir)
- Terraform apply
- Backfill Live-Lauf auf Testdaten

## Ticket-Zuordnung
Schließt **#123** und **#124**. Episch **#122** bleibt für Cutover/Cleanup (**#125**) offen → siehe unten.

Closes #123
Closes #124

Refs #122

## Follow-up (#125)
- Frontend: `courseUid` aus API mappen (`getCourses` & Co.)
- API-Pfade / Client langfristig auf UID ausrichten, Legacy-Fallbacks aufräumen

## Test plan
- [x] `npm --prefix backend test`
- [x] `npm --prefix backend run build`
- [x] `npm --prefix app test`
- [x] Nach Deploy: Backfill + Smoke (Kurs ändern, Swaps, Overrides)


Made with [Cursor](https://cursor.com)