### PR TITLE
Preserve course block window when editing course metadata

### DIFF
--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -478,6 +478,57 @@ describe("CourseList", () => {
     });
   });
 
+  it("überschreibt beim Kursbearbeiten keinen gesetzten Kursblock-Zeitraum", async () => {
+    const adminMembership: UserTenantMembership = {
+      ...baseMembership,
+      role: "admin",
+    };
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Kurzer Block",
+        weekday: "Mon",
+        time: "10:00",
+        capacity: 10,
+        status: "draft",
+        planningMode: "bounded_series",
+        seriesStartDate: "2026-01-05",
+        seriesEndDate: "2026-01-05",
+        visibleFrom: "2026-01-05",
+        visibleUntil: "2026-01-05",
+        participants: [],
+        dates: ["2026-01-05"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+    mockedUpdateCourse.mockResolvedValue({ ...mockCourses[0], name: "Kurzer Block umbenannt" });
+
+    render(<CourseList currentUser={baseUser} tenant={baseTenant} membership={adminMembership} />);
+
+    const user = userEvent.setup();
+    await screen.findByText("Kurzer Block");
+    await user.click(screen.getAllByRole("button", { name: /kurs bearbeiten kurzer block/i })[0]);
+
+    const nameInput = screen.getByLabelText("Kursname bearbeiten");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Kurzer Block umbenannt");
+    await user.click(screen.getByRole("button", { name: /^speichern$/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateCourse).toHaveBeenCalledWith(
+        "1",
+        expect.not.objectContaining({
+          seriesStartDate: expect.any(String),
+          seriesEndDate: expect.any(String),
+        }),
+      );
+    });
+  });
+
   it("setzt Fokus beim Öffnen ins Edit-Modal und hält Tab im Dialog", async () => {
     const adminMembership: UserTenantMembership = {
       ...baseMembership,

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -562,13 +562,15 @@ export default function CourseList({
         setFormError("Kurs nicht gefunden.");
         return;
       }
+      const previousPlanningMode = courseForEdit.planningMode ?? "bounded_series";
+      const planningModeChanged = editState.planningMode !== previousPlanningMode;
       await updateCourse(courseApiPathKey(courseForEdit), {
         name: trimmedName,
         weekday: editState.weekday,
         time: editState.time,
         capacity,
         status: editState.status,
-        ...buildSchedulingFromMode(editState.planningMode),
+        ...(planningModeChanged ? buildSchedulingFromMode(editState.planningMode) : {}),
       });
       closeEditModal();
       await fetchData();

--- a/app/src/components/courseDatesDialogUtils.ts
+++ b/app/src/components/courseDatesDialogUtils.ts
@@ -285,14 +285,18 @@ export function createDatesState(course: Course): CourseDatesEditorState {
   const initialStart =
     course.planningMode === "rolling_continuous"
       ? defaults.start
-      : (course.seriesStartDate ?? defaults.start);
+      : (course.seriesStartDate ?? course.visibleFrom ?? defaults.start);
+  const initialEnd =
+    course.planningMode === "rolling_continuous"
+      ? defaults.end
+      : (course.seriesEndDate ?? course.visibleUntil ?? defaults.end);
   return {
     courseId: course.id,
     weekday: course.weekday,
     planningMode: course.planningMode ?? "bounded_series",
     visibilityHorizonWeeks: normalizeHorizonWeeks(course.visibilityHorizonWeeks),
     seriesStartDate: initialStart,
-    seriesEndDate: course.seriesEndDate ?? defaults.end,
+    seriesEndDate: initialEnd,
     excludedDates: dedupeAndSortDates(course.excludedDates ?? []),
     rangeCalendarMonth: monthKeyFromIsoDate(initialStart) ?? toMonthKey(new Date()),
     excludedCalendarMonth: monthKeyFromIsoDate(initialStart) ?? toMonthKey(new Date()),


### PR DESCRIPTION
## Summary
- Beim Speichern im Kurs-Stammdaten-Dialog werden Planungs-/Serienfelder nur noch mitgeschickt, wenn sich der Planungsmodus geändert hat (nicht bei jeder Änderung von Name, Wochentag, Uhrzeit, Kapazität oder Status).
- Behebt #168: Ein festgelegter Kursblock-Zeitraum wird nicht mehr auf „heute + 90 Tage“ zurückgesetzt.
- Termine-Dialog: Fallback auf `visibleFrom`/`visibleUntil`, wenn Serienfelder fehlen.

## Test plan
- [x] `npm run test --prefix app -- src/components/CourseList.test.tsx -t "überschreibt beim Kursbearbeiten"`
- [ ] Manuell: Kursblock mit kurzem Zeitraum anlegen, Stammdaten ändern → Start/Ende im Termine-Dialog unverändert
- [ ] Manuell: Planungsmodus wechseln → erwartete Defaults (Kursblock: heute+90, rollend: 8 Wochen Horizon)


Made with [Cursor](https://cursor.com)