### PR TITLE
#125 Course UID API path cutover (GSI + frontend)

### DIFF
--- a/app/src/api/courses.test.ts
+++ b/app/src/api/courses.test.ts
@@ -17,6 +17,7 @@ describe("getCourses", () => {
       data: [
         {
           id: 1,
+          courseUid: "550e8400-e29b-41d4-a716-446655440000",
           name: "Yoga Basics",
           weekday: "Mon",
           time: "18:30",
@@ -38,6 +39,7 @@ describe("getCourses", () => {
     expect(result[0]).toEqual(
       expect.objectContaining({
         id: 1,
+        courseUid: "550e8400-e29b-41d4-a716-446655440000",
         name: "Yoga Basics",
         weekday: "Mon",
         time: "18:30",
@@ -76,6 +78,7 @@ describe("getCourses", () => {
     vi.mocked(axios.post).mockResolvedValueOnce({
       data: {
         id: 3,
+        courseUid: "660e8400-e29b-41d4-a716-446655440001",
         name: "Core",
         weekday: "Wed",
         time: "19:00",
@@ -104,6 +107,7 @@ describe("getCourses", () => {
     expect(result).toEqual(
       expect.objectContaining({
         id: 3,
+        courseUid: "660e8400-e29b-41d4-a716-446655440001",
         name: "Core",
         weekday: "Wed",
         time: "19:00",
@@ -119,6 +123,7 @@ describe("getCourses", () => {
     vi.mocked(axios.put).mockResolvedValueOnce({
       data: {
         id: 1,
+        courseUid: "770e8400-e29b-41d4-a716-446655440002",
         name: "Yoga Flow",
         weekday: "Tue",
         time: "18:00",
@@ -137,6 +142,7 @@ describe("getCourses", () => {
     });
     expect(result.status).toBe("active");
     expect(result.capacity).toBe(16);
+    expect(result.courseUid).toBe("770e8400-e29b-41d4-a716-446655440002");
   });
 
   it("löscht Kurs", async () => {

--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -7,6 +7,35 @@ type ApiCourse = Omit<Course, "participants" | "dates"> & {
   visibleDates?: string[];
 };
 
+function mapApiCourseToCourse(item: ApiCourse): Course {
+  const visibleDates = item.visibleDates ?? item.dates ?? [];
+  return {
+    id: item.id,
+    ...(item.courseUid?.trim() ? { courseUid: item.courseUid.trim() } : {}),
+    name: item.name,
+    weekday: item.weekday,
+    time: item.time,
+    capacity: item.capacity,
+    status: item.status ?? "active",
+    planningMode: item.planningMode,
+    visibilityMode: item.visibilityMode,
+    seriesStartDate: item.seriesStartDate,
+    seriesEndDate: item.seriesEndDate,
+    visibleFrom: item.visibleFrom,
+    visibleUntil: item.visibleUntil,
+    visibilityHorizonWeeks: item.visibilityHorizonWeeks,
+    excludedDates: item.excludedDates ?? [],
+    includedDates: item.includedDates ?? [],
+    visibleDates,
+    participants: item.participants ?? [],
+    dates: visibleDates,
+    ...(item.tenantId ? { tenantId: item.tenantId } : {}),
+    ...(item.instructors ? { instructors: item.instructors } : {}),
+    ...(item.studioId ? { studioId: item.studioId } : {}),
+    ...(item.roomId ? { roomId: item.roomId } : {}),
+  };
+}
+
 export type CreateCourseRequest = {
   name: string;
   weekday: string;
@@ -58,26 +87,7 @@ export type DeleteCourseResponse = {
 export async function getCourses(): Promise<Course[]> {
   try {
     const response = await axios.get<ApiCourse[]>("/courses");
-    return response.data.map((item) => ({
-      id: item.id,
-      name: item.name,
-      weekday: item.weekday,
-      time: item.time,
-      capacity: item.capacity,
-      status: item.status ?? "active",
-      planningMode: item.planningMode,
-      visibilityMode: item.visibilityMode,
-      seriesStartDate: item.seriesStartDate,
-      seriesEndDate: item.seriesEndDate,
-      visibleFrom: item.visibleFrom,
-      visibleUntil: item.visibleUntil,
-      visibilityHorizonWeeks: item.visibilityHorizonWeeks,
-      excludedDates: item.excludedDates ?? [],
-      includedDates: item.includedDates ?? [],
-      visibleDates: item.visibleDates ?? item.dates ?? [],
-      participants: item.participants ?? [],
-      dates: item.visibleDates ?? item.dates ?? [],
-    }));
+    return response.data.map(mapApiCourseToCourse);
   } catch (error) {
     console.error("Fehler beim Laden der Courses:", error);
     return [];
@@ -86,50 +96,12 @@ export async function getCourses(): Promise<Course[]> {
 
 export async function createCourse(request: CreateCourseRequest): Promise<Course> {
   const response = await axios.post<ApiCourse>("/courses", request);
-  return {
-    id: response.data.id,
-    name: response.data.name,
-    weekday: response.data.weekday,
-    time: response.data.time,
-    capacity: response.data.capacity,
-    status: response.data.status ?? "active",
-    planningMode: response.data.planningMode,
-    visibilityMode: response.data.visibilityMode,
-    seriesStartDate: response.data.seriesStartDate,
-    seriesEndDate: response.data.seriesEndDate,
-    visibleFrom: response.data.visibleFrom,
-    visibleUntil: response.data.visibleUntil,
-    visibilityHorizonWeeks: response.data.visibilityHorizonWeeks,
-    excludedDates: response.data.excludedDates ?? [],
-    includedDates: response.data.includedDates ?? [],
-    visibleDates: response.data.visibleDates ?? response.data.dates ?? [],
-    participants: response.data.participants ?? [],
-    dates: response.data.visibleDates ?? response.data.dates ?? [],
-  };
+  return mapApiCourseToCourse(response.data);
 }
 
 export async function updateCourse(courseId: number | string, request: UpdateCourseRequest): Promise<Course> {
   const response = await axios.put<ApiCourse>(`/courses/${encodeURIComponent(String(courseId))}`, request);
-  return {
-    id: response.data.id,
-    name: response.data.name,
-    weekday: response.data.weekday,
-    time: response.data.time,
-    capacity: response.data.capacity,
-    status: response.data.status ?? "active",
-    planningMode: response.data.planningMode,
-    visibilityMode: response.data.visibilityMode,
-    seriesStartDate: response.data.seriesStartDate,
-    seriesEndDate: response.data.seriesEndDate,
-    visibleFrom: response.data.visibleFrom,
-    visibleUntil: response.data.visibleUntil,
-    visibilityHorizonWeeks: response.data.visibilityHorizonWeeks,
-    excludedDates: response.data.excludedDates ?? [],
-    includedDates: response.data.includedDates ?? [],
-    visibleDates: response.data.visibleDates ?? response.data.dates ?? [],
-    participants: response.data.participants ?? [],
-    dates: response.data.visibleDates ?? response.data.dates ?? [],
-  };
+  return mapApiCourseToCourse(response.data);
 }
 
 export async function deleteCourse(courseId: number | string): Promise<DeleteCourseResponse> {

--- a/app/src/api/overrides.ts
+++ b/app/src/api/overrides.ts
@@ -14,13 +14,19 @@ export async function getOverrides(sinceDate?: string): Promise<CourseDateOverri
   }
 }
 
-export async function updateOverride(courseId: number, date: string, updates: Partial<CourseDateOverride>): Promise<void> {
+export async function updateOverride(
+  courseId: number | string,
+  date: string,
+  updates: Partial<CourseDateOverride>,
+): Promise<void> {
+  const pathCourse = encodeURIComponent(String(courseId));
+  const pathDate = encodeURIComponent(date);
   try {
     const headers = delegationHeaders();
     if (headers) {
-      await axios.put(`/course-overrides/${courseId}/${date}`, updates, { headers });
+      await axios.put(`/course-overrides/${pathCourse}/${pathDate}`, updates, { headers });
     } else {
-      await axios.put(`/course-overrides/${courseId}/${date}`, updates);
+      await axios.put(`/course-overrides/${pathCourse}/${pathDate}`, updates);
     }
     console.log('API Overrides Response (updates):', updates);
   } catch (error) {
@@ -28,13 +34,15 @@ export async function updateOverride(courseId: number, date: string, updates: Pa
   }
 }
 
-export async function deleteOverride(courseId: number, date: string): Promise<void> {
+export async function deleteOverride(courseId: number | string, date: string): Promise<void> {
+  const pathCourse = encodeURIComponent(String(courseId));
+  const pathDate = encodeURIComponent(date);
   try {
     const headers = delegationHeaders();
     if (headers) {
-      await axios.delete(`/course-overrides/${courseId}/${date}`, { headers });
+      await axios.delete(`/course-overrides/${pathCourse}/${pathDate}`, { headers });
     } else {
-      await axios.delete(`/course-overrides/${courseId}/${date}`);
+      await axios.delete(`/course-overrides/${pathCourse}/${pathDate}`);
     }
     console.log('API Overrides Response (delete):', { courseId, date });
   } catch (error) {

--- a/app/src/api/swaps.test.ts
+++ b/app/src/api/swaps.test.ts
@@ -51,6 +51,28 @@ describe("getSwaps", () => {
     expect(result[0].toCourseId).toBe(2);
   });
 
+  it("mappt fromCourseUid und toCourseUid aus der API", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [
+        {
+          user: "bob",
+          fromCourseId: "3",
+          fromCourseUid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          fromDate: "2025-07-01",
+          toCourseId: "4",
+          toCourseUid: "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj",
+          toDate: "2025-07-02",
+          status: "pending",
+        },
+      ],
+    });
+
+    const result = await getSwaps("bob");
+
+    expect(result[0].fromCourseUid).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    expect(result[0].toCourseUid).toBe("ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj");
+  });
+
   it("gibt leeres Array bei Fehler zurück", async () => {
     vi.mocked(axios.get).mockRejectedValueOnce(new Error("Network error"));
 

--- a/app/src/api/swaps.ts
+++ b/app/src/api/swaps.ts
@@ -2,10 +2,32 @@ import axios from "axios";
 import { CourseDateOverride, Swap } from "shared/types";
 import { delegationHeaders } from "./delegation";
 
-type ApiSwap = Omit<Swap, "fromCourseId" | "toCourseId"> & {
-  fromCourseId: string;
-  toCourseId: string;
+/** Rohdaten von GET /swaps und /swaps/status (Kurs-IDs oft als String). */
+type ApiSwapRow = {
+  user: string;
+  fromCourseId: string | number;
+  fromDate: string;
+  toCourseId: string | number;
+  toDate: string;
+  status: Swap["status"];
+  fromCourseUid?: string;
+  toCourseUid?: string;
 };
+
+function mapApiSwapRow(item: ApiSwapRow): Swap {
+  const fromUid = typeof item.fromCourseUid === "string" ? item.fromCourseUid.trim() : "";
+  const toUid = typeof item.toCourseUid === "string" ? item.toCourseUid.trim() : "";
+  return {
+    user: item.user,
+    fromCourseId: Number(item.fromCourseId),
+    fromDate: item.fromDate,
+    toCourseId: Number(item.toCourseId),
+    toDate: item.toDate,
+    status: item.status,
+    ...(fromUid ? { fromCourseUid: fromUid } : {}),
+    ...(toUid ? { toCourseUid: toUid } : {}),
+  };
+}
 
 export async function getSwaps(user: string, fromDate?: string, fromCourseId?: number, toDate?: string, toCourseId?: number, status?: string): Promise<Swap[]> {
   try {
@@ -17,24 +39,17 @@ export async function getSwaps(user: string, fromDate?: string, fromCourseId?: n
     if (status) params.status = status;
 
     console.log("getSwaps params:", params);
-    const response = await axios.get<ApiSwap[]>("/swaps", { params });
+    const response = await axios.get<ApiSwapRow[]>("/swaps", { params });
     let data = response.data;
     console.log("getSwaps initial response:", data);
     if (data.length === 0) {
       console.log("Retrying getSwaps...");
       await new Promise(resolve => setTimeout(resolve, 1000));
-      const retryResponse = await axios.get<ApiSwap[]>("/swaps", { params });
+      const retryResponse = await axios.get<ApiSwapRow[]>("/swaps", { params });
       data = retryResponse.data;
       console.log("getSwaps retry response:", data);
     }
-    return data.map((item) => ({
-      user: item.user,
-      fromCourseId: parseInt(item.fromCourseId),
-      fromDate: item.fromDate,
-      toCourseId: parseInt(item.toCourseId),
-      toDate: item.toDate,
-      status: item.status,
-    }));
+    return data.map(mapApiSwapRow);
   } catch (error) {
     console.error('Fehler beim Laden der Swaps:', error);
     return [];
@@ -91,9 +106,10 @@ export async function deleteSwap(swap: Swap): Promise<void> {
 export async function getSwapsByStatus(status: string): Promise<Swap[]> {
   try {
     console.log('getSwapsByStatus called with status:', status);
-    const response = await axios.get('/swaps/status', { params: { status } });
+    const response = await axios.get<ApiSwapRow[]>('/swaps/status', { params: { status } });
     console.log('getSwapsByStatus response:', response.data);
-    return response.data;
+    const data = Array.isArray(response.data) ? response.data : [];
+    return data.map(mapApiSwapRow);
   } catch (error) {
     console.error('Fehler beim Laden der Swaps by status:', error);
     return [];
@@ -108,8 +124,18 @@ export async function processPromotions(): Promise<{
   overrides: CourseDateOverride[];
 }> {
   try {
-    const response = await axios.post('/process-promotions', {});
-    return response.data;
+    const response = await axios.post<{
+      message: string;
+      iterations: number;
+      promoted: number;
+      swaps: ApiSwapRow[];
+      overrides: CourseDateOverride[];
+    }>('/process-promotions', {});
+    const body = response.data;
+    return {
+      ...body,
+      swaps: Array.isArray(body.swaps) ? body.swaps.map(mapApiSwapRow) : body.swaps,
+    };
   } catch (error) {
     console.error('Failed to process promotions:', error);
     throw error;

--- a/app/src/components/CourseDatesDialog.test.tsx
+++ b/app/src/components/CourseDatesDialog.test.tsx
@@ -114,7 +114,7 @@ describe("CourseDatesDialog", () => {
 
     await waitFor(() => {
       expect(mockedUpdateCourse).toHaveBeenCalledWith(
-        1,
+        "1",
         expect.objectContaining({
           planningMode: "bounded_series",
           visibilityMode: "fixed_window",
@@ -189,7 +189,7 @@ describe("CourseDatesDialog", () => {
 
     await waitFor(() => {
       expect(mockedUpdateCourse).toHaveBeenCalledWith(
-        1,
+        "1",
         expect.objectContaining({
           planningMode: "rolling_continuous",
           visibilityMode: "rolling_horizon",
@@ -320,7 +320,7 @@ describe("CourseDatesDialog", () => {
 
     await waitFor(() => {
       expect(mockedCancelCourseDate).toHaveBeenCalledWith(
-        1,
+        "1",
         "2026-01-06",
         expect.objectContaining({
           rollbackSuccessfulSwapsFromCancelledParticipants: false,

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -24,6 +24,7 @@ import {
   type CourseDatesEditorState,
 } from "./courseDatesDialogUtils";
 import { resolveWarningMessages } from "../i18n";
+import { courseApiPathKey } from "../lib/courseUid";
 
 type CourseDatesDialogProps = {
   course: Course | null;
@@ -569,7 +570,7 @@ export default function CourseDatesDialog({
     setFormError(null);
     setFormNotices([]);
     try {
-      const response = await cancelCourseDate(course.id, selectedCancellationDate, {
+      const response = await cancelCourseDate(courseApiPathKey(course), selectedCancellationDate, {
         rollbackSuccessfulSwapsFromCancelledParticipants: rollbackSuccessfulSwaps,
         rollbackPendingWaitlistSwapsFromOriginDate: rollbackPendingWaitlistSwaps,
       });
@@ -595,7 +596,7 @@ export default function CourseDatesDialog({
   };
 
   const saveDatesConfig = async () => {
-    if (!datesState || !canManageCourses || isActiveReadOnly) return;
+    if (!course || !datesState || !canManageCourses || isActiveReadOnly) return;
     if (datesState.planningMode === "bounded_series") {
       if (!datesSeriesRangeValid) {
         setFormError("Bitte einen gültigen Zeitraum mit Start- und Enddatum wählen.");
@@ -618,7 +619,7 @@ export default function CourseDatesDialog({
     setFormNotices([]);
     try {
       if (datesState.planningMode === "rolling_continuous") {
-        await updateCourse(datesState.courseId, {
+        await updateCourse(courseApiPathKey(course), {
           planningMode: "rolling_continuous",
           visibilityMode: "rolling_horizon",
           visibilityHorizonWeeks: datesState.visibilityHorizonWeeks,
@@ -626,7 +627,7 @@ export default function CourseDatesDialog({
           includedDates: [],
         });
       } else {
-        await updateCourse(datesState.courseId, {
+        await updateCourse(courseApiPathKey(course), {
           planningMode: "bounded_series",
           visibilityMode: "fixed_window",
           seriesStartDate: datesState.seriesStartDate,
@@ -655,12 +656,12 @@ export default function CourseDatesDialog({
       openImpactDialog();
       return;
     }
-    if (!datesState || !canManageCourses) return;
+    if (!course || !datesState || !canManageCourses) return;
     setSaving(true);
     setFormError(null);
     setFormNotices([]);
     try {
-      await updateCourse(datesState.courseId, {
+      await updateCourse(courseApiPathKey(course), {
         planningMode: "rolling_continuous",
         visibilityMode: "rolling_horizon",
         visibilityHorizonWeeks: datesState.visibilityHorizonWeeks,

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -470,7 +470,7 @@ describe("CourseList", () => {
 
     await waitFor(() => {
       expect(mockedUpdateCourse).toHaveBeenCalledWith(
-        1,
+        "1",
         expect.objectContaining({
           name: "Kurs A Neu",
         }),
@@ -666,7 +666,7 @@ describe("CourseList", () => {
 
     await waitFor(() => {
       expect(mockedUpdateCourse).toHaveBeenCalledWith(
-        1,
+        "1",
         expect.objectContaining({
           planningMode: "bounded_series",
           visibilityMode: "fixed_window",

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -28,6 +28,7 @@ import {
   updateCourse,
 } from "../api/courses";
 import { canSeeCourse } from "shared/permissions";
+import { courseApiPathKey } from "../lib/courseUid";
 
 type Props = {
   currentUser: User;
@@ -556,7 +557,12 @@ export default function CourseList({
     setSaving(true);
     setFormError(null);
     try {
-      await updateCourse(editState.id, {
+      const courseForEdit = visibleCourses.find((c) => c.id === editState.id);
+      if (!courseForEdit) {
+        setFormError("Kurs nicht gefunden.");
+        return;
+      }
+      await updateCourse(courseApiPathKey(courseForEdit), {
         name: trimmedName,
         weekday: editState.weekday,
         time: editState.time,
@@ -575,11 +581,11 @@ export default function CourseList({
   };
 
   const confirmDeleteCourse = async () => {
-    if (!canManageCourses || !deleteTargetId) return;
+    if (!canManageCourses || !deleteTargetCourse) return;
     setSaving(true);
     setFormError(null);
     try {
-      await deleteCourse(deleteTargetId);
+      await deleteCourse(courseApiPathKey(deleteTargetCourse));
       closeDeleteModal();
       await fetchData();
     } catch (err) {
@@ -592,10 +598,15 @@ export default function CourseList({
 
   const saveCourseMembers = async (courseId: number, participants: string[]) => {
     if (!canManageCourses) return;
+    const targetCourse = visibleCourses.find((c) => c.id === courseId);
+    if (!targetCourse) {
+      setFormError("Kurs nicht gefunden.");
+      return;
+    }
     setSaving(true);
     setFormError(null);
     try {
-      await updateCourse(courseId, { participants });
+      await updateCourse(courseApiPathKey(targetCourse), { participants });
       closeMembersModal();
       await fetchData();
     } catch (err) {

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { getEffectiveWaitlist } from "../lib/waitlist";
 import { sameDayUTC } from "../lib/dates";
+import { overrideCourseUidFields, swapCourseUidFields } from "../lib/courseUid";
 import { Swap, CourseDateOverride, Course, User } from "shared/types";
 import { createSwap, deleteSwap, processPromotions } from "../api/swaps";
 import { createOverride, updateOverride } from "../api/overrides";
@@ -100,6 +101,7 @@ export function useCourseSwaps(
                 participants: [...course.participants],
                 swapped: [],
                 waitlist: [],
+                ...overrideCourseUidFields(course),
               };
 
         const courseCapacity = course.capacity;
@@ -245,6 +247,7 @@ export function useCourseSwaps(
                   participants: fromCourse.participants.filter((p) => p.toLowerCase() !== userName.toLowerCase()),
                   swapped: [],
                   waitlist: [],
+                  ...overrideCourseUidFields(fromCourse),
                 };
           const originNextOverride: CourseDateOverride = {
             ...originOverride,
@@ -268,6 +271,7 @@ export function useCourseSwaps(
                   participants: [...targetCourse.participants],
                   swapped: [],
                   waitlist: [],
+                  ...overrideCourseUidFields(targetCourse),
                 };
           const newParticipants = targetOverride.participants.some(
             (p) => p.toLowerCase() === userName.toLowerCase()
@@ -293,6 +297,7 @@ export function useCourseSwaps(
           toCourseId,
           toDate: toDateIso,
           status: 'active',
+          ...swapCourseUidFields(fromCourse, targetCourse),
         };
         await createSwap(newSwap);
 
@@ -537,6 +542,7 @@ export function useCourseSwaps(
               participants: [...baseParticipants],  // alle bisherigen Teilnehmer
               swapped: [],
               waitlist: [userName], // neue Warteliste
+              ...overrideCourseUidFields(targetCourse),
             };
             updated.push(nextOverride);
             // Backend-Aufruf: Override erstellen
@@ -554,6 +560,7 @@ export function useCourseSwaps(
           toCourseId,
           toDate: toDateIso,
           status: 'pending',
+          ...swapCourseUidFields(fromCourse, targetCourse),
         };
         await createSwap(newSwap);
 

--- a/app/src/lib/courseUid.test.ts
+++ b/app/src/lib/courseUid.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
 import type { Course } from "shared/types";
-import { overrideCourseUidFields, swapCourseUidFields } from "./courseUid";
+import { courseApiPathKey, overrideCourseUidFields, swapCourseUidFields } from "./courseUid";
 
 describe("courseUid helpers", () => {
+  it("courseApiPathKey prefers uid over numeric id", () => {
+    const course = {
+      id: 7,
+      courseUid: "550e8400-e29b-41d4-a716-446655440000",
+    } as Pick<Course, "id" | "courseUid">;
+    expect(courseApiPathKey(course)).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("courseApiPathKey falls back to id without uid", () => {
+    const course = { id: 3 } as Pick<Course, "id" | "courseUid">;
+    expect(courseApiPathKey(course)).toBe("3");
+  });
+
   it("overrideCourseUidFields omits when missing", () => {
     const course = { courseUid: undefined } as Pick<Course, "courseUid">;
     expect(overrideCourseUidFields(course)).toEqual({});

--- a/app/src/lib/courseUid.test.ts
+++ b/app/src/lib/courseUid.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { Course } from "shared/types";
+import { overrideCourseUidFields, swapCourseUidFields } from "./courseUid";
+
+describe("courseUid helpers", () => {
+  it("overrideCourseUidFields omits when missing", () => {
+    const course = { courseUid: undefined } as Pick<Course, "courseUid">;
+    expect(overrideCourseUidFields(course)).toEqual({});
+  });
+
+  it("overrideCourseUidFields trims and returns uid", () => {
+    const course = { courseUid: "  550e8400-e29b-41d4-a716-446655440000  " };
+    expect(overrideCourseUidFields(course)).toEqual({
+      courseUid: "550e8400-e29b-41d4-a716-446655440000",
+    });
+  });
+
+  it("swapCourseUidFields sets both when present", () => {
+    const from = { courseUid: "aaa" };
+    const to = { courseUid: "bbb" };
+    expect(swapCourseUidFields(from, to)).toEqual({
+      fromCourseUid: "aaa",
+      toCourseUid: "bbb",
+    });
+  });
+});

--- a/app/src/lib/courseUid.ts
+++ b/app/src/lib/courseUid.ts
@@ -1,6 +1,15 @@
 import type { Course } from "shared/types";
 
 /**
+ * Pfadsegment für `/courses/:id`- und Override-Routen: bevorzugt `courseUid`, sonst Legacy-`id`.
+ * Entspricht der Backend-Auflösung über `GSI_CourseUid`.
+ */
+export function courseApiPathKey(course: Pick<Course, "id" | "courseUid">): string {
+  const uid = course.courseUid?.trim();
+  return uid ?? String(course.id);
+}
+
+/**
  * Optionale courseUid für neue Client-seitige Overrides (#125), analog zum Backend-Dual-Write.
  */
 export function overrideCourseUidFields(

--- a/app/src/lib/courseUid.ts
+++ b/app/src/lib/courseUid.ts
@@ -1,0 +1,26 @@
+import type { Course } from "shared/types";
+
+/**
+ * Optionale courseUid für neue Client-seitige Overrides (#125), analog zum Backend-Dual-Write.
+ */
+export function overrideCourseUidFields(
+  course: Pick<Course, "courseUid">,
+): { courseUid: string } | Record<string, never> {
+  const uid = course.courseUid?.trim();
+  return uid ? { courseUid: uid } : {};
+}
+
+/**
+ * Optionale fromCourseUid / toCourseUid für Swap-Payloads (#125).
+ */
+export function swapCourseUidFields(
+  fromCourse: Pick<Course, "courseUid">,
+  toCourse: Pick<Course, "courseUid">,
+): { fromCourseUid?: string; toCourseUid?: string } {
+  const fromUid = fromCourse.courseUid?.trim();
+  const toUid = toCourse.courseUid?.trim();
+  return {
+    ...(fromUid ? { fromCourseUid: fromUid } : {}),
+    ...(toUid ? { toCourseUid: toUid } : {}),
+  };
+}

--- a/backend/src/lambdas/cancelCourseDate/index.ts
+++ b/backend/src/lambdas/cancelCourseDate/index.ts
@@ -9,6 +9,7 @@ import {
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { dynamoClient } from "../shared/dynamoClient";
 import { deriveParticipantStatus } from "../shared/participantStatus";
+import { resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
@@ -156,9 +157,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     };
   }
 
-  const courseId = event.pathParameters?.courseId?.trim();
+  const rawCourseId = event.pathParameters?.courseId?.trim();
   const date = event.pathParameters?.date?.trim();
-  if (!courseId || !date) {
+  if (!rawCourseId || !date) {
     return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId or date in path" }) };
   }
 
@@ -177,6 +178,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     true;
 
   try {
+    const resolvedPath = await resolveLegacyCourseIdFromPathSegment(
+      client,
+      coursesTable,
+      tenantId,
+      rawCourseId,
+    );
+    if (!resolvedPath.ok) {
+      return { statusCode: resolvedPath.statusCode, body: resolvedPath.body };
+    }
+    const courseId = resolvedPath.legacyCourseId;
+
     console.info("cancelCourseDate start", {
       tenantId,
       actorUserId,

--- a/backend/src/lambdas/deleteCourse/index.ts
+++ b/backend/src/lambdas/deleteCourse/index.ts
@@ -6,6 +6,7 @@ import {
   ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
+import { resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 import { getTenantContext } from "../shared/tenantContext";
 
 const client = dynamoClient;
@@ -39,8 +40,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     };
   }
 
-  const courseId = event.pathParameters?.courseId?.trim();
-  if (!courseId) {
+  const rawCourseId = event.pathParameters?.courseId?.trim();
+  if (!rawCourseId) {
     return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId in path" }) };
   }
 
@@ -50,6 +51,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   }
 
   try {
+    const resolvedPath = await resolveLegacyCourseIdFromPathSegment(
+      client,
+      coursesTable,
+      tenantId,
+      rawCourseId,
+    );
+    if (!resolvedPath.ok) {
+      return { statusCode: resolvedPath.statusCode, body: resolvedPath.body };
+    }
+    const courseId = resolvedPath.legacyCourseId;
+
     const membershipResp = await client.send(
       new GetItemCommand({
         TableName: membershipsTable,

--- a/backend/src/lambdas/deleteOverride/index.test.ts
+++ b/backend/src/lambdas/deleteOverride/index.test.ts
@@ -8,6 +8,7 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
   return {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     DeleteItemCommand: jest.fn((input) => input),
+    QueryCommand: jest.fn((input) => input),
     mockSend,
   };
 });
@@ -19,7 +20,7 @@ describe("deleteOverride Lambda", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...OLD_ENV, OVERRIDES_TABLE: "test-overrides" };
+    process.env = { ...OLD_ENV, OVERRIDES_TABLE: "test-overrides", COURSES_TABLE: "test-courses" };
     mockSend.mockReset();
   });
 

--- a/backend/src/lambdas/deleteOverride/index.ts
+++ b/backend/src/lambdas/deleteOverride/index.ts
@@ -3,6 +3,7 @@ import { DeleteItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
+import { resolveLegacyCourseIdFromPathSegment } from '../shared/courseUid';
 
 const client = dynamoClient;
 
@@ -15,26 +16,44 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     actingForUserId,
   });
   if (delegationErrorResponse) return delegationErrorResponse;
-  const tableName = process.env.OVERRIDES_TABLE;
-  const courseId = event.pathParameters?.courseId;
-  const date = event.pathParameters?.date;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
+  const rawCourseId = event.pathParameters?.courseId?.trim();
+  const date = event.pathParameters?.date?.trim();
 
   try {
-    if (!courseId || !date) {
+    if (!overridesTable || !coursesTable) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'OVERRIDES_TABLE or COURSES_TABLE env var is not set' }),
+      };
+    }
+    if (!rawCourseId || !date) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Missing courseId or date' }) };
     }
 
-    const courseId_date = `${courseId}_${date}`;
+    const resolvedPath = await resolveLegacyCourseIdFromPathSegment(
+      client,
+      coursesTable,
+      tenantId,
+      rawCourseId,
+    );
+    if (!resolvedPath.ok) {
+      return { statusCode: resolvedPath.statusCode, body: resolvedPath.body };
+    }
+    const legacyCourseId = resolvedPath.legacyCourseId;
+
+    const courseId_date = `${legacyCourseId}_${date}`;
     console.log('deleteOverride audit', {
       tenantId,
       actorUserId: userId ?? null,
       actingForUserId: actingForUserId ?? null,
-      courseId,
+      legacyCourseId,
       date,
     });
     await client.send(
       new DeleteItemCommand({
-        TableName: tableName,
+        TableName: overridesTable,
         Key: {
           tenantId: { S: tenantId },
           courseId_date: { S: courseId_date },

--- a/backend/src/lambdas/shared/courseUid.ts
+++ b/backend/src/lambdas/shared/courseUid.ts
@@ -1,10 +1,92 @@
-import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { GetItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { randomUUID } from "node:crypto";
+
+/** Global Secondary Index auf der Courses-Tabelle (tenantId + courseUid). */
+export const GSI_COURSE_UID = "GSI_CourseUid";
+
+/**
+ * UUID v4 im Pfad (RFC 4122), case-insensitive Erkennung für Lookup.
+ * Keine Legacy-Zahlenstrings wie "12345" (zu kurz / kein Muster).
+ */
+export const COURSE_UID_PATH_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Neue stabile technische Kurs-ID (UUID v4). */
 export function generateCourseUid(): string {
   return randomUUID();
+}
+
+export function looksLikeCourseUidPathSegment(segment: string): boolean {
+  return COURSE_UID_PATH_REGEX.test(segment.trim());
+}
+
+export type ResolveLegacyCourseIdFromPathResult =
+  | { ok: true; legacyCourseId: string }
+  | { ok: false; statusCode: number; body: string };
+
+/**
+ * API-Pfad `{courseId}`: entweder Legacy-Kurs-ID (String, z. B. `"42"`) oder `courseUid` (UUID).
+ * UUID wird über GSI_CourseUid in die Dynamo-SK `courseId` aufgelöst.
+ */
+export async function resolveLegacyCourseIdFromPathSegment(
+  client: DynamoDBClient,
+  coursesTable: string,
+  tenantId: string,
+  rawSegment: string | undefined,
+): Promise<ResolveLegacyCourseIdFromPathResult> {
+  const segment = rawSegment?.trim();
+  if (!segment) {
+    return {
+      ok: false,
+      statusCode: 400,
+      body: JSON.stringify({ error: "Missing courseId in path" }),
+    };
+  }
+
+  if (!looksLikeCourseUidPathSegment(segment)) {
+    return { ok: true, legacyCourseId: segment };
+  }
+
+  const uidNormalized = segment.trim().toLowerCase();
+  try {
+    const resp = await client.send(
+      new QueryCommand({
+        TableName: coursesTable,
+        IndexName: GSI_COURSE_UID,
+        KeyConditionExpression: "tenantId = :tid AND courseUid = :uid",
+        ExpressionAttributeValues: {
+          ":tid": { S: tenantId },
+          ":uid": { S: uidNormalized },
+        },
+        Limit: 2,
+      }),
+    );
+    const items = resp.Items ?? [];
+    if (items.length === 0) {
+      return {
+        ok: false,
+        statusCode: 404,
+        body: JSON.stringify({ error: "Course not found" }),
+      };
+    }
+    const legacy = items[0].courseId?.S?.trim();
+    if (!legacy) {
+      return {
+        ok: false,
+        statusCode: 500,
+        body: JSON.stringify({ error: "Course record incomplete" }),
+      };
+    }
+    return { ok: true, legacyCourseId: legacy };
+  } catch (e) {
+    console.error("resolveLegacyCourseIdFromPathSegment Query failed", e);
+    return {
+      ok: false,
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to resolve course" }),
+    };
+  }
 }
 
 /**

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -8,7 +8,7 @@ import {
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
 import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
-import { generateCourseUid } from "../shared/courseUid";
+import { generateCourseUid, resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
@@ -187,8 +187,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     };
   }
 
-  const courseId = event.pathParameters?.courseId?.trim();
-  if (!courseId) {
+  const rawCourseId = event.pathParameters?.courseId?.trim();
+  if (!rawCourseId) {
     return { statusCode: 400, body: JSON.stringify({ error: "Missing courseId in path" }) };
   }
 
@@ -196,6 +196,17 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (!actorUserId) {
     return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
   }
+
+  const resolvedPath = await resolveLegacyCourseIdFromPathSegment(
+    client,
+    coursesTable,
+    tenantId,
+    rawCourseId,
+  );
+  if (!resolvedPath.ok) {
+    return { statusCode: resolvedPath.statusCode, body: resolvedPath.body };
+  }
+  const courseId = resolvedPath.legacyCourseId;
 
   const body = parseBody(event);
   if (!body) {

--- a/backend/src/lambdas/updateOverride/index.test.ts
+++ b/backend/src/lambdas/updateOverride/index.test.ts
@@ -1,5 +1,10 @@
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBClient, UpdateItemCommand, UpdateItemCommandInput } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+  UpdateItemCommandInput,
+} from '@aws-sdk/client-dynamodb';
 import { handler } from './index';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 
@@ -8,6 +13,7 @@ const dynamoMock = mockClient(DynamoDBClient);
 beforeEach(() => {
   dynamoMock.reset();
   process.env.OVERRIDES_TABLE = 'yogaswap-backend-demo-courseOverrides-table';
+  process.env.COURSES_TABLE = 'test-courses-table';
 });
 
 describe('updateOverride Lambda', () => {
@@ -37,6 +43,7 @@ describe('updateOverride Lambda', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ message: 'Override updated' });
     expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(0);
 
     // Zugriff auf das Input-Objekt des Commands (typisiert!)
     const call = dynamoMock.call(0).args[0].input as UpdateItemCommandInput;
@@ -152,5 +159,38 @@ describe('updateOverride Lambda', () => {
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body)).toEqual({ error: 'Failed to update override' });
     expect(dynamoMock.calls()).toHaveLength(1);
+  });
+
+  it('resolves courseUid path segment via GSI then updates override', async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ courseId: { S: '42' }, courseUid: { S: '550e8400-e29b-41d4-a716-446655440000' } }],
+    });
+    dynamoMock.on(UpdateItemCommand).resolves({});
+
+    const uidPath = '550e8400-e29b-41d4-a716-446655440000';
+    const event: APIGatewayProxyEvent = {
+      pathParameters: { courseId: uidPath, date: '2025-10-01' },
+      body: JSON.stringify({
+        participants: ['Luna'],
+      }),
+      headers: {},
+      multiValueHeaders: {},
+      httpMethod: 'PUT',
+      isBase64Encoded: false,
+      path: `/overrides/${uidPath}/2025-10-01`,
+      queryStringParameters: null,
+      multiValueQueryStringParameters: null,
+      stageVariables: null,
+      resource: '',
+      requestContext: {} as any,
+    };
+
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(200);
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(1);
+    expect(dynamoMock.commandCalls(UpdateItemCommand)).toHaveLength(1);
+    const updateCall = dynamoMock.commandCalls(UpdateItemCommand)[0].args[0].input as UpdateItemCommandInput;
+    expect(updateCall.Key?.courseId_date?.S).toBe('42_2025-10-01');
   });
 });

--- a/backend/src/lambdas/updateOverride/index.ts
+++ b/backend/src/lambdas/updateOverride/index.ts
@@ -3,6 +3,7 @@ import { UpdateItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
+import { resolveLegacyCourseIdFromPathSegment } from '../shared/courseUid';
 
 const client = dynamoClient;
 
@@ -15,15 +16,34 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     actingForUserId,
   });
   if (delegationErrorResponse) return delegationErrorResponse;
-  const tableName = process.env.OVERRIDES_TABLE;
-  const courseId = event.pathParameters?.courseId;
-  const date = event.pathParameters?.date;
-  const updates = JSON.parse(event.body || '{}');
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
+  const rawCourseId = event.pathParameters?.courseId?.trim();
+  const date = event.pathParameters?.date?.trim();
 
   try {
-    if (!courseId || !date) {
+    if (!overridesTable || !coursesTable) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'OVERRIDES_TABLE or COURSES_TABLE env var is not set' }),
+      };
+    }
+    if (!rawCourseId || !date) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Missing courseId or date' }) };
     }
+
+    const resolvedPath = await resolveLegacyCourseIdFromPathSegment(
+      client,
+      coursesTable,
+      tenantId,
+      rawCourseId,
+    );
+    if (!resolvedPath.ok) {
+      return { statusCode: resolvedPath.statusCode, body: resolvedPath.body };
+    }
+    const legacyCourseId = resolvedPath.legacyCourseId;
+
+    const updates = JSON.parse(event.body || '{}');
 
     let updateExpression = 'SET';
     const expressionAttributeValues: Record<string, any> = {};
@@ -71,10 +91,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     updateExpression = updateExpression.slice(0, -1); // Entferne letztes Komma
 
-    const courseId_date = `${courseId}_${date}`;
+    const courseId_date = `${legacyCourseId}_${date}`;
     await client.send(
       new UpdateItemCommand({
-        TableName: tableName,
+        TableName: overridesTable,
         Key: { tenantId: { S: tenantId }, courseId_date: { S: courseId_date } },
         UpdateExpression: updateExpression,
         ExpressionAttributeNames: expressionAttributeNames,

--- a/projects/yogaswap/dynamodb.tf
+++ b/projects/yogaswap/dynamodb.tf
@@ -43,6 +43,7 @@ module "course_overrides_table" {
 }
 
 # Tenant-scoped: PK = tenantId, SK = courseId (string, z. B. "1", "2")
+# GSI_CourseUid: Lookup tenantId + courseUid → Projektion ALL (UUID in API-Pfaden)
 module "courses_table" {
   source    = "../modules/dynamodb"
   name      = "${var.project}-courses-table"
@@ -50,7 +51,16 @@ module "courses_table" {
   range_key = "courseId"
   attributes = [
     { name = "tenantId", type = "S" },
-    { name = "courseId", type = "S" }
+    { name = "courseId", type = "S" },
+    { name = "courseUid", type = "S" }
+  ]
+  global_secondary_index = [
+    {
+      name            = "GSI_CourseUid"
+      hash_key        = "tenantId"
+      range_key       = "courseUid"
+      projection_type = "ALL"
+    }
   ]
 }
 

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -96,10 +96,11 @@ locals {
     "update_override" = {
       name             = "update-override"
       file_name        = "updateOverride.zip"
-      table_arns       = [module.course_overrides_table.table_arn]
-      dynamodb_actions = ["dynamodb:UpdateItem"]
+      table_arns       = [module.course_overrides_table.table_arn, module.courses_table.table_arn]
+      dynamodb_actions = ["dynamodb:UpdateItem", "dynamodb:Query"]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -107,10 +108,11 @@ locals {
     "delete_override" = {
       name             = "delete-override"
       file_name        = "deleteOverride.zip"
-      dynamodb_actions = ["dynamodb:DeleteItem"]
-      table_arns       = [module.course_overrides_table.table_arn]
+      dynamodb_actions = ["dynamodb:DeleteItem", "dynamodb:Query"]
+      table_arns       = [module.course_overrides_table.table_arn, module.courses_table.table_arn]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []


### PR DESCRIPTION
## Ziel
Kursbezogene REST-Pfade akzeptieren stabile `courseUid` (UUID) zusätzlich zur Legacy-`courseId`; das Frontend nutzt UUID bevorzugt.

## Backend
- DynamoDB: GSI `GSI_CourseUid` auf der Courses-Tabelle (`tenantId` + `courseUid`).
- `resolveLegacyCourseIdFromPathSegment` in `shared/courseUid.ts`: UUID → Query auf GSI, sonst Pfad = Legacy-ID.
- Auflösung in: `updateCourse`, `cancelCourseDate`, `deleteCourse`, `updateOverride`, `deleteOverride`.
- IAM: `update_override` / `delete_override` mit `COURSES_TABLE` + `dynamodb:Query`.

## Frontend
- `courseApiPathKey(course)`: bevorzugt `courseUid`, Fallback numerische `id`.
- `CourseList`, `CourseDatesDialog`: Kurs-APIs über diesen Schlüssel.
- `updateOverride` / `deleteOverride`: `number | string`, URL-segmente encodiert.
- Dual-Write `courseUid` bei neuen Overrides/Swaps in `useCourseSwaps` (früherer Commit).
- API-Mapping `courseUid` / Swap-UIDs aus Responses (früherer Commit).

## Deployment / Voraussetzungen
- `terraform apply` (GSI).
- Lambdas neu deployen.
- Kurse mit `courseUid` (Backfill) – bei euch erledigt.

## Tests
- Backend Jest, App Vitest; Smoke manuell mit UUID-Pfaden.

## Follow-up (optional)
- `useCourseSwaps`: Override-PUTs könnten ebenfalls `courseApiPathKey` nutzen (derzeit Legacy-ID in URL, weiterhin gültig).
- `getOverrides?courseId=` bleibt numerisch, falls später UID-Filter nötig.

Made with [Cursor](https://cursor.com)