### PR TITLE
Allow empty bounded courses to deactivate and delete (#166)

### DIFF
--- a/app/src/api/courses.ts
+++ b/app/src/api/courses.ts
@@ -99,16 +99,33 @@ export async function createCourse(request: CreateCourseRequest): Promise<Course
   return mapApiCourseToCourse(response.data);
 }
 
+function apiErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const backendError =
+      typeof error.response?.data?.error === "string" ? error.response.data.error : undefined;
+    return backendError ?? fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
 export async function updateCourse(courseId: number | string, request: UpdateCourseRequest): Promise<Course> {
-  const response = await axios.put<ApiCourse>(`/courses/${encodeURIComponent(String(courseId))}`, request);
-  return mapApiCourseToCourse(response.data);
+  try {
+    const response = await axios.put<ApiCourse>(`/courses/${encodeURIComponent(String(courseId))}`, request);
+    return mapApiCourseToCourse(response.data);
+  } catch (error) {
+    throw new Error(apiErrorMessage(error, "Kurs konnte nicht gespeichert werden."));
+  }
 }
 
 export async function deleteCourse(courseId: number | string): Promise<DeleteCourseResponse> {
-  const response = await axios.delete<DeleteCourseResponse>(
-    `/courses/${encodeURIComponent(String(courseId))}`,
-  );
-  return response.data;
+  try {
+    const response = await axios.delete<DeleteCourseResponse>(
+      `/courses/${encodeURIComponent(String(courseId))}`,
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(apiErrorMessage(error, "Kurs konnte nicht gelöscht werden."));
+  }
 }
 
 export async function cancelCourseDate(

--- a/backend/src/lambdas/deleteCourse/index.test.ts
+++ b/backend/src/lambdas/deleteCourse/index.test.ts
@@ -64,6 +64,10 @@ describe("deleteCourse Lambda", () => {
       SWAPS_TABLE: "test-swaps",
     };
     mockSend.mockReset();
+    (GetItemCommand as unknown as jest.Mock).mockClear();
+    (DeleteItemCommand as unknown as jest.Mock).mockClear();
+    (QueryCommand as unknown as jest.Mock).mockClear();
+    (ScanCommand as unknown as jest.Mock).mockClear();
   });
 
   afterAll(() => {
@@ -103,30 +107,55 @@ describe("deleteCourse Lambda", () => {
     expect(JSON.parse(result.body).error).toBe(deleteError);
   });
 
-  test("blocks delete when future dates exist", async () => {
+  test("allows delete for inactive course without participants despite future dates", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
       .mockResolvedValueOnce({
         Item: { ...baseCourseItem("inactive"), dates: { L: [{ S: tomorrow.toISOString().slice(0, 10) }] } },
-      });
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
     const result = await handler(makeEvent());
-    expect(result.statusCode).toBe(400);
-    expect(JSON.parse(result.body).error).toBe(deleteError);
+    expect(result.statusCode).toBe(200);
+    expect(DeleteItemCommand).toHaveBeenCalled();
   });
 
-  test("blocks delete when open overrides exist", async () => {
+  test("blocks delete when open overrides with waitlist exist", async () => {
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
       .mockResolvedValueOnce({ Item: baseCourseItem("inactive") })
       .mockResolvedValueOnce({
-        Items: [{ date: { S: new Date().toISOString().slice(0, 10) }, participants: { L: [{ S: "luna" }] } }],
+        Items: [
+          {
+            date: { S: "2099-01-06" },
+            participants: { L: [] },
+            waitlist: { L: [{ S: "luna" }] },
+          },
+        ],
       });
     const result = await handler(makeEvent());
     expect(result.statusCode).toBe(400);
     expect(QueryCommand).toHaveBeenCalled();
     expect(ScanCommand).not.toHaveBeenCalled();
+  });
+
+  test("allows delete when override only has stale participants", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({ Item: baseCourseItem("inactive") })
+      .mockResolvedValueOnce({
+        Items: [{ date: { S: "2099-01-06" }, participants: { L: [{ S: "luna" }] } }],
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+    expect(DeleteItemCommand).toHaveBeenCalled();
   });
 
   test("blocks delete when open swaps exist", async () => {

--- a/backend/src/lambdas/deleteCourse/index.ts
+++ b/backend/src/lambdas/deleteCourse/index.ts
@@ -8,22 +8,12 @@ import {
 import { dynamoClient } from "../shared/dynamoClient";
 import { resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 import { getTenantContext } from "../shared/tenantContext";
+import {
+  hasBlockingUpcomingCourseDates,
+  overrideBlocksCourseLifecycle,
+} from "../shared/courseLifecycle";
 
 const client = dynamoClient;
-
-function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
-  const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) return false;
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  return date >= startOfToday;
-}
-
-function hasAnyListEntries(item: Record<string, { L?: Array<{ S?: string }> }>): boolean {
-  const participantsCount = item.participants?.L?.length ?? 0;
-  const swappedCount = item.swapped?.L?.length ?? 0;
-  const waitlistCount = item.waitlist?.L?.length ?? 0;
-  return participantsCount > 0 || swappedCount > 0 || waitlistCount > 0;
-}
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const coursesTable = process.env.COURSES_TABLE;
@@ -115,10 +105,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const now = new Date();
-    const hasUpcomingDates = (item.dates?.L ?? []).some((d) =>
-      d.S ? isFutureOrTodayDateString(d.S, now) : false,
-    );
-    if (hasUpcomingDates) {
+    const courseTime = item.time?.S ?? "";
+    const storedDates = (item.dates?.L ?? []).map((d) => d.S ?? "").filter(Boolean);
+    if (hasBlockingUpcomingCourseDates(storedDates, courseTime, now, participantsCount > 0)) {
       return {
         statusCode: 400,
         body: JSON.stringify({
@@ -139,13 +128,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         },
       }),
     );
-    const hasOpenOverrides = (overridesResp.Items ?? []).some((overrideItem) => {
-      const dateValue = overrideItem.date?.S;
-      if (!dateValue || !isFutureOrTodayDateString(dateValue, now)) return false;
-      return hasAnyListEntries(
-        overrideItem as unknown as Record<string, { L?: Array<{ S?: string }> }>,
-      );
-    });
+    const hasOpenOverrides = (overridesResp.Items ?? []).some((overrideItem) =>
+      overrideBlocksCourseLifecycle(
+        overrideItem as Record<string, { S?: string; L?: Array<{ S?: string }> }>,
+        now,
+        participantsCount > 0,
+      ),
+    );
     if (hasOpenOverrides) {
       return {
         statusCode: 400,

--- a/backend/src/lambdas/shared/courseLifecycle.test.ts
+++ b/backend/src/lambdas/shared/courseLifecycle.test.ts
@@ -1,0 +1,33 @@
+import {
+  hasBlockingUpcomingCourseDates,
+  overrideBlocksCourseLifecycle,
+} from "./courseLifecycle";
+
+describe("courseLifecycle", () => {
+  test("overrideBlocksCourseLifecycle ignores stale participants when course is empty", () => {
+    const now = new Date("2026-05-19T12:00:00");
+    const item = {
+      date: { S: "2026-05-20" },
+      participants: { L: [{ S: "luna" }] },
+    };
+    expect(overrideBlocksCourseLifecycle(item, now, false)).toBe(false);
+  });
+
+  test("overrideBlocksCourseLifecycle blocks waitlist on future date for empty course", () => {
+    const now = new Date("2026-05-19T12:00:00");
+    const item = {
+      date: { S: "2026-05-20" },
+      waitlist: { L: [{ S: "luna" }] },
+    };
+    expect(overrideBlocksCourseLifecycle(item, now, false)).toBe(true);
+  });
+
+  test("hasBlockingUpcomingCourseDates uses date+time when course has participants", () => {
+    const dates = ["2026-05-19"];
+    const before = new Date(2026, 4, 19, 8, 0, 0);
+    const after = new Date(2026, 4, 19, 10, 0, 0);
+    expect(hasBlockingUpcomingCourseDates(dates, "09:00", before, true)).toBe(true);
+    expect(hasBlockingUpcomingCourseDates(dates, "09:00", after, true)).toBe(false);
+    expect(hasBlockingUpcomingCourseDates(dates, "09:00", before, false)).toBe(false);
+  });
+});

--- a/backend/src/lambdas/shared/courseLifecycle.ts
+++ b/backend/src/lambdas/shared/courseLifecycle.ts
@@ -1,0 +1,41 @@
+import { hasUpcomingCourseOccurrences } from "./courseDates";
+
+function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return false;
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return date >= startOfToday;
+}
+
+function hasAnyListEntries(item: Record<string, { L?: Array<{ S?: string }> }>): boolean {
+  const participantsCount = item.participants?.L?.length ?? 0;
+  const swappedCount = item.swapped?.L?.length ?? 0;
+  const waitlistCount = item.waitlist?.L?.length ?? 0;
+  return participantsCount > 0 || swappedCount > 0 || waitlistCount > 0;
+}
+
+/** Override blocks deactivate/delete when it still has open swap/waitlist state (or participants while the course has members). */
+export function overrideBlocksCourseLifecycle(
+  item: Record<string, { S?: string; L?: Array<{ S?: string }> }>,
+  now: Date,
+  courseHasParticipants: boolean,
+): boolean {
+  const dateValue = item.date?.S;
+  if (!dateValue || !isFutureOrTodayDateString(dateValue, now)) return false;
+  if (!courseHasParticipants) {
+    const swappedCount = item.swapped?.L?.length ?? 0;
+    const waitlistCount = item.waitlist?.L?.length ?? 0;
+    return swappedCount > 0 || waitlistCount > 0;
+  }
+  return hasAnyListEntries(item);
+}
+
+export function hasBlockingUpcomingCourseDates(
+  dateIsos: string[],
+  courseTime: string,
+  now: Date,
+  courseHasParticipants: boolean,
+): boolean {
+  if (!courseHasParticipants) return false;
+  return hasUpcomingCourseOccurrences(dateIsos, courseTime, now);
+}

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -77,6 +77,10 @@ describe("updateCourse Lambda", () => {
       SWAPS_TABLE: "test-swaps",
     };
     mockSend.mockReset();
+    (GetItemCommand as unknown as jest.Mock).mockClear();
+    (PutItemCommand as unknown as jest.Mock).mockClear();
+    (QueryCommand as unknown as jest.Mock).mockClear();
+    (ScanCommand as unknown as jest.Mock).mockClear();
   });
 
   afterAll(() => {
@@ -138,6 +142,22 @@ describe("updateCourse Lambda", () => {
     expect(JSON.parse(result.body).error).toMatch(/Invalid status transition/);
   });
 
+  test("allows active -> draft for bounded_series without participants", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          participants: { L: [] },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent({ status: "draft" }));
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).status).toBe("draft");
+  });
+
   test("allows active -> draft for rolling course without participants", async () => {
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
@@ -157,7 +177,7 @@ describe("updateCourse Lambda", () => {
     expect(JSON.parse(result.body).status).toBe("draft");
   });
 
-  test("blocks active -> inactive when future dates exist", async () => {
+  test("blocks active -> inactive when upcoming occurrences exist and course has participants", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     mockSend
@@ -174,14 +194,65 @@ describe("updateCourse Lambda", () => {
     expect(JSON.parse(result.body).error).toMatch(/Kurs kann nicht deaktiviert werden/);
   });
 
-  test("blocks active -> inactive when open overrides/swaps exist", async () => {
+  test("allows active -> inactive for bounded_series without participants despite future dates", async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowIso = tomorrow.toISOString().slice(0, 10);
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          participants: { L: [] },
+          dates: { L: [{ S: tomorrowIso }] },
+        },
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent({ status: "inactive" }));
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).status).toBe("inactive");
+  });
+
+  test("allows active -> inactive without participants when override only has stale participants", async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...baseCourseItem("active"),
+          participants: { L: [] },
+          dates: { L: [{ S: tomorrow.toISOString().slice(0, 10) }] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            date: { S: tomorrow.toISOString().slice(0, 10) },
+            participants: { L: [{ S: "luna" }] },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(makeEvent({ status: "inactive" }));
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body).status).toBe("inactive");
+    expect(ScanCommand).toHaveBeenCalled();
+  });
+
+  test("blocks active -> inactive when open overrides exist", async () => {
     mockSend
       .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
       .mockResolvedValueOnce({ Item: baseCourseItem("active") })
       .mockResolvedValueOnce({
         Items: [
           {
-            date: { S: new Date().toISOString().slice(0, 10) },
+            date: { S: "2099-01-06" },
             participants: { L: [{ S: "luna" }] },
           },
         ],

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -12,6 +12,7 @@ import {
   hasUpcomingCourseOccurrences,
   pruneScheduleExceptions,
 } from "../shared/courseDates";
+import { overrideBlocksCourseLifecycle, hasBlockingUpcomingCourseDates } from "../shared/courseLifecycle";
 import { generateCourseUid, resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 
 const client = dynamoClient;
@@ -76,13 +77,6 @@ function isValidDateRange(start?: string, end?: string): boolean {
   return start <= end;
 }
 
-function isFutureOrTodayDateString(isoDate: string, now: Date): boolean {
-  const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) return false;
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  return date >= startOfToday;
-}
-
 function isCourseInFutureWithBuffer(courseDate: string, courseTime: string, now: Date): boolean {
   try {
     const [year, month, day] = courseDate.split("-").map(Number);
@@ -117,25 +111,26 @@ function getRollingExcludeLockBounds(now: Date): { startIso: string; endIso: str
   };
 }
 
-function hasAnyListEntries(item: Record<string, { L?: Array<{ S?: string }> }>): boolean {
-  const participantsCount = item.participants?.L?.length ?? 0;
-  const swappedCount = item.swapped?.L?.length ?? 0;
-  const waitlistCount = item.waitlist?.L?.length ?? 0;
-  return participantsCount > 0 || swappedCount > 0 || waitlistCount > 0;
-}
-
 async function canDeactivateCourse(params: {
   tenantId: string;
   courseId: string;
+  courseTime: string;
+  hasParticipants: boolean;
   swapsTable: string;
   overridesTable: string;
   existingDates: string[];
 }): Promise<boolean> {
   const now = new Date();
-  const hasUpcomingDates = params.existingDates.some((date) =>
-    isFutureOrTodayDateString(date, now),
-  );
-  if (hasUpcomingDates) return false;
+  if (
+    hasBlockingUpcomingCourseDates(
+      params.existingDates,
+      params.courseTime,
+      now,
+      params.hasParticipants,
+    )
+  ) {
+    return false;
+  }
 
   const overridesResp = await client.send(
     new QueryCommand({
@@ -148,11 +143,13 @@ async function canDeactivateCourse(params: {
       },
     }),
   );
-  const hasOpenOverrides = (overridesResp.Items ?? []).some((item) => {
-    const dateValue = item.date?.S;
-    if (!dateValue || !isFutureOrTodayDateString(dateValue, now)) return false;
-    return hasAnyListEntries(item as Record<string, { L?: Array<{ S?: string }> }>);
-  });
+  const hasOpenOverrides = (overridesResp.Items ?? []).some((item) =>
+    overrideBlocksCourseLifecycle(
+      item as Record<string, { S?: string; L?: Array<{ S?: string }> }>,
+      now,
+      params.hasParticipants,
+    ),
+  );
   if (hasOpenOverrides) return false;
 
   const swapsResp = await client.send(
@@ -361,19 +358,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const currentStatus = item.status?.S ?? "active";
     const nextStatus = status ?? currentStatus;
     if (status && nextStatus !== currentStatus) {
-      const currentPlanningMode = item.planningMode?.S ?? "bounded_series";
-      const requestedPlanningMode = planningMode ?? currentPlanningMode;
       const hasParticipants = (item.participants?.L?.length ?? 0) > 0;
       const transitionAllowed =
         (currentStatus === "inactive" && nextStatus === "draft") ||
         (currentStatus === "draft" && nextStatus === "active") ||
         (currentStatus === "active" && nextStatus === "inactive") ||
-        (
-          currentStatus === "active" &&
-          nextStatus === "draft" &&
-          requestedPlanningMode === "rolling_continuous" &&
-          !hasParticipants
-        );
+        (currentStatus === "active" && nextStatus === "draft" && !hasParticipants);
       if (!transitionAllowed) {
         return {
           statusCode: 400,
@@ -408,6 +398,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         const canDeactivate = await canDeactivateCourse({
           tenantId,
           courseId,
+          courseTime: item.time?.S ?? "",
+          hasParticipants,
           swapsTable,
           overridesTable,
           existingDates,


### PR DESCRIPTION
## Summary

Behebt #166: Kursblöcke (`bounded_series`) ohne Teilnehmer ließen sich nicht auf **Inaktiv** / **In Planung** setzen und damit nicht aufräumen/löschen.

- **`updateCourse`:** `active` → `draft` ohne Teilnehmer auch für Kursblöcke; Deaktivierung ohne TN trotz zukünftiger Termine; Terminprüfung mit Datum+Uhrzeit bei Kursen mit Teilnehmern
- **`deleteCourse`:** gleiche Lifecycle-Regeln — leere inaktive Kurse löschbar trotz Zukunftsterminen; veraltete Override-`participants` blockieren nicht mehr
- Gemeinsame Logik in `backend/src/lambdas/shared/courseLifecycle.ts`
- **Frontend:** API-Fehlertexte aus `error`-Feld in `updateCourse` / `deleteCourse`

**Unverändert:** Kurse mit zugewiesenen Teilnehmern und kommenden Terminen können nicht von `active` weg; inaktive Kurse mit Teilnehmern bleiben nicht löschbar.

## Test plan

- [ ] Leerer Kursblock: Status **Inaktiv** / **In Planung** speichern → 200
- [ ] Danach Kurs **löschen** → 200
- [ ] Kursblock mit Teilnehmern + Zukunftsterminen: Deaktivieren → 400 mit deutscher Meldung
- [ ] Inaktiver Kurs mit Teilnehmern (Nachlauf): Löschen → 400
- [ ] `npm test` Backend (`updateCourse`, `deleteCourse`, `courseLifecycle`) und App `courses.test`

Fixes #166

Made with [Cursor](https://cursor.com)