### PR TITLE
Docs: course UID vs legacy ID (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Bei der Ausarbeitung habe ich AI bewusst als Sparringspartner genutzt, um Entsch
 
 ---
 
+## 🔑 Kurs-Identifikatoren (`courseUid` und Legacy-ID)
+
+Jeder Kurs hat eine **stabile UUID** (`courseUid`) für API-Pfade und fachliche Referenzen. Parallel bleibt die **numerische Legacy-ID** (Feld `id` in der App, DynamoDB-SK `courseId`):
+
+- **DynamoDB**: Sort-Key und zusammengesetzte Keys – z. B. Course-Overrides (`courseId_date`), Swaps und zugehörige GSI-Attribute.
+- **Swaps**: `fromCourseId` / `toCourseId` bleiben Teil der bestehenden Schlüssel- und Indexpfade und sorgen für **lesbare** zusammengesetzte IDs – nicht nur für die Oberfläche.
+- **REST**: Kursbezogene URLs akzeptieren **UUID oder Legacy-ID**; UUIDs werden serverseitig per GSI `GSI_CourseUid` auf die Legacy-SK abgebildet.
+
+Ausführlicher: [docs/course-identifiers.md](docs/course-identifiers.md) · Typkommentare: `shared/src/types.ts` (`Course`, `Swap`, `CourseDateOverride`).
+
+---
+
 ## 👥 #130 Scope A: Kursmitglieder verwalten
 
 Dieser Abschnitt dokumentiert den aktuellen Stand von **Issue #130, Scope A** (Kurs-Teilnehmerliste + Fremdverwaltung).

--- a/docs/course-identifiers.md
+++ b/docs/course-identifiers.md
@@ -1,0 +1,31 @@
+# Kurs-Identifikatoren: `courseUid` und Legacy-`courseId`
+
+## Kurzfassung
+
+- **`courseUid`**: UUID (v4), stabile technische Kurs-ID. Wird u. a. in REST-Pfaden und für übergreifende Referenzen genutzt; in DynamoDB über den Global Secondary Index **`GSI_CourseUid`** (`tenantId` + `courseUid`) auffindbar.
+- **Legacy numerische ID**: Feld **`id`** im Client-Modell, Entsprechung **`courseId`** als String in DynamoDB (Sort-Key der Courses-Tabelle pro Tenant).
+
+Beide existieren **parallel**. Die Migration (#122) führt `courseUid` ein und befüllt bestehende Datensätze (Backfill); der Cutover (#125) erlaubt UUIDs in API-Pfaden mit Auflösung auf die Legacy-SK.
+
+## Warum die numerische ID nicht „nur Anzeige“ ist
+
+Die Legacy-ID bleibt Bestandteil des Datenmodells und der Speicherung:
+
+| Bereich | Rolle der Legacy-ID |
+|--------|----------------------|
+| **Courses (DynamoDB)** | Sort-Key `courseId` neben Partition `tenantId`. |
+| **Overrides** | Schlüsselteil `courseId_date` (String-Konkatenation aus Legacy-Kurs-ID und Datum). |
+| **Swaps** | Zusammengesetzte IDs und GSI-Range-Felder enthalten die numerische Kurs-ID (z. B. `fromDate_fromCourseId_status`, `toDate_toCourseId_status`, `swapId`) – **lesbar** und kompatibel mit dem bestehenden Design. |
+| **API (kompatibel)** | Clients und ältere Aufrufe können weiter die numerische ID in Pfaden verwenden. |
+
+`courseUid` und `fromCourseUid` / `toCourseUid` an Swaps bzw. Overrides sind **Dual-Write**-Felder für die neue Referenz, ohne die bestehenden Schlüsselpfade sofort zu ersetzen.
+
+## Operatives
+
+- **Backfill** (bestehende Kurse/Referenzen): im Verzeichnis `backend` z. B. `npm run backfill:course-uids` (siehe Skript `src/scripts/backfill_course_uids.ts`).
+- **Infra**: GSI `GSI_CourseUid` auf der Courses-Tabelle (Terraform: `projects/yogaswap/dynamodb.tf`).
+- **Code**: Zentrale Pfadlogik im Frontend z. B. `courseApiPathKey` in `app/src/lib/courseUid.ts`; Auflösung im Backend in `backend/src/lambdas/shared/courseUid.ts`.
+
+## Siehe auch
+
+- Typdefinitionen und JSDoc: `shared/src/types.ts` (`Course`, `Swap`, `CourseDateOverride`).

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -9,6 +9,7 @@ export type TenantContext = {
 export type CourseDateOverride = {
   // Zugehöriger Tenant (wird bei Multi-Tenancy Pflicht, aktuell optional für Migration)
   tenantId?: string;
+  /** Legacy-Kurs-ID (numerisch); zusammen mit `date` Schlüsselteil und Lesbarkeit in Listen. */
   courseId: number;
   /** Stabile technische Kurs-ID (UUID), Dual-Write mit {@link Course.courseUid}. */
   courseUid?: string;
@@ -27,10 +28,17 @@ export type Swap = {
   // Tenant-Kontext für den Swap
   tenantId?: string;
   user: string;        // der Teilnehmer
+  /**
+   * Legacy-Kurs-ID (numerisch): bleibt u. a. für lesbare Swap-Schlüssel und GSI-Range-Attribute
+   * (`fromDate_fromCourseId_status`, `toDate_toCourseId_status`, `swapId`), nicht nur für UI.
+   */
   fromCourseId: number;
   /** Stabile Kurs-ID am Ursprung (Dual-Write). */
   fromCourseUid?: string;
   fromDate: string;    // ISO des Ursprungstermins
+  /**
+   * Legacy-Kurs-ID am Ziel — wie {@link Swap.fromCourseId}: Lesbarkeit und bestehende Schlüsselpfade.
+   */
   toCourseId: number;
   /** Stabile Kurs-ID am Ziel (Dual-Write). */
   toCourseUid?: string;
@@ -46,10 +54,14 @@ export type Course = {
   // Tenant, zu dem der Kurs gehört
   tenantId?: string;
   /**
-   * Stabile technische Kurs-ID (UUID). Nach Abschluss der Migration (#122) Primärreferenz für APIs;
-   * `id` / `courseId` bleiben für Legacy und Anzeige nutzbar.
+   * Stabile technische Kurs-ID (UUID). Primärreferenz für neue API-Pfade und übergreifende Referenzen.
+   *
+   * Die numerische {@link Course.id} (Legacy) bleibt parallel bestehen: DynamoDB-Sort-Key,
+   * zusammengesetzte Keys (Overrides `courseId_date`, Swap-IDs und GSI-Felder mit Kursbezug),
+   * sowie nachvollziehbare Anzeige — nicht nur „Sortierung“.
    */
   courseUid?: string;
+  /** Legacy-Kurs-ID (numerisch), entspricht der DynamoDB-SK `courseId` und numerischen Referenzen im Modell. */
   id: number;
   name: string;
   weekday: string; // z.B. "Mon", "Tue", ...


### PR DESCRIPTION
## Inhalt
- `shared/src/types.ts`: JSDoc zu `Course`, `Swap`, `CourseDateOverride` (Legacy-ID bleibt für Keys, Swaps, Lesbarkeit).
- `README.md`: kurzer Abschnitt **Kurs-Identifikatoren** mit Link ins Detail-Doc.
- `docs/course-identifiers.md`: Architektur-/Betriebsnotiz (Dynamo, Swaps, GSI, Backfill-Pointer).

## Ticket
Closes #122

## Review
Nur Doku – kein Laufzeitverhalten.