### PR TITLE
Gate course visibility by status, grace period, and getCourses reconcile

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -116,8 +116,46 @@ body {
 .course-head {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
+  gap: 8px;
   margin-bottom: 8px;
+}
+
+.course-head-title {
+  min-width: 0;
+}
+
+.course-status-badge {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+  padding: 3px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.course-status-badge--inactive {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.course-status-badge--auto {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.course-card--inactive-participant {
+  border-color: #e5e7eb;
+  background: #fafafa;
+}
+
+.course-inactive-notice {
+  margin-top: 4px;
+}
+
+.course-inactive-swap-actions {
+  margin-top: 8px;
 }
 
 .course-row {

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -68,6 +68,26 @@ describe("CourseCard", () => {
     cleanup();
   });
 
+  it("zeigt Badge und Hinweis bei gesperrter Teilnehmer-Ansicht für inaktiven Kurs", () => {
+    const inactiveCourse: Course = {
+      ...baseCourse,
+      status: "inactive",
+      seriesEndDate: "2099-01-01",
+      dates: [],
+    };
+
+    renderCourseCard({
+      course: inactiveCourse,
+      dates: [],
+      overrides: [],
+      participantActionsLocked: true,
+    });
+
+    expect(screen.getByText("Automatisch inaktiv")).toBeInTheDocument();
+    expect(screen.getByText(/automatisch beendet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
+  });
+
   it("zeigt Hinweis, wenn keine zukünftigen Termine vorhanden sind", () => {
     const courseWithoutFutureDates: Course = {
       ...baseCourse,

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,9 +1,12 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
+  buildCourseOccurrenceLocal,
+  courseEndDateIso,
   formatCourseIsoDateDe,
   getInactiveGraceLastDayIso,
   isCourseInInactiveGracePeriod,
+  isWithinPostCourseEndGrace,
   looksLikeAutomaticallyInactive,
 } from "shared/courseStatus";
 import { swapSettings } from "../data/swapSettings";
@@ -150,8 +153,17 @@ export default function CourseCard({
   const hasUpcomingDates = dates.length > 0;
   const courseStatus = course.status ?? "active";
   const isInactiveCourse = courseStatus === "inactive";
-  const inInactiveGrace = isInactiveCourse && isCourseInInactiveGracePeriod(course, tenantSettings);
-  const graceLastIso = inInactiveGrace ? getInactiveGraceLastDayIso(course, tenantSettings) : undefined;
+  const inPostEndGrace = isWithinPostCourseEndGrace(course, tenantSettings);
+  const inInactiveGrace =
+    isInactiveCourse && isCourseInInactiveGracePeriod(course, tenantSettings);
+  const graceLastIso =
+    inPostEndGrace || inInactiveGrace
+      ? getInactiveGraceLastDayIso(course, tenantSettings)
+      : undefined;
+  const lastOccurrenceIso = courseEndDateIso(course);
+  const lastOccurrenceDate =
+    lastOccurrenceIso != null ? buildCourseOccurrenceLocal(lastOccurrenceIso, course.time) : null;
+  const showLastTermInSelect = hasNoUpcomingDates && lastOccurrenceDate != null && inPostEndGrace;
   const showAutoInactiveBadge =
     participantActionsLocked && looksLikeAutomaticallyInactive(course, hasUpcomingDates);
   const userSwapsOnCourse = useMemo(
@@ -167,7 +179,7 @@ export default function CourseCard({
     !participantActionsLocked && hasUpcomingDates && (isParticipant || originallyParticipant);
 
   const inactiveNotice = participantActionsLocked
-    ? showAutoInactiveBadge
+    ? showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
       ? graceLastIso
         ? `Dieser Kurs wurde automatisch beendet (keine weiteren Termine). Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
         : "Dieser Kurs wurde automatisch beendet. Du kannst nur noch bestehende Tausche verwalten."
@@ -175,6 +187,12 @@ export default function CourseCard({
         ? `Dieser Kurs ist inaktiv. Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
         : "Dieser Kurs ist inaktiv. Du kannst nur noch bestehende Tausche verwalten."
     : null;
+
+  useEffect(() => {
+    if (showLastTermInSelect && lastOccurrenceDate) {
+      setSelectedDate(lastOccurrenceDate.toISOString());
+    }
+  }, [showLastTermInSelect, lastOccurrenceIso, course.time, lastOccurrenceDate]);
 
   return (
     <div
@@ -187,13 +205,17 @@ export default function CourseCard({
             {course.weekday} · {course.time}
           </div>
         </div>
-        {participantActionsLocked && isInactiveCourse && (
+        {participantActionsLocked && (
           <span
             className={`course-status-badge ${
-              showAutoInactiveBadge ? "course-status-badge--auto" : "course-status-badge--inactive"
+              showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+                ? "course-status-badge--auto"
+                : "course-status-badge--inactive"
             }`}
           >
-            {showAutoInactiveBadge ? "Automatisch inaktiv" : "Inaktiv"}
+            {showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+              ? "Automatisch inaktiv"
+              : "Inaktiv"}
           </span>
         )}
       </div>
@@ -209,11 +231,15 @@ export default function CourseCard({
       <div className="course-row">
         <div className="muted">Termine:</div>
         <select
-          value={hasNoUpcomingDates ? "" : selectedDate}
+          value={hasNoUpcomingDates && !showLastTermInSelect ? "" : selectedDate}
           onChange={(e) => setSelectedDate(e.target.value)}
-          disabled={hasNoUpcomingDates}
+          disabled={hasNoUpcomingDates && !showLastTermInSelect}
         >
-          {hasNoUpcomingDates ? (
+          {showLastTermInSelect && lastOccurrenceDate ? (
+            <option value={lastOccurrenceDate.toISOString()}>
+              {lastOccurrenceDate.toLocaleDateString()} (letzter Termin)
+            </option>
+          ) : hasNoUpcomingDates ? (
             <option value="">—</option>
           ) : (
             dates

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useState } from "react";
-import { Swap, CourseDateOverride, Course, User } from "shared/types";
+import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
+import {
+  formatCourseIsoDateDe,
+  getInactiveGraceLastDayIso,
+  isCourseInInactiveGracePeriod,
+  looksLikeAutomaticallyInactive,
+} from "shared/courseStatus";
 import { swapSettings } from "../data/swapSettings";
 import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
 
@@ -10,6 +16,9 @@ type Props = {
   dates: Date[];
   overrides: CourseDateOverride[];
   swaps: Swap[];
+  /** Teilnehmer-Ansicht: keine neuen Absagen/Tauschanfragen bei inaktivem Kurs. */
+  participantActionsLocked?: boolean;
+  tenantSettings?: TenantSettings;
   onToggleAbsence: (course: Course, dateIso: string, userName: string) => void;
   confirmSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
   requestSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
@@ -32,6 +41,8 @@ export default function CourseCard({
   dates,
   overrides,
   swaps,
+  participantActionsLocked = false,
+  tenantSettings,
   onToggleAbsence,
   confirmSwap,
   requestSwap,
@@ -136,13 +147,55 @@ export default function CourseCard({
   const pendingCount = pendingSwapsFromOrigin.length;
   const hasPendingRequestsFromOrigin = pendingCount > 0;
 
+  const hasUpcomingDates = dates.length > 0;
+  const courseStatus = course.status ?? "active";
+  const isInactiveCourse = courseStatus === "inactive";
+  const inInactiveGrace = isInactiveCourse && isCourseInInactiveGracePeriod(course, tenantSettings);
+  const graceLastIso = inInactiveGrace ? getInactiveGraceLastDayIso(course, tenantSettings) : undefined;
+  const showAutoInactiveBadge =
+    participantActionsLocked && looksLikeAutomaticallyInactive(course, hasUpcomingDates);
+  const userSwapsOnCourse = useMemo(
+    () =>
+      swaps.filter(
+        (s) =>
+          s.user === userName &&
+          (s.fromCourseId === course.id || s.toCourseId === course.id),
+      ),
+    [swaps, userName, course.id],
+  );
+  const canUseTermActions =
+    !participantActionsLocked && hasUpcomingDates && (isParticipant || originallyParticipant);
+
+  const inactiveNotice = participantActionsLocked
+    ? showAutoInactiveBadge
+      ? graceLastIso
+        ? `Dieser Kurs wurde automatisch beendet (keine weiteren Termine). Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
+        : "Dieser Kurs wurde automatisch beendet. Du kannst nur noch bestehende Tausche verwalten."
+      : graceLastIso
+        ? `Dieser Kurs ist inaktiv. Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
+        : "Dieser Kurs ist inaktiv. Du kannst nur noch bestehende Tausche verwalten."
+    : null;
+
   return (
-    <div className="course-card">
+    <div
+      className={`course-card${participantActionsLocked ? " course-card--inactive-participant" : ""}`}
+    >
       <div className="course-head">
-        <h3>{course.name}</h3>
-        <div className="muted">
-          {course.weekday} · {course.time}
+        <div className="course-head-title">
+          <h3>{course.name}</h3>
+          <div className="muted">
+            {course.weekday} · {course.time}
+          </div>
         </div>
+        {participantActionsLocked && isInactiveCourse && (
+          <span
+            className={`course-status-badge ${
+              showAutoInactiveBadge ? "course-status-badge--auto" : "course-status-badge--inactive"
+            }`}
+          >
+            {showAutoInactiveBadge ? "Automatisch inaktiv" : "Inaktiv"}
+          </span>
+        )}
       </div>
 
       <div className="course-row">
@@ -211,13 +264,19 @@ export default function CourseCard({
         </div>
       </div>
 
-      {hasNoUpcomingDates && (
+      {hasNoUpcomingDates && !participantActionsLocked && (
         <div className="course-row">
           <span className="muted small">Zur Zeit sind keine zukünftigen Termine für diesen Kurs geplant.</span>
         </div>
       )}
 
-      {!hasNoUpcomingDates && (isParticipant || originallyParticipant) ? (
+      {inactiveNotice && (
+        <div className="course-row course-inactive-notice" role="status">
+          <span className="muted small">{inactiveNotice}</span>
+        </div>
+      )}
+
+      {canUseTermActions ? (
         <div className="actions">
           {swapForThisTerm ? (
             <>
@@ -291,7 +350,7 @@ export default function CourseCard({
               )}
         </div>
 
-      ) : !hasNoUpcomingDates ? (
+      ) : !participantActionsLocked && !hasNoUpcomingDates ? (
         <>
           {swapForWaitlist ? (
             <div className="actions">
@@ -307,6 +366,22 @@ export default function CourseCard({
           )}
         </>
       ) : null}
+
+      {participantActionsLocked && userSwapsOnCourse.length > 0 && (
+        <div className="actions course-inactive-swap-actions">
+          {userSwapsOnCourse.map((swap) => (
+            <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
+              <button
+                type="button"
+                className="secondary danger"
+                onClick={() => cancelSwap(swap, course.id)}
+              >
+                {swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Status-Text separat unter den Buttons */}
       {!hasNoUpcomingDates && allSwapsForThisTerm.length > 0 && (
@@ -341,7 +416,7 @@ export default function CourseCard({
         </div>
       )}
       {/* Swap-Modal */}
-      {!hasNoUpcomingDates && showSwapModal && (
+      {canUseTermActions && showSwapModal && (
         <div className="modal-backdrop">
           <div className="modal">
             <h4>

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -37,9 +37,13 @@ const mockedGetSwapsByStatus = getSwapsByStatus as unknown as ReturnType<typeof 
 const mockedGetParticipants = getParticipants as unknown as ReturnType<typeof vi.fn>;
 const mockedCanSeeCourse = canSeeCourse as unknown as ReturnType<typeof vi.fn>;
 
-vi.mock("shared/permissions", () => ({
-  canSeeCourse: vi.fn(),
-}));
+vi.mock("shared/permissions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("shared/permissions")>();
+  return {
+    ...actual,
+    canSeeCourse: vi.fn(),
+  };
+});
 
 const baseUser: User = {
   nickname: "alice",
@@ -117,9 +121,7 @@ describe("CourseList", () => {
     await waitFor(() => {
       expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument();
       expect(
-        screen.queryByText(
-          /Aktuell keine Termine zum Anzeigen\. Es gibt nur vergangene Termine oder noch keine Kurse\./i,
-        ),
+        screen.queryByText(/Aktuell keine Kurse in dieser Ansicht/i),
       ).not.toBeInTheDocument();
     });
   });
@@ -161,11 +163,7 @@ describe("CourseList", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Aktuell keine Termine zum Anzeigen\. Es gibt nur vergangene Termine oder noch keine Kurse\./i,
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Aktuell keine Kurse in dieser Ansicht/i)).toBeInTheDocument();
     });
   });
 
@@ -217,7 +215,7 @@ describe("CourseList", () => {
     });
   });
 
-  it("rendert alle Kurse ohne Filter, wenn kein Tenant und keine Membership übergeben werden", async () => {
+  it("wendet canSeeCourse mit Cognito-Fallback an, wenn kein Tenant/Membership übergeben wird", async () => {
     const mockCourses: Course[] = [
       {
         tenantId: "default-tenant",
@@ -249,14 +247,16 @@ describe("CourseList", () => {
 
     render(<CourseList currentUser={baseUser} />);
 
-    // Kurse werden ohne Filter gerendert (können mehrfach vorkommen)
+    // Standard-Teilnehmer sieht beide aktiven Kurse; Kacheln können mehrfach vorkommen
     const kursAElements = await screen.findAllByText("Kurs A");
     const kursBElements = await screen.findAllByText("Kurs B");
     expect(kursAElements.length).toBeGreaterThan(0);
     expect(kursBElements.length).toBeGreaterThan(0);
 
-    // Ohne Tenant/Membership wird canSeeCourse nicht aufgerufen
-    expect(canSeeCourse).not.toHaveBeenCalled();
+    // Synthetische Membership: canSeeCourse wird pro Kurs aufgerufen (Standard-Teilnehmer sieht beide Kurse)
+    await waitFor(() => {
+      expect(canSeeCourse).toHaveBeenCalled();
+    });
   });
 
   it("zeigt Admin-Kursverwaltung und legt Kurs über Modal an", async () => {

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -29,6 +29,10 @@ import {
   updateCourse,
 } from "../api/courses";
 import { canSeeCourse, canShowParticipantCourseCard } from "shared/permissions";
+import {
+  looksLikeAutomaticallyInactive,
+  wouldAutoDeactivateBoundedSeries,
+} from "shared/courseStatus";
 import { courseApiPathKey } from "../lib/courseUid";
 
 type Props = {
@@ -692,6 +696,14 @@ export default function CourseList({
       <div className="grid">
         {coursesToRender.map((course) => {
           const dates = getCourseDates(course);
+          const hasUpcomingDates = dates.length > 0;
+          const statusLabel =
+            STATUS_OPTIONS.find((entry) => entry.value === (course.status ?? "active"))?.label ?? "Aktiv";
+          const statusHint = looksLikeAutomaticallyInactive(course, hasUpcomingDates)
+            ? " · automatisch inaktiv"
+            : wouldAutoDeactivateBoundedSeries(course, hasUpcomingDates)
+              ? " · wird beim Speichern inaktiv"
+              : "";
           return (
             <div key={course.id}>
               {canSeeCourseManagement && (
@@ -699,8 +711,8 @@ export default function CourseList({
                   <span className="course-card-actions-status">
                     Status:{" "}
                     <strong>
-                      {STATUS_OPTIONS.find((entry) => entry.value === (course.status ?? "active"))?.label ??
-                        "Aktiv"}
+                      {statusLabel}
+                      {statusHint}
                     </strong>
                   </span>
                   <div className="course-card-actions-buttons">
@@ -750,6 +762,10 @@ export default function CourseList({
                 dates={dates}
                 overrides={filteredOverrides}
                 swaps={swaps}
+                participantActionsLocked={
+                  !canSeeCourseManagement && (course.status ?? "active") === "inactive"
+                }
+                tenantSettings={tenant?.settings}
                 onToggleAbsence={onToggleAbsence}
                 confirmSwap={confirmSwap}
                 requestSwap={requestSwap}

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -315,7 +315,24 @@ export default function CourseList({
     );
   }, [courses, tenant?.settings, effectiveMembership, currentUser.nickname]);
 
-  const coursesWithUpcoming = visibleCourses.filter((c) => getCourseDates(c).length > 0);
+  const coursesWithUpcoming = useMemo(() => {
+    const hasUpcomingDates = (c: Course) => getCourseDates(c).length > 0;
+    if (!effectiveMembership) {
+      return visibleCourses.filter(hasUpcomingDates);
+    }
+    const seeCtx = (course: Course) => ({
+      isTaughtByUser: (course.instructors ?? []).some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
+      isBookedByUser: course.participants.some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
+    });
+    return visibleCourses.filter((c) => {
+      if (hasUpcomingDates(c)) return true;
+      // Inaktive Kurse im Nachlauf (#149): keine zukuenftigen Termine, aber noch sichtbar fuer Swaps
+      if (c.status === "inactive") {
+        return canSeeCourse(effectiveMembership, tenant?.settings, c, seeCtx(c));
+      }
+      return false;
+    });
+  }, [visibleCourses, effectiveMembership, tenant?.settings, currentUser.nickname]);
   const coursesToRender = canSeeCourseManagement ? visibleCourses : coursesWithUpcoming;
   const deleteTargetCourse = deleteTargetId
     ? visibleCourses.find((course) => course.id === deleteTargetId)

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -30,6 +30,7 @@ import {
 } from "../api/courses";
 import { canSeeCourse, canShowParticipantCourseCard } from "shared/permissions";
 import {
+  isWithinPostCourseEndGrace,
   looksLikeAutomaticallyInactive,
   wouldAutoDeactivateBoundedSeries,
 } from "shared/courseStatus";
@@ -765,7 +766,9 @@ export default function CourseList({
                 overrides={filteredOverrides}
                 swaps={swaps}
                 participantActionsLocked={
-                  !canSeeCourseManagement && (course.status ?? "active") === "inactive"
+                  !canSeeCourseManagement &&
+                  ((course.status ?? "active") === "inactive" ||
+                    isWithinPostCourseEndGrace(course, tenant?.settings))
                 }
                 tenantSettings={tenant?.settings}
                 onToggleAbsence={onToggleAbsence}

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -16,6 +16,7 @@ import {
   User,
   Tenant,
   UserTenantMembership,
+  DEFAULT_TENANT_ID,
 } from "shared/types";
 import { getSwaps } from "../api/swaps";
 import { getSwapsByStatus } from "../api/swaps";
@@ -27,7 +28,7 @@ import {
   getCourses,
   updateCourse,
 } from "../api/courses";
-import { canSeeCourse } from "shared/permissions";
+import { canSeeCourse, canShowParticipantCourseCard } from "shared/permissions";
 import { courseApiPathKey } from "../lib/courseUid";
 
 type Props = {
@@ -231,8 +232,19 @@ export default function CourseList({
     };
   }, [membership, forceParticipantView, currentUser.nickname]);
 
-  const isAdmin = effectiveMembership?.role === "admin";
-  const isInstructor = effectiveMembership?.role === "instructor";
+  /** Ohne Dynamo-Membership (häufig bei Teilnehmer:innen): Rolle aus Cognito + Tenant für Kachel-Sichtbarkeit. */
+  const membershipForPermissions = useMemo<UserTenantMembership>(() => {
+    if (effectiveMembership) return effectiveMembership;
+    return {
+      userId: currentUser.nickname,
+      tenantId: tenant?.tenantId ?? DEFAULT_TENANT_ID,
+      role: currentUser.role,
+    };
+  }, [effectiveMembership, tenant?.tenantId, currentUser.nickname, currentUser.role]);
+
+  const resolvedRole = effectiveMembership?.role ?? currentUser.role;
+  const isAdmin = resolvedRole === "admin";
+  const isInstructor = resolvedRole === "instructor";
   const canSeeCourseManagement = isAdmin || isInstructor;
   const canManageCourses = isAdmin;
 
@@ -304,36 +316,28 @@ export default function CourseList({
   }, [currentUser?.nickname]);
 
   const visibleCourses = useMemo(() => {
-    if (!tenant?.settings || !effectiveMembership) {
-      return courses;
-    }
     return courses.filter((course) =>
-      canSeeCourse(effectiveMembership, tenant.settings, course, {
+      canSeeCourse(membershipForPermissions, tenant?.settings, course, {
         isTaughtByUser: (course.instructors ?? []).some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
         isBookedByUser: course.participants.some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
       }),
     );
-  }, [courses, tenant?.settings, effectiveMembership, currentUser.nickname]);
+  }, [courses, membershipForPermissions, tenant?.settings, currentUser.nickname]);
 
-  const coursesWithUpcoming = useMemo(() => {
-    const hasUpcomingDates = (c: Course) => getCourseDates(c).length > 0;
-    if (!effectiveMembership) {
-      return visibleCourses.filter(hasUpcomingDates);
-    }
+  const participantCoursesToRender = useMemo(() => {
+    const hasVisibleCourseDates = (c: Course) => getCourseDates(c).length > 0;
     const seeCtx = (course: Course) => ({
       isTaughtByUser: (course.instructors ?? []).some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
       isBookedByUser: course.participants.some((p) => p.toLowerCase() === currentUser.nickname.toLowerCase()),
     });
-    return visibleCourses.filter((c) => {
-      if (hasUpcomingDates(c)) return true;
-      // Inaktive Kurse im Nachlauf (#149): keine zukuenftigen Termine, aber noch sichtbar fuer Swaps
-      if (c.status === "inactive") {
-        return canSeeCourse(effectiveMembership, tenant?.settings, c, seeCtx(c));
-      }
-      return false;
-    });
-  }, [visibleCourses, effectiveMembership, tenant?.settings, currentUser.nickname]);
-  const coursesToRender = canSeeCourseManagement ? visibleCourses : coursesWithUpcoming;
+    return visibleCourses.filter((c) =>
+      canShowParticipantCourseCard(membershipForPermissions, tenant?.settings, c, {
+        ...seeCtx(c),
+        hasVisibleCourseDates: hasVisibleCourseDates(c),
+      }),
+    );
+  }, [visibleCourses, membershipForPermissions, tenant?.settings, currentUser.nickname]);
+  const coursesToRender = canSeeCourseManagement ? visibleCourses : participantCoursesToRender;
   const deleteTargetCourse = deleteTargetId
     ? visibleCourses.find((course) => course.id === deleteTargetId)
     : undefined;
@@ -646,12 +650,12 @@ export default function CourseList({
     return <div role="alert">{error}</div>;
   }
 
-  if (visibleCourses.length === 0 || (!canSeeCourseManagement && coursesWithUpcoming.length === 0)) {
+  if (visibleCourses.length === 0 || (!canSeeCourseManagement && participantCoursesToRender.length === 0)) {
     return (
       <div className="muted" style={{ textAlign: "center", padding: "2rem" }} role="status" aria-live="polite">
         {canSeeCourseManagement
           ? "Aktuell sind noch keine Kurse angelegt."
-          : "Aktuell keine Termine zum Anzeigen. Es gibt nur vergangene Termine oder noch keine Kurse."}
+          : "Aktuell keine Kurse in dieser Ansicht — z. B. keine anstehenden Termine, Kurse in Planung, Sichtbarkeit nach Buchung/Lehrkraft oder abgelaufener Nachlauf bei inaktiven Kursen."}
       </div>
     );
   }

--- a/app/src/lib/dates.ts
+++ b/app/src/lib/dates.ts
@@ -1,19 +1,18 @@
 // lib/dates.ts
 import { CourseDateOverride, Course, User } from "shared/types";
+import { buildCourseOccurrenceLocal } from "shared/courseStatus";
 import type { SwapSettings } from "../types";
 
 export function getCourseDates(course: Course, now: Date = new Date()) {
-  const [hours, minutes] = course.time.split(":").map(Number);
-  return course.dates
+  return (course.dates ?? [])
     .map((d) => {
-      const date = new Date(d);
-      if (isNaN(date.getTime())) {
+      const occurrence = buildCourseOccurrenceLocal(d, course.time);
+      if (!occurrence) {
         console.warn(`Ungültiges Datum in course.dates: ${d} für course ${course.id}`);
-        return null; // Ungültige Daten überspringen
       }
-      return new Date(date.getFullYear(), date.getMonth(), date.getDate(), hours, minutes);
+      return occurrence;
     })
-    .filter((d): d is Date => d !== null) // Type-Guard
+    .filter((d): d is Date => d !== null)
     .filter((d) => d >= now);
 }
 

--- a/app/src/shared/courseStatus.test.ts
+++ b/app/src/shared/courseStatus.test.ts
@@ -41,8 +41,9 @@ describe("courseStatus", () => {
 
   it("prüft upcoming occurrences mit Uhrzeit", () => {
     const term = ["2026-05-18"];
-    const before = new Date("2026-05-18T10:00:00.000+02:00");
-    const after = new Date("2026-05-18T19:00:00.000+02:00");
+    // UTC-Zeiten: CI läuft in UTC; ISO-Datum + lokale Uhrzeit würden sonst vom Offset abweichen.
+    const before = new Date(Date.UTC(2026, 4, 18, 10, 0, 0));
+    const after = new Date(Date.UTC(2026, 4, 18, 19, 0, 0));
     expect(hasUpcomingCourseOccurrences(term, "18:00", before)).toBe(true);
     expect(hasUpcomingCourseOccurrences(term, "18:00", after)).toBe(false);
     expect(

--- a/app/src/shared/courseStatus.test.ts
+++ b/app/src/shared/courseStatus.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   courseEndDateIso,
   getInactiveGraceLastDayIso,
+  hasUpcomingCourseOccurrences,
   isCourseInInactiveGracePeriod,
+  isWithinPostCourseEndGrace,
   looksLikeAutomaticallyInactive,
   wouldAutoDeactivateBoundedSeries,
 } from "shared/courseStatus";
@@ -35,6 +37,21 @@ describe("courseStatus", () => {
     expect(isCourseInInactiveGracePeriod(inactive, undefined, within)).toBe(true);
     expect(isCourseInInactiveGracePeriod(inactive, undefined, after)).toBe(false);
     expect(getInactiveGraceLastDayIso(inactive)).toBe("2026-05-17");
+  });
+
+  it("prüft upcoming occurrences mit Uhrzeit", () => {
+    const term = ["2026-05-18"];
+    const before = new Date("2026-05-18T10:00:00.000+02:00");
+    const after = new Date("2026-05-18T19:00:00.000+02:00");
+    expect(hasUpcomingCourseOccurrences(term, "18:00", before)).toBe(true);
+    expect(hasUpcomingCourseOccurrences(term, "18:00", after)).toBe(false);
+    expect(
+      isWithinPostCourseEndGrace(
+        { ...baseCourse, dates: term, time: "18:00", seriesEndDate: "2026-05-18" },
+        undefined,
+        after,
+      ),
+    ).toBe(true);
   });
 
   it("erkennt auto-inaktiv-Heuristik und pending deactivation", () => {

--- a/app/src/shared/courseStatus.test.ts
+++ b/app/src/shared/courseStatus.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  courseEndDateIso,
+  getInactiveGraceLastDayIso,
+  isCourseInInactiveGracePeriod,
+  looksLikeAutomaticallyInactive,
+  wouldAutoDeactivateBoundedSeries,
+} from "shared/courseStatus";
+import type { Course } from "shared/types";
+
+const baseCourse: Course = {
+  id: 1,
+  name: "Test",
+  weekday: "Mon",
+  time: "10:00",
+  capacity: 10,
+  participants: [],
+  dates: [],
+  planningMode: "bounded_series",
+};
+
+describe("courseStatus", () => {
+  it("ermittelt Kursende aus seriesEndDate", () => {
+    expect(courseEndDateIso({ ...baseCourse, seriesEndDate: "2026-05-10" })).toBe("2026-05-10");
+  });
+
+  it("prüft Nachlauf für inaktive Kurse", () => {
+    const inactive = {
+      ...baseCourse,
+      status: "inactive" as const,
+      seriesEndDate: "2026-05-10",
+    };
+    const within = new Date(Date.UTC(2026, 4, 15, 12, 0, 0));
+    const after = new Date(Date.UTC(2026, 4, 20, 12, 0, 0));
+    expect(isCourseInInactiveGracePeriod(inactive, undefined, within)).toBe(true);
+    expect(isCourseInInactiveGracePeriod(inactive, undefined, after)).toBe(false);
+    expect(getInactiveGraceLastDayIso(inactive)).toBe("2026-05-17");
+  });
+
+  it("erkennt auto-inaktiv-Heuristik und pending deactivation", () => {
+    const inactive = { ...baseCourse, status: "inactive" as const };
+    const active = { ...baseCourse, status: "active" as const };
+    expect(looksLikeAutomaticallyInactive(inactive, false)).toBe(true);
+    expect(looksLikeAutomaticallyInactive(active, false)).toBe(false);
+    expect(wouldAutoDeactivateBoundedSeries(active, false)).toBe(true);
+    expect(wouldAutoDeactivateBoundedSeries(active, true)).toBe(false);
+  });
+});

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -316,6 +316,24 @@ describe("permissions", () => {
       ).toBe(false);
     });
 
+    it("zeigt aktiven Ein-Termin-Kurs im Nachlauf nach Terminbeginn ohne zukuenftige Termine", () => {
+      const endedToday = {
+        ...dummyCourse,
+        status: "active" as const,
+        seriesEndDate: "2026-05-18",
+        dates: ["2026-05-18"],
+        time: "18:00",
+      };
+      const afterTerm = new Date("2026-05-18T19:00:00.000+02:00");
+      expect(
+        canShowParticipantCourseCard(participantMembership, defaultSettings, endedToday, {
+          ...baseCtx,
+          hasVisibleCourseDates: false,
+          now: afterTerm,
+        }),
+      ).toBe(true);
+    });
+
     it("zeigt inaktiven Kurs im Nachlauf auch ohne sichtbare Termine", () => {
       const inactiveEnded = {
         ...dummyCourse,

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -206,6 +206,94 @@ describe("permissions", () => {
         }),
       ).toBe(true);
     });
+
+    it("blendet Participant Kurse in draft aus", () => {
+      const draft = { ...dummyCourse, status: "draft" as const };
+      expect(
+        canSeeCourse(participantMembership, defaultSettings, draft, {
+          isTaughtByUser: true,
+          isBookedByUser: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("erlaubt Instructor draft-Kurse bei Zuordnung (Planung), nicht ohne", () => {
+      const draft = { ...dummyCourse, status: "draft" as const };
+      expect(
+        canSeeCourse(instructorMembership, restrictiveSettings, draft, {
+          isTaughtByUser: true,
+          isBookedByUser: false,
+        }),
+      ).toBe(true);
+      expect(
+        canSeeCourse(instructorMembership, restrictiveSettings, draft, {
+          isTaughtByUser: false,
+          isBookedByUser: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("zeigt Participant inaktive Kurse nur im Nachlauf (UTC) nach Kursende", () => {
+      const inactiveEnded = {
+        ...dummyCourse,
+        status: "inactive" as const,
+        seriesEndDate: "2026-05-10",
+      };
+      const withinGrace = new Date(Date.UTC(2026, 4, 17, 12, 0, 0));
+      expect(
+        canSeeCourse(participantMembership, defaultSettings, inactiveEnded, {
+          isTaughtByUser: false,
+          isBookedByUser: false,
+          now: withinGrace,
+        }),
+      ).toBe(true);
+
+      const afterGrace = new Date(Date.UTC(2026, 4, 18, 12, 0, 0));
+      expect(
+        canSeeCourse(participantMembership, defaultSettings, inactiveEnded, {
+          isTaughtByUser: false,
+          isBookedByUser: false,
+          now: afterGrace,
+        }),
+      ).toBe(false);
+    });
+
+    it("respektiert inactiveGraceDaysAfterCourseEnd im Tenant", () => {
+      const inactiveEnded = {
+        ...dummyCourse,
+        status: "inactive" as const,
+        seriesEndDate: "2026-05-10",
+      };
+      const dayAfterShortGrace = new Date(Date.UTC(2026, 4, 14, 12, 0, 0));
+      expect(
+        canSeeCourse(
+          participantMembership,
+          { ...defaultSettings, inactiveGraceDaysAfterCourseEnd: 3 },
+          inactiveEnded,
+          {
+            isTaughtByUser: false,
+            isBookedByUser: false,
+            now: dayAfterShortGrace,
+          },
+        ),
+      ).toBe(false);
+    });
+
+    it("blendet inaktiven Kurs fuer Participant aus, wenn Buchungs-/Instructor-Restriktion greift", () => {
+      const inactiveEnded = {
+        ...dummyCourse,
+        status: "inactive" as const,
+        seriesEndDate: "2026-05-10",
+      };
+      const withinGrace = new Date(Date.UTC(2026, 4, 12, 12, 0, 0));
+      expect(
+        canSeeCourse(participantMembership, restrictiveSettings, inactiveEnded, {
+          isTaughtByUser: false,
+          isBookedByUser: false,
+          now: withinGrace,
+        }),
+      ).toBe(false);
+    });
   });
 
   describe("canStartDelegationForCourse", () => {

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -324,7 +324,7 @@ describe("permissions", () => {
         dates: ["2026-05-18"],
         time: "18:00",
       };
-      const afterTerm = new Date("2026-05-18T19:00:00.000+02:00");
+      const afterTerm = new Date(Date.UTC(2026, 4, 18, 19, 0, 0));
       expect(
         canShowParticipantCourseCard(participantMembership, defaultSettings, endedToday, {
           ...baseCtx,

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -6,6 +6,7 @@ import {
   canStartDelegationForCourse,
   canSeeAllCourses,
   canSeeCourse,
+  canShowParticipantCourseCard,
 } from "shared/permissions";
 import type {
   UserTenantMembership,
@@ -291,6 +292,57 @@ describe("permissions", () => {
           isTaughtByUser: false,
           isBookedByUser: false,
           now: withinGrace,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("canShowParticipantCourseCard", () => {
+    const baseCtx = { isTaughtByUser: false, isBookedByUser: false };
+
+    it("zeigt aktiven Kurs nur mit sichtbaren Terminen", () => {
+      const withDate = { ...dummyCourse, dates: ["2026-06-01"] };
+      expect(
+        canShowParticipantCourseCard(participantMembership, defaultSettings, withDate, {
+          ...baseCtx,
+          hasVisibleCourseDates: true,
+        }),
+      ).toBe(true);
+      expect(
+        canShowParticipantCourseCard(participantMembership, defaultSettings, withDate, {
+          ...baseCtx,
+          hasVisibleCourseDates: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("zeigt inaktiven Kurs im Nachlauf auch ohne sichtbare Termine", () => {
+      const inactiveEnded = {
+        ...dummyCourse,
+        status: "inactive" as const,
+        seriesEndDate: "2026-05-10",
+        dates: [],
+      };
+      const withinGrace = new Date(Date.UTC(2026, 4, 12, 12, 0, 0));
+      expect(
+        canShowParticipantCourseCard(participantMembership, defaultSettings, inactiveEnded, {
+          ...baseCtx,
+          hasVisibleCourseDates: false,
+          now: withinGrace,
+        }),
+      ).toBe(true);
+    });
+
+    it("blendet draft auch mit Terminen aus", () => {
+      const draftWithDate = {
+        ...dummyCourse,
+        status: "draft" as const,
+        dates: ["2026-06-01"],
+      };
+      expect(
+        canShowParticipantCourseCard(participantMembership, defaultSettings, draftWithDate, {
+          ...baseCtx,
+          hasVisibleCourseDates: true,
         }),
       ).toBe(false);
     });

--- a/backend/src/lambdas/createCourse/index.ts
+++ b/backend/src/lambdas/createCourse/index.ts
@@ -2,7 +2,11 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { GetItemCommand, PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
-import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
+import {
+  deriveVisibleDates,
+  hasUpcomingCourseOccurrences,
+  pruneScheduleExceptions,
+} from "../shared/courseDates";
 import { generateCourseUid } from "../shared/courseUid";
 
 const client = dynamoClient;
@@ -211,10 +215,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       includedDates,
       fallbackDates: [],
     });
-    const todayIso = new Date().toISOString().slice(0, 10);
-    const hasFutureVisibleDates = visibleDates.some((entry) => entry >= todayIso);
+    const hasUpcomingOccurrences = hasUpcomingCourseOccurrences(visibleDates, time, new Date());
     const effectiveStatus =
-      status === "active" && planningMode === "bounded_series" && !hasFutureVisibleDates
+      status === "active" && planningMode === "bounded_series" && !hasUpcomingOccurrences
         ? "inactive"
         : status;
     if (effectiveStatus !== status) {

--- a/backend/src/lambdas/getCourses/index.test.ts
+++ b/backend/src/lambdas/getCourses/index.test.ts
@@ -162,6 +162,47 @@ describe("getCourses Lambda", () => {
     jest.useRealTimers();
   });
 
+  test("reconciles to inactive when same-day term time has passed", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-18T19:00:00.000+02:00"));
+
+    mockSend
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            id: { N: "4" },
+            courseId: { S: "4" },
+            name: { S: "Ein Termin heute" },
+            weekday: { S: "Mon" },
+            time: { S: "18:00" },
+            capacity: { N: "10" },
+            status: { S: "active" },
+            planningMode: { S: "bounded_series" },
+            visibilityMode: { S: "fixed_window" },
+            seriesStartDate: { S: "2026-05-18" },
+            seriesEndDate: { S: "2026-05-18" },
+            visibleFrom: { S: "2026-05-18" },
+            visibleUntil: { S: "2026-05-18" },
+            participants: { L: [{ S: "alice" }] },
+            dates: { L: [{ S: "2026-05-18" }] },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)[0].status).toBe("inactive");
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({ status: { S: "inactive" } }),
+      }),
+    );
+
+    jest.useRealTimers();
+  });
+
   test("derives visible dates from bounded series with fixed window and exclusions", async () => {
     mockSend.mockResolvedValueOnce({
       Items: [

--- a/backend/src/lambdas/getCourses/index.test.ts
+++ b/backend/src/lambdas/getCourses/index.test.ts
@@ -164,7 +164,7 @@ describe("getCourses Lambda", () => {
 
   test("reconciles to inactive when same-day term time has passed", async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date("2026-05-18T19:00:00.000+02:00"));
+    jest.setSystemTime(new Date(Date.UTC(2026, 4, 18, 19, 0, 0)));
 
     mockSend
       .mockResolvedValueOnce({

--- a/backend/src/lambdas/getCourses/index.test.ts
+++ b/backend/src/lambdas/getCourses/index.test.ts
@@ -7,11 +7,12 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
   return {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     QueryCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
     mockSend,
   };
 });
 
-const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+const { mockSend, PutItemCommand } = jest.requireMock("@aws-sdk/client-dynamodb");
 
 describe("getCourses Lambda", () => {
   const OLD_ENV = process.env;
@@ -115,6 +116,50 @@ describe("getCourses Lambda", () => {
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body).error).toBe("Failed to get courses");
+  });
+
+  test("reconciles active bounded_series without future dates to inactive on read", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+
+    mockSend
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            tenantId: { S: "default-tenant" },
+            id: { N: "3" },
+            courseId: { S: "3" },
+            name: { S: "Abgelaufen" },
+            weekday: { S: "Mon" },
+            time: { S: "10:00" },
+            capacity: { N: "10" },
+            status: { S: "active" },
+            planningMode: { S: "bounded_series" },
+            visibilityMode: { S: "fixed_window" },
+            seriesStartDate: { S: "2020-01-01" },
+            seriesEndDate: { S: "2020-01-31" },
+            visibleFrom: { S: "2020-01-01" },
+            visibleUntil: { S: "2020-01-31" },
+            participants: { L: [] },
+            dates: { L: [{ S: "2020-01-06" }] },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body[0].status).toBe("inactive");
+    expect(PutItemCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          status: { S: "inactive" },
+        }),
+      }),
+    );
+
+    jest.useRealTimers();
   });
 
   test("derives visible dates from bounded series with fixed window and exclusions", async () => {

--- a/backend/src/lambdas/getCourses/index.ts
+++ b/backend/src/lambdas/getCourses/index.ts
@@ -120,6 +120,7 @@ export const handler = async (
         planningMode,
         visibleDates,
         storedDates: fallbackDates,
+        courseTime: item.time?.S ?? "",
         now,
       });
 

--- a/backend/src/lambdas/getCourses/index.ts
+++ b/backend/src/lambdas/getCourses/index.ts
@@ -1,10 +1,54 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 import { deriveVisibleDates } from "../shared/courseDates";
+import { computeCourseReconcile } from "../shared/courseReconcile";
 
 const client = dynamoClient;
+
+function mapItemToCourseResponse(
+  item: Record<string, AttributeValue>,
+  visibleDates: string[],
+  effectiveStatus: string,
+) {
+  const excludedDates = item.excludedDates?.L
+    ? item.excludedDates.L.map((d) => d.S).filter(Boolean) as string[]
+    : [];
+  const includedDates = item.includedDates?.L
+    ? item.includedDates.L.map((d) => d.S).filter(Boolean) as string[]
+    : [];
+  const planningMode = item.planningMode?.S;
+  const visibilityMode = item.visibilityMode?.S;
+
+  return {
+    id: Number(item.id?.N ?? item.courseId?.S ?? 0),
+    courseId: item.courseId?.S,
+    ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
+    name: item.name.S!,
+    weekday: item.weekday.S!,
+    time: item.time.S!,
+    capacity: Number(item.capacity.N!),
+    status: effectiveStatus,
+    planningMode,
+    visibilityMode,
+    seriesStartDate: item.seriesStartDate?.S,
+    seriesEndDate: item.seriesEndDate?.S,
+    visibleFrom: item.visibleFrom?.S,
+    visibleUntil: item.visibleUntil?.S,
+    visibilityHorizonWeeks: item.visibilityHorizonWeeks?.N
+      ? Number(item.visibilityHorizonWeeks.N)
+      : undefined,
+    excludedDates,
+    includedDates,
+    visibleDates,
+    participants: item.participants?.L
+      ? item.participants.L.map((p) => p.S).filter(Boolean)
+      : [],
+    dates: visibleDates,
+  };
+}
 
 export const handler = async (
   event: APIGatewayProxyEvent,
@@ -21,12 +65,12 @@ export const handler = async (
 
   try {
     const { tenantId, userId } = getTenantContext(event);
-    console.log('getCourses tenant context', { tenantId, userId });
+    console.log("getCourses tenant context", { tenantId, userId });
 
     const result = await client.send(
       new QueryCommand({
         TableName: tableName,
-        KeyConditionExpression: "tenantId = :tid", // :tid = Platzhalter für tenantId (PK)
+        KeyConditionExpression: "tenantId = :tid",
         ExpressionAttributeValues: { ":tid": { S: tenantId } },
         ConsistentRead: true,
       }),
@@ -34,21 +78,26 @@ export const handler = async (
 
     const items = result.Items || [];
     if (items.length === 0) {
-      console.log(
-        "getCourses: Query returned 0 items for tenantId=",
-        tenantId,
-      );
+      console.log("getCourses: Query returned 0 items for tenantId=", tenantId);
     }
-    const courses = items.map((item) => {
-      const fallbackDates = item.dates?.L ? item.dates.L.map((d: any) => d.S).filter(Boolean) : [];
+
+    const now = new Date();
+    const courses = [];
+
+    for (const item of items) {
+      const fallbackDates = item.dates?.L
+        ? item.dates.L.map((d) => d.S).filter(Boolean) as string[]
+        : [];
       const excludedDates = item.excludedDates?.L
-        ? item.excludedDates.L.map((d: any) => d.S).filter(Boolean)
+        ? item.excludedDates.L.map((d) => d.S).filter(Boolean) as string[]
         : [];
       const includedDates = item.includedDates?.L
-        ? item.includedDates.L.map((d: any) => d.S).filter(Boolean)
+        ? item.includedDates.L.map((d) => d.S).filter(Boolean) as string[]
         : [];
       const planningMode = item.planningMode?.S;
       const visibilityMode = item.visibilityMode?.S;
+      const storedStatus = item.status?.S ?? "active";
+
       const visibleDates = deriveVisibleDates({
         planningMode,
         visibilityMode,
@@ -63,37 +112,63 @@ export const handler = async (
         excludedDates,
         includedDates,
         fallbackDates,
+        now,
       });
 
-      return {
-        id: Number(item.id?.N ?? item.courseId?.S ?? 0),
-        courseId: item.courseId?.S,
-        ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
-        name: item.name.S!,
-        weekday: item.weekday.S!,
-        time: item.time.S!,
-        capacity: Number(item.capacity.N!),
-        status: item.status?.S ?? "active",
+      const reconcile = computeCourseReconcile({
+        storedStatus,
         planningMode,
-        visibilityMode,
-        seriesStartDate: item.seriesStartDate?.S,
-        seriesEndDate: item.seriesEndDate?.S,
-        visibleFrom: item.visibleFrom?.S,
-        visibleUntil: item.visibleUntil?.S,
-        visibilityHorizonWeeks: item.visibilityHorizonWeeks?.N
-          ? Number(item.visibilityHorizonWeeks.N)
-          : undefined,
-        excludedDates,
-        includedDates,
         visibleDates,
-        participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
-        dates: visibleDates,
-      };
-    });
+        storedDates: fallbackDates,
+        now,
+      });
+
+      if (reconcile.shouldPersist) {
+        const persistedItem: Record<string, AttributeValue> = {
+          ...item,
+          status: { S: reconcile.effectiveStatus },
+          dates: { L: reconcile.visibleDates.map((entry) => ({ S: entry })) },
+        };
+        await client.send(
+          new PutItemCommand({
+            TableName: tableName,
+            Item: persistedItem,
+          }),
+        );
+        if (reconcile.statusChanged) {
+          console.info(
+            JSON.stringify({
+              actor: "system",
+              timestamp: now.toISOString(),
+              courseId: item.courseId?.S,
+              reason: "empty_future_schedule",
+              source: "getCourses_reconcile",
+              previousStatus: storedStatus,
+              nextStatus: reconcile.effectiveStatus,
+            }),
+          );
+        }
+        if (reconcile.datesChanged) {
+          console.info(
+            JSON.stringify({
+              actor: "system",
+              timestamp: now.toISOString(),
+              courseId: item.courseId?.S,
+              reason: "derived_dates_sync",
+              source: "getCourses_reconcile",
+            }),
+          );
+        }
+      }
+
+      courses.push(
+        mapItemToCourseResponse(item, reconcile.visibleDates, reconcile.effectiveStatus),
+      );
+    }
 
     return { statusCode: 200, body: JSON.stringify(courses) };
   } catch (error) {
-    console.error('Error getting courses:', error);
-    return { statusCode: 500, body: JSON.stringify({ error: 'Failed to get courses' }) };
+    console.error("Error getting courses:", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to get courses" }) };
   }
 };

--- a/backend/src/lambdas/shared/courseDates.ts
+++ b/backend/src/lambdas/shared/courseDates.ts
@@ -203,3 +203,26 @@ export function deriveVisibleDates(input: DeriveVisibleDatesInput): string[] {
 
   return Array.from(visibleSet).sort((a, b) => a.localeCompare(b));
 }
+
+const TIME_HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/** Lokaler Kursbeginn (abgestimmt mit App `getCourseDates`). */
+export function buildCourseOccurrenceLocal(isoDate: string, time: string): Date | null {
+  if (!ISO_DATE_ONLY.test(isoDate.trim()) || !TIME_HHMM.test(time.trim())) return null;
+  const [hours, minutes] = time.split(":").map(Number);
+  const base = new Date(isoDate);
+  if (Number.isNaN(base.getTime())) return null;
+  return new Date(base.getFullYear(), base.getMonth(), base.getDate(), hours, minutes);
+}
+
+export function hasUpcomingCourseOccurrences(
+  dateIsos: string[],
+  time: string,
+  now: Date = new Date(),
+): boolean {
+  for (const iso of dateIsos) {
+    const occurrence = buildCourseOccurrenceLocal(iso, time);
+    if (occurrence && occurrence >= now) return true;
+  }
+  return false;
+}

--- a/backend/src/lambdas/shared/courseReconcile.test.ts
+++ b/backend/src/lambdas/shared/courseReconcile.test.ts
@@ -28,7 +28,7 @@ describe("courseReconcile", () => {
         "bounded_series",
         termToday,
         "18:00",
-        new Date("2026-05-18T10:00:00.000+02:00"),
+        new Date(Date.UTC(2026, 4, 18, 10, 0, 0)),
       ),
     ).toBe("active");
     expect(
@@ -37,7 +37,7 @@ describe("courseReconcile", () => {
         "bounded_series",
         termToday,
         "18:00",
-        new Date("2026-05-18T19:00:00.000+02:00"),
+        new Date(Date.UTC(2026, 4, 18, 19, 0, 0)),
       ),
     ).toBe("inactive");
   });

--- a/backend/src/lambdas/shared/courseReconcile.test.ts
+++ b/backend/src/lambdas/shared/courseReconcile.test.ts
@@ -1,0 +1,64 @@
+import {
+  computeCourseReconcile,
+  dateListsEqual,
+  resolveEffectiveCourseStatus,
+} from "./courseReconcile";
+
+describe("courseReconcile", () => {
+  const pastOnly = ["2020-01-06", "2020-01-13"];
+  const future = ["2099-06-02"];
+
+  test("auto-inactivates active bounded_series without future visible dates", () => {
+    expect(
+      resolveEffectiveCourseStatus("active", "bounded_series", pastOnly, new Date("2026-05-18")),
+    ).toBe("inactive");
+  });
+
+  test("keeps active when future visible dates exist", () => {
+    expect(
+      resolveEffectiveCourseStatus("active", "bounded_series", future, new Date("2026-05-18")),
+    ).toBe("active");
+  });
+
+  test("does not change draft or inactive status", () => {
+    expect(resolveEffectiveCourseStatus("draft", "bounded_series", pastOnly)).toBe("draft");
+    expect(resolveEffectiveCourseStatus("inactive", "bounded_series", future)).toBe("inactive");
+  });
+
+  test("computeCourseReconcile flags persist when status or dates drift", () => {
+    const statusOnly = computeCourseReconcile({
+      storedStatus: "active",
+      planningMode: "bounded_series",
+      visibleDates: pastOnly,
+      storedDates: pastOnly,
+      now: new Date("2026-05-18"),
+    });
+    expect(statusOnly.shouldPersist).toBe(true);
+    expect(statusOnly.statusChanged).toBe(true);
+    expect(statusOnly.datesChanged).toBe(false);
+
+    const datesOnly = computeCourseReconcile({
+      storedStatus: "active",
+      planningMode: "rolling_continuous",
+      visibleDates: future,
+      storedDates: pastOnly,
+      now: new Date("2026-05-18"),
+    });
+    expect(datesOnly.shouldPersist).toBe(true);
+    expect(datesOnly.statusChanged).toBe(false);
+    expect(datesOnly.datesChanged).toBe(true);
+
+    const noop = computeCourseReconcile({
+      storedStatus: "active",
+      planningMode: "bounded_series",
+      visibleDates: future,
+      storedDates: future,
+      now: new Date("2026-05-18"),
+    });
+    expect(noop.shouldPersist).toBe(false);
+  });
+
+  test("dateListsEqual ignores order", () => {
+    expect(dateListsEqual(["2026-01-02", "2026-01-01"], ["2026-01-01", "2026-01-02"])).toBe(true);
+  });
+});

--- a/backend/src/lambdas/shared/courseReconcile.test.ts
+++ b/backend/src/lambdas/shared/courseReconcile.test.ts
@@ -8,21 +8,49 @@ describe("courseReconcile", () => {
   const pastOnly = ["2020-01-06", "2020-01-13"];
   const future = ["2099-06-02"];
 
-  test("auto-inactivates active bounded_series without future visible dates", () => {
+  test("auto-inactivates active bounded_series without upcoming occurrences (date only)", () => {
     expect(
-      resolveEffectiveCourseStatus("active", "bounded_series", pastOnly, new Date("2026-05-18")),
+      resolveEffectiveCourseStatus(
+        "active",
+        "bounded_series",
+        pastOnly,
+        "18:00",
+        new Date("2026-05-18T12:00:00.000Z"),
+      ),
     ).toBe("inactive");
   });
 
-  test("keeps active when future visible dates exist", () => {
+  test("keeps active on term day until course time has passed", () => {
+    const termToday = ["2026-05-18"];
     expect(
-      resolveEffectiveCourseStatus("active", "bounded_series", future, new Date("2026-05-18")),
+      resolveEffectiveCourseStatus(
+        "active",
+        "bounded_series",
+        termToday,
+        "18:00",
+        new Date("2026-05-18T10:00:00.000+02:00"),
+      ),
+    ).toBe("active");
+    expect(
+      resolveEffectiveCourseStatus(
+        "active",
+        "bounded_series",
+        termToday,
+        "18:00",
+        new Date("2026-05-18T19:00:00.000+02:00"),
+      ),
+    ).toBe("inactive");
+  });
+
+  test("keeps active when future occurrence exists", () => {
+    expect(
+      resolveEffectiveCourseStatus("active", "bounded_series", future, "18:00", new Date("2026-05-18")),
     ).toBe("active");
   });
 
   test("does not change draft or inactive status", () => {
-    expect(resolveEffectiveCourseStatus("draft", "bounded_series", pastOnly)).toBe("draft");
-    expect(resolveEffectiveCourseStatus("inactive", "bounded_series", future)).toBe("inactive");
+    expect(resolveEffectiveCourseStatus("draft", "bounded_series", pastOnly, "18:00")).toBe("draft");
+    expect(resolveEffectiveCourseStatus("inactive", "bounded_series", future, "18:00")).toBe("inactive");
   });
 
   test("computeCourseReconcile flags persist when status or dates drift", () => {
@@ -31,7 +59,8 @@ describe("courseReconcile", () => {
       planningMode: "bounded_series",
       visibleDates: pastOnly,
       storedDates: pastOnly,
-      now: new Date("2026-05-18"),
+      courseTime: "18:00",
+      now: new Date("2026-05-18T12:00:00.000Z"),
     });
     expect(statusOnly.shouldPersist).toBe(true);
     expect(statusOnly.statusChanged).toBe(true);
@@ -42,6 +71,7 @@ describe("courseReconcile", () => {
       planningMode: "rolling_continuous",
       visibleDates: future,
       storedDates: pastOnly,
+      courseTime: "18:00",
       now: new Date("2026-05-18"),
     });
     expect(datesOnly.shouldPersist).toBe(true);
@@ -53,6 +83,7 @@ describe("courseReconcile", () => {
       planningMode: "bounded_series",
       visibleDates: future,
       storedDates: future,
+      courseTime: "18:00",
       now: new Date("2026-05-18"),
     });
     expect(noop.shouldPersist).toBe(false);

--- a/backend/src/lambdas/shared/courseReconcile.ts
+++ b/backend/src/lambdas/shared/courseReconcile.ts
@@ -1,21 +1,23 @@
 /**
  * Lazy reconcile for course reads (#149): align persisted status/dates with derived schedule.
- * Same auto-inactive rule as createCourse/updateCourse (bounded_series, no future visible dates).
+ * Auto-inactive when no upcoming occurrence (date + time), aligned with app getCourseDates.
  */
+
+import { hasUpcomingCourseOccurrences } from "./courseDates";
 
 export function resolveEffectiveCourseStatus(
   storedStatus: string,
   planningMode: string | undefined,
   visibleDates: string[],
+  courseTime: string,
   now: Date = new Date(),
 ): string {
-  const todayIso = now.toISOString().slice(0, 10);
-  const hasFutureVisibleDates = visibleDates.some((entry) => entry >= todayIso);
   const status = storedStatus || "active";
+  const hasUpcoming = hasUpcomingCourseOccurrences(visibleDates, courseTime, now);
   if (
     status === "active" &&
     (planningMode ?? "bounded_series") === "bounded_series" &&
-    !hasFutureVisibleDates
+    !hasUpcoming
   ) {
     return "inactive";
   }
@@ -46,6 +48,7 @@ export function computeCourseReconcile(input: {
   planningMode?: string;
   visibleDates: string[];
   storedDates: string[];
+  courseTime: string;
   now?: Date;
 }): CourseReconcileOutcome {
   const now = input.now ?? new Date();
@@ -53,6 +56,7 @@ export function computeCourseReconcile(input: {
     input.storedStatus,
     input.planningMode,
     input.visibleDates,
+    input.courseTime,
     now,
   );
   const statusChanged = effectiveStatus !== (input.storedStatus || "active");

--- a/backend/src/lambdas/shared/courseReconcile.ts
+++ b/backend/src/lambdas/shared/courseReconcile.ts
@@ -1,0 +1,67 @@
+/**
+ * Lazy reconcile for course reads (#149): align persisted status/dates with derived schedule.
+ * Same auto-inactive rule as createCourse/updateCourse (bounded_series, no future visible dates).
+ */
+
+export function resolveEffectiveCourseStatus(
+  storedStatus: string,
+  planningMode: string | undefined,
+  visibleDates: string[],
+  now: Date = new Date(),
+): string {
+  const todayIso = now.toISOString().slice(0, 10);
+  const hasFutureVisibleDates = visibleDates.some((entry) => entry >= todayIso);
+  const status = storedStatus || "active";
+  if (
+    status === "active" &&
+    (planningMode ?? "bounded_series") === "bounded_series" &&
+    !hasFutureVisibleDates
+  ) {
+    return "inactive";
+  }
+  return status;
+}
+
+export function sortedDateList(values: string[]): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+export function dateListsEqual(a: string[], b: string[]): boolean {
+  const left = sortedDateList(a);
+  const right = sortedDateList(b);
+  if (left.length !== right.length) return false;
+  return left.every((entry, index) => entry === right[index]);
+}
+
+export type CourseReconcileOutcome = {
+  effectiveStatus: string;
+  visibleDates: string[];
+  shouldPersist: boolean;
+  statusChanged: boolean;
+  datesChanged: boolean;
+};
+
+export function computeCourseReconcile(input: {
+  storedStatus: string;
+  planningMode?: string;
+  visibleDates: string[];
+  storedDates: string[];
+  now?: Date;
+}): CourseReconcileOutcome {
+  const now = input.now ?? new Date();
+  const effectiveStatus = resolveEffectiveCourseStatus(
+    input.storedStatus,
+    input.planningMode,
+    input.visibleDates,
+    now,
+  );
+  const statusChanged = effectiveStatus !== (input.storedStatus || "active");
+  const datesChanged = !dateListsEqual(input.storedDates, input.visibleDates);
+  return {
+    effectiveStatus,
+    visibleDates: input.visibleDates,
+    shouldPersist: statusChanged || datesChanged,
+    statusChanged,
+    datesChanged,
+  };
+}

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -7,7 +7,11 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getTenantContext } from "../shared/tenantContext";
-import { deriveVisibleDates, pruneScheduleExceptions } from "../shared/courseDates";
+import {
+  deriveVisibleDates,
+  hasUpcomingCourseOccurrences,
+  pruneScheduleExceptions,
+} from "../shared/courseDates";
 import { generateCourseUid, resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 
 const client = dynamoClient;
@@ -524,10 +528,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       includedDates: nextIncludedDates,
       fallbackDates: item.dates?.L?.map((entry) => entry.S ?? "").filter(Boolean) ?? [],
     });
-    const todayIso = new Date().toISOString().slice(0, 10);
-    const hasFutureVisibleDates = nextDates.some((entry) => entry >= todayIso);
+    const hasUpcomingOccurrences = hasUpcomingCourseOccurrences(nextDates, nextTime, new Date());
     let effectiveStatus = nextStatus;
-    if (effectiveStatus === "active" && nextPlanningMode === "bounded_series" && !hasFutureVisibleDates) {
+    if (
+      effectiveStatus === "active" &&
+      nextPlanningMode === "bounded_series" &&
+      !hasUpcomingOccurrences
+    ) {
       effectiveStatus = "inactive";
       console.info(
         JSON.stringify({

--- a/docs/course-status-visibility.md
+++ b/docs/course-status-visibility.md
@@ -1,0 +1,175 @@
+# Kursstatus, Sichtbarkeit und Auto-Transition (#149)
+
+Dokumentation zum Verhalten ab Issue [#149](https://github.com/CurlyKarin/yogaswap/issues/149): welche Kurse Teilnehmer:innen sehen, wann ein Kursblock automatisch `inactive` wird, und wie der Nachlauf mit dem Tauschfenster zusammenhängt.
+
+## Kurzfassung
+
+| Thema | Verhalten |
+|--------|-----------|
+| **`draft`** | Teilnehmer:innen sehen den Kurs nicht. |
+| **`active`** | Normale Sichtbarkeit; Termine über `getCourseDates` (Datum + Uhrzeit ≥ jetzt). |
+| **`active` → `inactive`** | Automatisch bei **Kursblock** (`bounded_series`), wenn kein Termin mehr in der Zukunft liegt (Datum **und** Uhrzeit). |
+| **Nachlauf** | Nach Kursende bleibt ein **`inactive`** Kurs für Teilnehmer:innen noch **X Kalendertage** sichtbar (Default **7**, UTC). |
+| **Lazy Reconcile** | Beim **`GET /courses`** (`get-courses` Lambda) werden Status und abgeleitete `dates` bei Bedarf in DynamoDB nachgezogen. |
+
+Studio-Konfiguration für den Nachlauf perspektivisch über Tenant-Settings ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)), siehe Abschnitt [Nachlauf und Tauschfenster](#nachlauf-und-tauschfenster).
+
+---
+
+## Sichtbarkeit nach Rolle
+
+```mermaid
+flowchart LR
+  subgraph participant [Teilnehmer:in]
+    P1{status?}
+    P1 -->|draft| PH[nicht sichtbar]
+    P1 -->|active| PA[sichtbar mit Zukunftsterminen]
+    P1 -->|inactive| PI{Nachlauf?}
+    PI -->|ja| PG[Kachel sichtbar, letzter Termin, eingeschränkte Aktionen]
+    PI -->|nein| PH
+  end
+
+  subgraph admin [Admin / Instructor Verwaltung]
+    A1[Status filtert nicht]
+    A2[immer in Kursliste wenn Berechtigung]
+  end
+```
+
+**Quelle im Code:** `shared/src/permissions.ts` — `canSeeCourse`, `canShowParticipantCourseCard`.
+
+Teilnehmer-Kachel auch **ohne Zukunftstermine**, wenn:
+
+- `inactive` im Nachlauf, oder
+- `active`, Termin vorbei, aber noch innerhalb des Nachlaufs (`isWithinPostCourseEndGrace` — Übergangsphase bis Reconcile).
+
+---
+
+## Automatischer Übergang `active` → `inactive`
+
+Gilt nur für **`bounded_series`** (Kursblock), nicht für durchlaufende Kurse (`rolling_continuous`, siehe [#165](https://github.com/CurlyKarin/yogaswap/issues/165)).
+
+**Bedingung:** Kein Eintrag in den abgeleiteten sichtbaren Terminen (`visibleDates`), dessen **Kursbeginn** (ISO-Datum + `time`) noch ≥ jetzt ist.
+
+```mermaid
+flowchart TD
+  A[Gespeicherter status: active] --> B[visibleDates aus Planungsmodell ableiten]
+  B --> C{bounded_series?}
+  C -->|nein| Z[status unverändert]
+  C -->|ja| D{noch Termin mit Start >= jetzt?}
+  D -->|ja| Z
+  D -->|nein| E[effectiveStatus: inactive]
+  E --> F{Persistieren}
+  F --> G[Antwort + DynamoDB]
+```
+
+**Auslöser (gleiche Regel):**
+
+| Pfad | Lambda / Handler |
+|------|------------------|
+| Kursliste laden | `get-courses` → `GET /courses` |
+| Kurs speichern | `update-course` → `PUT /courses/{id}` |
+| Kurs anlegen | `create-course` → `POST /courses` |
+
+**Wichtig:** Die alte Prüfung nur auf Kalendertag (`datum >= heute`) würde am **Termintag** noch `active` lassen. Aktuell gilt überall **Datum + Uhrzeit** (`hasUpcomingCourseOccurrences` in `shared/src/courseStatus.ts` bzw. `backend/src/lambdas/shared/courseDates.ts`).
+
+Manuelles `active` → `inactive` bleibt an bestehende Guards gebunden (offene Termine, Swaps, Teilnehmer) — nur in `updateCourse`, nicht beim Lazy Reconcile.
+
+---
+
+## Lazy Reconcile in `getCourses`
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant API as API GET /courses
+  participant Lambda as get-courses
+  participant DDB as DynamoDB courses
+
+  App->>API: Kursliste laden
+  API->>Lambda: invoke
+  Lambda->>DDB: Query tenantId
+  loop pro Kurs
+    Lambda->>Lambda: deriveVisibleDates
+    Lambda->>Lambda: computeCourseReconcile
+    alt status oder dates geändert
+      Lambda->>DDB: PutItem
+      Lambda->>Lambda: Log getCourses_reconcile
+    end
+  end
+  Lambda-->>App: JSON mit effectiveStatus + dates
+```
+
+**Lambda:** `get-courses` (ZIP: `getCourses.zip`, Code: `backend/src/lambdas/getCourses/index.ts`).
+
+**IAM:** `dynamodb:PutItem` auf der Courses-Tabelle (Terraform: `get_courses` in `projects/yogaswap/main.tf`).
+
+**Logs (CloudWatch):** u. a. `reason: empty_future_schedule`, `source: getCourses_reconcile`.
+
+Deploy ändert **keine** bestehenden Kurse von selbst — der Effekt entsteht beim **nächsten** erfolgreichen `GET /courses` nach Ausrollen der Lambda.
+
+---
+
+## Nachlauf und Tauschfenster
+
+Nach dem **letzten Kursende** (`courseEndDateIso`: `seriesEndDate` → `visibleUntil` → max aus `dates`) bleiben inaktive Kursblöcke für Teilnehmer:innen noch sichtbar:
+
+```
+letzterTagNachlauf = Kursende + inactiveGraceDaysAfterCourseEnd   (Kalendertage, UTC)
+```
+
+| Einstellung | Ort (aktuell) | Default |
+|-------------|---------------|---------|
+| Nachlauf nach Kursende | `TenantSettings.inactiveGraceDaysAfterCourseEnd` | **7** |
+| Tauschfenster (App-Demo) | `app/src/data/swapSettings.ts` (`minOffsetDays` / `maxOffsetDays`) | **-7 / +7** |
+
+**Produktentscheidung (#149):** Nachlauf und Swap-Fenster sollen **dieselbe Konfigurationsfamilie** nutzen (nicht zwei willkürlich getrennte Konstanten). Bis die Studio-UI ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)) das abbildet, ist der Nachlauf-Default an `maxOffsetDays` angeglichen.
+
+Im Nachlauf:
+
+- Kurskachel mit Badge „Automatisch inaktiv“ / „Inaktiv“
+- **Letzter Termin** im Dropdown (auch ohne Zukunftstermine in `getCourseDates`)
+- Keine neuen Absagen/Tauschanfragen; offene Swaps noch verwalten (Hinweistext mit Enddatum des Nachlaufs)
+
+**Quelle:** `shared/src/courseStatus.ts`, `app/src/components/CourseCard.tsx`, `app/src/components/CourseList.tsx`.
+
+---
+
+## Admin-Hinweise in der UI
+
+| Anzeige | Bedeutung |
+|---------|-----------|
+| **wird beim Speichern inaktiv** | DB noch `active`, aber keine Zukunftstermine (heuristisch `wouldAutoDeactivateBoundedSeries`) |
+| **automatisch inaktiv** | `inactive` und typisch per Auto-Transition gesetzt |
+
+Nach erfolgreichem Reconcile verschwindet „wird beim Speichern inaktiv“ zugunsten von **Inaktiv** / **automatisch inaktiv**.
+
+---
+
+## Relevante Dateien
+
+| Bereich | Datei |
+|---------|--------|
+| Permissions | `shared/src/permissions.ts` |
+| Kursende / Nachlauf / Occurrences | `shared/src/courseStatus.ts` |
+| Tenant-Typ | `shared/src/types.ts` (`inactiveGraceDaysAfterCourseEnd`) |
+| Reconcile-Logik | `backend/src/lambdas/shared/courseReconcile.ts` |
+| GET Kurse | `backend/src/lambdas/getCourses/index.ts` |
+| Terminliste UI | `app/src/lib/dates.ts` (`getCourseDates`) |
+| Kurskarte | `app/src/components/CourseCard.tsx` |
+
+---
+
+## Mermaid in Cursor anzeigen
+
+Diese Datei in Cursor öffnen → **Markdown-Vorschau** (`Cmd+Shift+V` / `Ctrl+Shift+V`). Mermaid-Blöcke werden in der Vorschau gerendert.
+
+Extern: [mermaid.live](https://mermaid.live) oder GitHub nach Push.
+
+---
+
+## Siehe auch
+
+- [#149](https://github.com/CurlyKarin/yogaswap/issues/149) — Umsetzung Sichtbarkeit + Auto-Transition
+- [#44](https://github.com/CurlyKarin/yogaswap/issues/44) — Studio-Settings (Tauschfenster + geplanter Nachlauf)
+- [#129](https://github.com/CurlyKarin/yogaswap/issues/129) — Lifecycle-Guardrails (`updateCourse` / Prune)
+- [#165](https://github.com/CurlyKarin/yogaswap/issues/165) — Rollende Kurse mit optionalem Ende

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -134,7 +134,7 @@ locals {
       name             = "get-courses"
       file_name        = "getCourses.zip"
       table_arns       = [module.courses_table.table_arn]
-      dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem"]
+      dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem", "dynamodb:PutItem"]
       tables = {
         "COURSES_TABLE" = module.courses_table.table_name
       }

--- a/shared/src/courseStatus.ts
+++ b/shared/src/courseStatus.ts
@@ -4,6 +4,29 @@ import type { Course, TenantSettings } from "./types";
 export const DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END = 7;
 
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/** Lokaler Kursbeginn (gleiche Logik wie `getCourseDates` in der App). */
+export function buildCourseOccurrenceLocal(isoDate: string, time: string): Date | null {
+  if (!ISO_DATE_ONLY.test(isoDate.trim()) || !TIME_HHMM.test(time.trim())) return null;
+  const [hours, minutes] = time.split(":").map(Number);
+  const base = new Date(isoDate);
+  if (Number.isNaN(base.getTime())) return null;
+  return new Date(base.getFullYear(), base.getMonth(), base.getDate(), hours, minutes);
+}
+
+/** Mindestens ein Termin liegt in der Zukunft (Datum + Uhrzeit). */
+export function hasUpcomingCourseOccurrences(
+  dateIsos: string[],
+  time: string,
+  now: Date = new Date(),
+): boolean {
+  for (const iso of dateIsos) {
+    const occurrence = buildCourseOccurrenceLocal(iso, time);
+    if (occurrence && occurrence >= now) return true;
+  }
+  return false;
+}
 
 export function toIsoDateUtc(d: Date): string {
   return d.toISOString().slice(0, 10);
@@ -52,9 +75,24 @@ export function isCourseInInactiveGracePeriod(
   now: Date = new Date(),
 ): boolean {
   if ((course.status ?? "active") !== "inactive") return false;
-  const lastGraceIso = getInactiveGraceLastDayIso(course, settings);
-  if (!lastGraceIso) return false;
-  return toIsoDateUtc(now) <= lastGraceIso;
+  return isWithinPostCourseEndGrace(course, settings, now);
+}
+
+/**
+ * Nach Kursende (letzter Termin vorbei), innerhalb des Nachlaufs — auch wenn Status noch `active`
+ * (z. B. vor getCourses-Reconcile).
+ */
+export function isWithinPostCourseEndGrace(
+  course: Pick<Course, "dates" | "time" | "seriesEndDate" | "visibleUntil" | "status">,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  const endIso = courseEndDateIso(course);
+  if (!endIso) return false;
+  if (hasUpcomingCourseOccurrences(course.dates ?? [], course.time, now)) return false;
+  const graceDays = settings?.inactiveGraceDaysAfterCourseEnd ?? DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+  const lastGraceInclusiveIso = addCalendarDaysIsoUtc(endIso, graceDays);
+  return toIsoDateUtc(now) <= lastGraceInclusiveIso;
 }
 
 /**

--- a/shared/src/courseStatus.ts
+++ b/shared/src/courseStatus.ts
@@ -1,0 +1,89 @@
+import type { Course, TenantSettings } from "./types";
+
+/** Default-Nachlauf in Tagen (an app swapSettings.maxOffsetDays angeglichen). */
+export const DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END = 7;
+
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export function toIsoDateUtc(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function addCalendarDaysIsoUtc(iso: string, days: number): string {
+  const [y, m, day] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, day));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * Letztes Kursende (YYYY-MM-DD) fuer Nachlauf bei inaktiven Kursen:
+ * seriesEndDate, sonst visibleUntil, sonst groesstes gueltiges Datum in `dates`.
+ */
+export function courseEndDateIso(
+  course: Pick<Course, "seriesEndDate" | "visibleUntil" | "dates">,
+): string | undefined {
+  const series = course.seriesEndDate?.trim();
+  if (series && ISO_DATE_ONLY.test(series)) return series;
+  const visible = course.visibleUntil?.trim();
+  if (visible && ISO_DATE_ONLY.test(visible)) return visible;
+  const raw = course.dates ?? [];
+  const valid = raw.filter((d) => typeof d === "string" && ISO_DATE_ONLY.test(d.trim()));
+  if (valid.length === 0) return undefined;
+  const trimmed = valid.map((d) => d.trim());
+  trimmed.sort((a, b) => b.localeCompare(a));
+  return trimmed[0];
+}
+
+export function getInactiveGraceLastDayIso(
+  course: Pick<Course, "seriesEndDate" | "visibleUntil" | "dates" | "status">,
+  settings?: TenantSettings,
+): string | undefined {
+  const endIso = courseEndDateIso(course);
+  if (!endIso) return undefined;
+  const graceDays = settings?.inactiveGraceDaysAfterCourseEnd ?? DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+  return addCalendarDaysIsoUtc(endIso, graceDays);
+}
+
+/** Teilnehmer-Nachlauf: heute (UTC) liegt noch im Fenster nach Kursende. */
+export function isCourseInInactiveGracePeriod(
+  course: Course,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  if ((course.status ?? "active") !== "inactive") return false;
+  const lastGraceIso = getInactiveGraceLastDayIso(course, settings);
+  if (!lastGraceIso) return false;
+  return toIsoDateUtc(now) <= lastGraceIso;
+}
+
+/**
+ * Entspricht der Backend-Regel in updateCourse (bounded_series ohne Zukunftstermine).
+ * `hasUpcomingDates` kommt vom Aufrufer (z. B. getCourseDates.length > 0).
+ */
+export function wouldAutoDeactivateBoundedSeries(
+  course: Course,
+  hasUpcomingDates: boolean,
+): boolean {
+  const status = course.status ?? "active";
+  const planningMode = course.planningMode ?? "bounded_series";
+  return status === "active" && planningMode === "bounded_series" && !hasUpcomingDates;
+}
+
+/**
+ * Heuristik ohne DB-Feld: inaktiver Kursblock ohne Zukunftstermine (typisch auto-gesetzt).
+ */
+export function looksLikeAutomaticallyInactive(
+  course: Course,
+  hasUpcomingDates: boolean,
+): boolean {
+  if ((course.status ?? "active") !== "inactive") return false;
+  const planningMode = course.planningMode ?? "bounded_series";
+  return planningMode === "bounded_series" && !hasUpcomingDates;
+}
+
+export function formatCourseIsoDateDe(iso: string): string {
+  return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeZone: "UTC" }).format(
+    new Date(`${iso}T12:00:00.000Z`),
+  );
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,5 @@
 // shared/src/index.ts
 export * from './types';
+export * from './courseStatus';
 export * from './lib/storage';
 export * from './data/mockUsers';

--- a/shared/src/permissions.ts
+++ b/shared/src/permissions.ts
@@ -2,7 +2,9 @@ import {
   addCalendarDaysIsoUtc,
   courseEndDateIso,
   DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END,
+  isWithinPostCourseEndGrace,
   toIsoDateUtc,
+  wouldAutoDeactivateBoundedSeries,
 } from "./courseStatus";
 import type {
   Course,
@@ -209,6 +211,15 @@ export function canShowParticipantCourseCard(
 ): boolean {
   if (!canSeeCourse(membership, settings, course, context)) return false;
   if (context.hasVisibleCourseDates) return true;
-  return (course.status ?? "active") === "inactive";
+  const status = course.status ?? "active";
+  if (status === "inactive") return true;
+  const now = context.now ?? new Date();
+  if (
+    wouldAutoDeactivateBoundedSeries(course, context.hasVisibleCourseDates) &&
+    isWithinPostCourseEndGrace(course, settings, now)
+  ) {
+    return true;
+  }
+  return false;
 }
 

--- a/shared/src/permissions.ts
+++ b/shared/src/permissions.ts
@@ -1,3 +1,9 @@
+import {
+  addCalendarDaysIsoUtc,
+  courseEndDateIso,
+  DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END,
+  toIsoDateUtc,
+} from "./courseStatus";
 import type {
   Course,
   ParticipantStatus,
@@ -121,41 +127,6 @@ export function canSeeAllCourses(
   return false;
 }
 
-/** Default-Nachlauf in Tagen (an app swapSettings.maxOffsetDays angeglichen). */
-const DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END = 7;
-
-const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-
-function toIsoDateUtc(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function addCalendarDaysIsoUtc(iso: string, days: number): string {
-  const [y, m, day] = iso.split("-").map(Number);
-  const dt = new Date(Date.UTC(y, m - 1, day));
-  dt.setUTCDate(dt.getUTCDate() + days);
-  return dt.toISOString().slice(0, 10);
-}
-
-/**
- * Letztes Kursende (YYYY-MM-DD) fuer Teilnehmer-Nachlauf bei inaktiven Kursen:
- * seriesEndDate, sonst visibleUntil, sonst groesstes gueltiges Datum in `dates`.
- */
-function courseEndDateIsoForInactiveGrace(
-  course: Pick<Course, "seriesEndDate" | "visibleUntil" | "dates">,
-): string | undefined {
-  const series = course.seriesEndDate?.trim();
-  if (series && ISO_DATE_ONLY.test(series)) return series;
-  const visible = course.visibleUntil?.trim();
-  if (visible && ISO_DATE_ONLY.test(visible)) return visible;
-  const raw = course.dates ?? [];
-  const valid = raw.filter((d) => typeof d === "string" && ISO_DATE_ONLY.test(d.trim()));
-  if (valid.length === 0) return undefined;
-  const trimmed = valid.map((d) => d.trim());
-  trimmed.sort((a, b) => b.localeCompare(a));
-  return trimmed[0];
-}
-
 function participantBaseVisible(
   settings: TenantSettings | undefined,
   context: { isTaughtByUser?: boolean; isBookedByUser?: boolean },
@@ -208,7 +179,7 @@ export function canSeeCourse(
   if (status === "draft") return false;
 
   if (status === "inactive") {
-    const endIso = courseEndDateIsoForInactiveGrace(course);
+    const endIso = courseEndDateIso(course);
     if (!endIso) return false;
     const graceDays = settings?.inactiveGraceDaysAfterCourseEnd ?? DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
     const lastGraceInclusiveIso = addCalendarDaysIsoUtc(endIso, graceDays);

--- a/shared/src/permissions.ts
+++ b/shared/src/permissions.ts
@@ -218,3 +218,26 @@ export function canSeeCourse(
   return participantBaseVisible(settings, context);
 }
 
+/**
+ * Teilnehmer-Kursliste (Kacheln): Kurs anzeigen, wenn {@link canSeeCourse} zutrifft und
+ * entweder sichtbare Termine existieren (`hasVisibleCourseDates`, z. B. aus
+ * `getCourseDates`) oder der Kurs `inactive` ist (Nachlauf ohne aktuelle Termine).
+ *
+ * Admin/Instructor-Listen nutzen `visibleCourses` direkt, nicht diese Funktion.
+ */
+export function canShowParticipantCourseCard(
+  membership: UserTenantMembership,
+  settings: TenantSettings | undefined,
+  course: Course,
+  context: {
+    isTaughtByUser?: boolean;
+    isBookedByUser?: boolean;
+    now?: Date;
+    hasVisibleCourseDates: boolean;
+  },
+): boolean {
+  if (!canSeeCourse(membership, settings, course, context)) return false;
+  if (context.hasVisibleCourseDates) return true;
+  return (course.status ?? "active") === "inactive";
+}
+

--- a/shared/src/permissions.ts
+++ b/shared/src/permissions.ts
@@ -8,11 +8,10 @@ import type {
 /**
  * Hinweis:
  * Diese Datei ist die fachliche Source-of-Truth fuer Permissions.
- * Aktuell existiert zusaetzlich eine technische Kopie in
- * `backend/src/lambdas/shared/permissions.ts`, damit Backend-Tests/Lambda-Bundles
- * ohne ESM/Jest-Interop-Probleme laufen.
- * Bei Aenderungen bitte beide Stellen synchron halten, bis die Build-Toolchain
- * vereinheitlicht ist.
+ * In `backend/src/lambdas/shared/permissions.ts` liegt eine technische Teilkopie
+ * (nur Lambda-relevante Hilfen); `canSeeCourse` und weitere UI-Funktionen dort
+ * ergaenzen, sobald das Backend sie braucht. Build: `shared` vor App-Tests bauen
+ * (`npm run build --prefix shared`), da Vite `shared` auf `shared/dist` alias.
  */
 
 /**
@@ -122,14 +121,66 @@ export function canSeeAllCourses(
   return false;
 }
 
+/** Default-Nachlauf in Tagen (an app swapSettings.maxOffsetDays angeglichen). */
+const DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END = 7;
+
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function toIsoDateUtc(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addCalendarDaysIsoUtc(iso: string, days: number): string {
+  const [y, m, day] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, day));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * Letztes Kursende (YYYY-MM-DD) fuer Teilnehmer-Nachlauf bei inaktiven Kursen:
+ * seriesEndDate, sonst visibleUntil, sonst groesstes gueltiges Datum in `dates`.
+ */
+function courseEndDateIsoForInactiveGrace(
+  course: Pick<Course, "seriesEndDate" | "visibleUntil" | "dates">,
+): string | undefined {
+  const series = course.seriesEndDate?.trim();
+  if (series && ISO_DATE_ONLY.test(series)) return series;
+  const visible = course.visibleUntil?.trim();
+  if (visible && ISO_DATE_ONLY.test(visible)) return visible;
+  const raw = course.dates ?? [];
+  const valid = raw.filter((d) => typeof d === "string" && ISO_DATE_ONLY.test(d.trim()));
+  if (valid.length === 0) return undefined;
+  const trimmed = valid.map((d) => d.trim());
+  trimmed.sort((a, b) => b.localeCompare(a));
+  return trimmed[0];
+}
+
+function participantBaseVisible(
+  settings: TenantSettings | undefined,
+  context: { isTaughtByUser?: boolean; isBookedByUser?: boolean },
+): boolean {
+  if (settings?.participantsSeeOnlyOwnInstructors) {
+    return !!context.isBookedByUser || !!context.isTaughtByUser;
+  }
+  return true;
+}
+
 /**
  * Sichtbarkeitscheck auf Kurs-Ebene.
  * Der Aufrufer entscheidet, ob er bereits alle Kurse gefiltert hat
  * (z. B. durch canSeeAllCourses) oder hier pro Kurs filtern möchte.
  *
- * Für einen echten Teilnehmer-Fall müsste hier zusätzlich
- * Kontext über "eigene Instructor:innen" / Buchungen übergeben werden.
- * Das ist bewusst noch nicht ausmodelliert und kann später erweitert werden.
+ * Teilnehmer:innen:
+ * - `draft`: nie sichtbar
+ * - `inactive`: nur im Nachlauf (Kursende + TenantSettings.inactiveGraceDaysAfterCourseEnd,
+ *   Default 7 Tage) und nur wenn die bestehende Buchungs-/Instructor-Logik zutrifft
+ * - `active` / ohne Status: wie bisher
+ *
+ * Instructor:innen / Admins: Status filtert die Sichtbarkeit nicht (Planung / Verwaltung).
+ *
+ * `context.now` optional (Default: `new Date()`); fuer Tests oder deterministische UI
+ * explizit setzen. Nachlauf vergleicht Kalendertage in UTC (ISO-Datum).
  */
 export function canSeeCourse(
   membership: UserTenantMembership,
@@ -138,8 +189,14 @@ export function canSeeCourse(
   context: {
     isTaughtByUser?: boolean;
     isBookedByUser?: boolean;
+    /** Referenzzeit fuer inaktiven Nachlauf; Default `new Date()`. */
+    now?: Date;
   },
 ): boolean {
+  const refNow = context.now ?? new Date();
+  const todayIso = toIsoDateUtc(refNow);
+  const status = course.status ?? "active";
+
   if (membership.role === "admin") return true;
 
   if (membership.role === "instructor") {
@@ -148,11 +205,16 @@ export function canSeeCourse(
   }
 
   // Participant
-  if (settings?.participantsSeeOnlyOwnInstructors) {
-    return !!context.isBookedByUser || !!context.isTaughtByUser;
+  if (status === "draft") return false;
+
+  if (status === "inactive") {
+    const endIso = courseEndDateIsoForInactiveGrace(course);
+    if (!endIso) return false;
+    const graceDays = settings?.inactiveGraceDaysAfterCourseEnd ?? DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+    const lastGraceInclusiveIso = addCalendarDaysIsoUtc(endIso, graceDays);
+    if (todayIso > lastGraceInclusiveIso) return false;
   }
 
-  // Default: Teilnehmer:in sieht alle freigeschalteten Kurse
-  return true;
+  return participantBaseVisible(settings, context);
 }
 

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -159,6 +159,13 @@ export interface TenantSettings {
    * Geplante Nachschaerfung nach Rollout via Tenant-Policy.
    */
   delegationCanManageActiveParticipants?: boolean;
+  /**
+   * Kalendertage nach dem letzten sichtbaren Kursende: inaktive Kurse bleiben fuer
+   * Teilnehmer:innen in Listen sichtbar (Swap-/Nachlauf-Fenster). Vergleich erfolgt
+   * in UTC (YYYY-MM-DD). Default im Code: 7 — fachlich an Swap maxOffsetDays gekoppelt,
+   * bis Studio-Einstellungen das Feld setzen.
+   */
+  inactiveGraceDaysAfterCourseEnd?: number;
 }
 
 // Verknüpfung zwischen User und Tenant inkl. Rolle und optionalen Overrides.


### PR DESCRIPTION
## Summary
- Teilnehmer:innen sehen `draft` nicht; inaktive Kursblöcke nur im Nachlauf (Default 7 Tage nach Kursende, UTC).
- Auto-Transition `active` → `inactive` für Kursblöcke ohne Zukunftstermin (Datum + Uhrzeit); Lazy Reconcile in `get-courses` beim `GET /courses`.
- UI: Badges, eingeschränkte Teilnehmer-Aktionen im Nachlauf, letzter Termin in der Kachel; Cognito-Fallback für Permissions.
- Doku: `docs/course-status-visibility.md` (inkl. Mermaid); Verweis auf #44 für gekoppelte Studio-Settings (Nachlauf ↔ Tauschfenster).

Closes #149

## Test plan
- [x] `npm run test --prefix shared` (permissions, courseStatus)
- [x] `npm run test --prefix backend -- getCourses courseReconcile`
- [x] `npm run test --prefix app -- src/shared/permissions.test.ts src/shared/courseStatus.test.ts`
- [ ] Nach Merge/Deploy: `npm run build --prefix shared` vor App-Build
- [ ] Manuell: Kursblock mit abgelaufenem Termin → Reload setzt `inactive`, TN sieht Kachel im Nachlauf mit letztem Termin
- [ ] Manuell: `draft`-Kurs für Teilnehmer nicht sichtbar
- [ ] Terraform: `get-courses` mit `dynamodb:PutItem` applied

## Follow-ups (nicht in diesem PR)
- #44 — `inactiveGraceDaysAfterCourseEnd` und Swap-Fenster in Studio-Settings
- #164 — Wochenansicht
- #165 — Rollende Kurse mit Ende


Made with [Cursor](https://cursor.com)