### PR TITLE
Per-tenant studio settings (#44)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -803,6 +803,50 @@ a:focus-visible {
   gap: 0.75rem 1rem;
 }
 
+.studio-field-label-block {
+  display: block;
+  width: 100%;
+}
+
+.studio-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.studio-field-hint-popover {
+  display: block;
+  margin: 0.25rem 0 0.35rem;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: #444;
+  background: #f8f8f8;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+.studio-field-hint[aria-expanded="true"] {
+  background: #e8f0fe;
+  border-color: #9ab;
+  color: #234;
+}
+
+.studio-field-hint {
+  flex-shrink: 0;
+  width: 1.15rem;
+  height: 1.15rem;
+  padding: 0;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  background: #f5f5f5;
+  color: #555;
+  cursor: help;
+}
+
 /* Responsive */
 @media (max-width: 1023px) {
   .grid { grid-template-columns: repeat(2, 1fr); }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -793,6 +793,16 @@ a:focus-visible {
   width: 100%;
 }
 
+.studio-settings-section {
+  margin-bottom: 1rem;
+}
+
+.studio-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
 /* Responsive */
 @media (max-width: 1023px) {
   .grid { grid-template-columns: repeat(2, 1fr); }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -261,7 +261,11 @@ function MainApp() {
 
       {currentUser && canInvite && !actingForUserIdState && (
         <section className="main-section main-section-admin">
-          <AdminPanel canEditRoles={(membership?.role ?? currentUser.role) === "admin"} />
+          <AdminPanel
+            canEditRoles={(membership?.role ?? currentUser.role) === "admin"}
+            tenant={tenant}
+            onTenantUpdated={(updated) => setTenant(updated)}
+          />
         </section>
       )}
 

--- a/app/src/api/tenantSettings.ts
+++ b/app/src/api/tenantSettings.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+import type { Tenant } from "shared/types";
+import type { StudioSettingsPatch } from "shared/tenantSettings";
+
+function apiErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const backendError =
+      typeof error.response?.data?.error === "string" ? error.response.data.error : undefined;
+    return backendError ?? fallback;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+export async function updateTenantSettings(patch: StudioSettingsPatch): Promise<Tenant> {
+  try {
+    const response = await axios.put<Tenant>("/tenant-settings", patch);
+    return response.data;
+  } catch (error) {
+    throw new Error(apiErrorMessage(error, "Studio-Einstellungen konnten nicht gespeichert werden."));
+  }
+}

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -8,8 +8,9 @@ import {
   updateParticipant,
   type ParticipantWithStatus,
 } from "../api/participants";
-import type { UserRole } from "shared/types";
+import type { Tenant, UserRole } from "shared/types";
 import { getStatusPresentation } from "../lib/participants";
+import StudioSettingsSection from "./StudioSettingsSection";
 
 const ROLE_LABELS_DE: Record<UserRole, string> = {
   admin: "Admin",
@@ -25,6 +26,8 @@ function getRoleLabel(role: UserRole | undefined): string {
 
 type AdminPanelProps = {
   canEditRoles?: boolean;
+  tenant?: Tenant | null;
+  onTenantUpdated?: (tenant: Tenant) => void;
 };
 type CreateNicknameCheckState =
   | "idle"
@@ -34,7 +37,11 @@ type CreateNicknameCheckState =
   | "active_conflict"
   | "exists_in_tenant";
 
-export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
+export default function AdminPanel({
+  canEditRoles = false,
+  tenant = null,
+  onTenantUpdated,
+}: AdminPanelProps) {
   const [participants, setParticipants] = useState<ParticipantWithStatus[]>([]);
   const [participantsLoading, setParticipantsLoading] = useState(false);
   const [participantsError, setParticipantsError] = useState("");
@@ -932,7 +939,11 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
   };
   
   return (
-    <div className="admin-panel">
+    <>
+      {canEditRoles && tenant && onTenantUpdated ? (
+        <StudioSettingsSection tenant={tenant} onSaved={onTenantUpdated} />
+      ) : null}
+      <div className="admin-panel">
       <div>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.5rem" }}>
           <h3 style={{ margin: 0 }}>Teilnehmer verwalten</h3>
@@ -1547,5 +1558,6 @@ export default function AdminPanel({ canEditRoles = false }: AdminPanelProps) {
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -9,8 +9,9 @@ import {
   isWithinPostCourseEndGrace,
   looksLikeAutomaticallyInactive,
 } from "shared/courseStatus";
-import { swapSettings } from "../data/swapSettings";
+import { resolveSwapWindow } from "shared/tenantSettings";
 import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
+import type { SwapSettings } from "../types";
 
 type Props = {
   course: Course;
@@ -51,6 +52,11 @@ export default function CourseCard({
   requestSwap,
   cancelSwap,
 }: Props) {
+  const swapWindow: SwapSettings = useMemo(
+    () => resolveSwapWindow(tenantSettings),
+    [tenantSettings],
+  );
+
   const [selectedDate, setSelectedDate] = useState<string>(
     dates[0]?.toISOString() || ""
   );
@@ -100,18 +106,18 @@ export default function CourseCard({
 
   const availableSwapDates = useMemo(
     () =>
-      getAvailableDates(allCourses, overrides, currentUser, swapSettings, new Date(selectedDate))
+      getAvailableDates(allCourses, overrides, currentUser, swapWindow, new Date(selectedDate))
         .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
         .sort((a, b) => a.date.getTime() - b.date.getTime()),
-    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds]
+    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow]
   );
 
   const waitlistDates = useMemo(
     () =>
-      getWaitlistDates(allCourses, overrides, currentUser, swapSettings, new Date(selectedDate))
+      getWaitlistDates(allCourses, overrides, currentUser, swapWindow, new Date(selectedDate))
         .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
         .sort((a, b) => a.date.getTime() - b.date.getTime()),
-    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds]
+    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow]
   );
 
   const swapForThisTerm = useMemo(

--- a/app/src/components/CourseDatesDialog.tsx
+++ b/app/src/components/CourseDatesDialog.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from "react";
 import { Calendar } from "lucide-react";
-import type { Course, CourseDateOverride, Swap } from "shared/types";
+import type { Course, CourseDateOverride, Swap, TenantSettings } from "shared/types";
+import { resolveRollingExcludeLockWeeks } from "shared/tenantSettings";
 import { cancelCourseDate, updateCourse } from "../api/courses";
 import CourseModalFrame from "./CourseModalFrame";
 import {
   DEFAULT_ROLLING_HORIZON_WEEKS,
-  DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS,
   WEEKDAY_ORDER,
   buildSeriesCalendarCells,
   compareIsoDate,
@@ -31,6 +31,7 @@ type CourseDatesDialogProps = {
   overrides: CourseDateOverride[];
   swaps: Swap[];
   canManageCourses: boolean;
+  tenantSettings?: TenantSettings;
   onClose: () => void;
   onSaved: () => Promise<void> | void;
 };
@@ -77,9 +78,14 @@ export default function CourseDatesDialog({
   overrides,
   swaps,
   canManageCourses,
+  tenantSettings,
   onClose,
   onSaved,
 }: CourseDatesDialogProps) {
+  const excludeLockWeeks = useMemo(
+    () => resolveRollingExcludeLockWeeks(tenantSettings),
+    [tenantSettings],
+  );
   const [datesState, setDatesState] = useState<CourseDatesEditorState | null>(null);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
@@ -165,7 +171,7 @@ export default function CourseDatesDialog({
   const rollingHorizonValid =
     !!datesState &&
     Number.isInteger(datesState.visibilityHorizonWeeks) &&
-    datesState.visibilityHorizonWeeks >= DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS;
+    datesState.visibilityHorizonWeeks >= excludeLockWeeks;
   const isActiveCancellationMode = course?.status === "active";
   const isRollingActiveMode = isActiveCancellationMode && datesState?.planningMode === "rolling_continuous";
   const isActiveReadOnly =
@@ -240,8 +246,8 @@ export default function CourseDatesDialog({
 
   const rollingExcludeLockRange = useMemo(() => {
     if (!datesState || datesState.planningMode !== "rolling_continuous" || !isActiveCancellationMode) return null;
-    return getRollingExcludeLockRangeIso(DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS);
-  }, [datesState, isActiveCancellationMode]);
+    return getRollingExcludeLockRangeIso(excludeLockWeeks);
+  }, [datesState, isActiveCancellationMode, excludeLockWeeks]);
 
   const rollingExcludeSelectionRange = useMemo(() => {
     if (!datesState || datesState.planningMode !== "rolling_continuous") return null;
@@ -412,7 +418,7 @@ export default function CourseDatesDialog({
             ...prev,
             visibilityHorizonWeeks:
               Number.isInteger(numericValue) && numericValue > 0
-                ? Math.max(numericValue, DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS)
+                ? Math.max(numericValue, excludeLockWeeks)
                 : DEFAULT_ROLLING_HORIZON_WEEKS,
           }
         : prev,
@@ -605,7 +611,7 @@ export default function CourseDatesDialog({
     } else if (datesState.planningMode === "rolling_continuous") {
       if (!rollingHorizonValid) {
         setFormError(
-          `Bitte mindestens ${DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS} Wochen für die Sichtbarkeit eingeben.`,
+          `Bitte mindestens ${excludeLockWeeks} Wochen für die Sichtbarkeit eingeben.`,
         );
         return;
       }
@@ -729,7 +735,7 @@ export default function CourseDatesDialog({
                 <input
                   id="rolling-horizon-weeks"
                   type="number"
-                  min={DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS}
+                  min={excludeLockWeeks}
                   step={1}
                   value={datesState.visibilityHorizonWeeks}
                   onChange={(event) => setRollingHorizonWeeks(event.target.value)}
@@ -980,7 +986,7 @@ export default function CourseDatesDialog({
                 <input
                   id="rolling-horizon-weeks"
                   type="number"
-                  min={DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS}
+                  min={excludeLockWeeks}
                   step={1}
                   value={datesState.visibilityHorizonWeeks}
                   onChange={(event) => setRollingHorizonWeeks(event.target.value)}
@@ -1010,7 +1016,7 @@ export default function CourseDatesDialog({
               <span className="course-editor-note">
                 {datesState.planningMode === "rolling_continuous"
                   ? isRollingActiveMode
-                    ? `Innerhalb der nächsten ${DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS} Wochen nur Absage; danach auch Ausschließen möglich.`
+                    ? `Innerhalb der nächsten ${excludeLockWeeks} Wochen nur Absage; danach auch Ausschließen möglich.`
                     : "Im Planungsmodus können alle Serientermine als Ausnahme gesetzt werden."
                   : "Nur Serientermine im Zeitraum sind wählbar."}
               </span>
@@ -1077,7 +1083,7 @@ export default function CourseDatesDialog({
                             isActiveReadOnly
                               ? "Nur Ansicht im aktiven Kurs"
                               : rollingLocked
-                                ? `Innerhalb der nächsten ${DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS} Wochen nur Absage möglich`
+                                ? `Innerhalb der nächsten ${excludeLockWeeks} Wochen nur Absage möglich`
                                 : (cell.isSeriesDate ? "Als Ausnahme setzen/entfernen" : "Nur Serientermine auswählbar")
                           }
                         >

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -836,6 +836,7 @@ export default function CourseList({
         overrides={filteredOverrides}
         swaps={swaps}
         canManageCourses={canManageCourses}
+        tenantSettings={tenant?.settings}
         onClose={closeDatesModal}
         onSaved={fetchData}
       />

--- a/app/src/components/StudioSettingsSection.tsx
+++ b/app/src/components/StudioSettingsSection.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import type { Tenant } from "shared/types";
+import {
+  resolveInactiveGraceDays,
+  resolveSwapWindow,
+  validateStudioSettingsPatch,
+} from "shared/tenantSettings";
+import { updateTenantSettings } from "../api/tenantSettings";
+
+type StudioSettingsSectionProps = {
+  tenant: Tenant;
+  onSaved: (tenant: Tenant) => void;
+};
+
+export default function StudioSettingsSection({ tenant, onSaved }: StudioSettingsSectionProps) {
+  const swapDefaults = resolveSwapWindow(tenant.settings);
+  const graceDefault = resolveInactiveGraceDays(tenant.settings);
+
+  const [name, setName] = useState(tenant.name);
+  const [inactiveGraceDays, setInactiveGraceDays] = useState(String(graceDefault));
+  const [minOffsetDays, setMinOffsetDays] = useState(String(swapDefaults.minOffsetDays));
+  const [maxOffsetDays, setMaxOffsetDays] = useState(String(swapDefaults.maxOffsetDays));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    const swap = resolveSwapWindow(tenant.settings);
+    setName(tenant.name);
+    setInactiveGraceDays(String(resolveInactiveGraceDays(tenant.settings)));
+    setMinOffsetDays(String(swap.minOffsetDays));
+    setMaxOffsetDays(String(swap.maxOffsetDays));
+    setError(null);
+    setSuccess(null);
+  }, [tenant]);
+
+  const handleSave = async () => {
+    const patch = {
+      name: name.trim(),
+      inactiveGraceDaysAfterCourseEnd: Number.parseInt(inactiveGraceDays, 10),
+      minOffsetDays: Number.parseInt(minOffsetDays, 10),
+      maxOffsetDays: Number.parseInt(maxOffsetDays, 10),
+    };
+    const validationError = validateStudioSettingsPatch(patch);
+    if (validationError) {
+      setError(validationError);
+      setSuccess(null);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await updateTenantSettings(patch);
+      onSaved(updated);
+      setSuccess("Studio-Einstellungen gespeichert.");
+    } catch (err) {
+      console.error("Failed to save studio settings", err);
+      setError(err instanceof Error ? err.message : "Speichern fehlgeschlagen.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="admin-panel studio-settings-section" aria-labelledby="studio-settings-heading">
+      <h3 id="studio-settings-heading" style={{ marginTop: 0 }}>
+        Studio-Einstellungen
+      </h3>
+      <p className="muted small" style={{ marginTop: 0 }}>
+        Gilt für das aktuelle Studio ({tenant.tenantId}). Weitere Optionen kommen schrittweise dazu.
+      </p>
+
+      <div className="studio-settings-grid">
+        <label className="dialog-field">
+          <span className="dialog-field-label">Studioname</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={saving}
+            autoComplete="organization"
+          />
+        </label>
+
+        <label className="dialog-field">
+          <span className="dialog-field-label">Nachlauf nach Kursende (Tage)</span>
+          <input
+            type="number"
+            min={0}
+            max={90}
+            value={inactiveGraceDays}
+            onChange={(e) => setInactiveGraceDays(e.target.value)}
+            disabled={saving}
+          />
+        </label>
+
+        <label className="dialog-field">
+          <span className="dialog-field-label">Tauschfenster: frühestens (Tage)</span>
+          <input
+            type="number"
+            min={-90}
+            max={90}
+            value={minOffsetDays}
+            onChange={(e) => setMinOffsetDays(e.target.value)}
+            disabled={saving}
+          />
+        </label>
+
+        <label className="dialog-field">
+          <span className="dialog-field-label">Tauschfenster: spätestens (Tage)</span>
+          <input
+            type="number"
+            min={-90}
+            max={90}
+            value={maxOffsetDays}
+            onChange={(e) => setMaxOffsetDays(e.target.value)}
+            disabled={saving}
+          />
+        </label>
+      </div>
+
+      <p className="course-editor-note">
+        Relativ zum gewählten Kurstermin. Der Nachlauf sollte zum spätesten Tauschtag passen (oft gleiche
+        Anzahl Tage).
+      </p>
+
+      {error && (
+        <p className="form-error" role="alert">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="muted small" role="status">
+          {success}
+        </p>
+      )}
+
+      <div style={{ marginTop: "0.75rem" }}>
+        <button type="button" className="btn-primary" onClick={handleSave} disabled={saving}>
+          {saving ? "Speichern…" : "Studio-Einstellungen speichern"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/app/src/components/StudioSettingsSection.tsx
+++ b/app/src/components/StudioSettingsSection.tsx
@@ -1,11 +1,46 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import type { Tenant } from "shared/types";
 import {
   resolveInactiveGraceDays,
+  resolveRollingExcludeLockWeeks,
   resolveSwapWindow,
   validateStudioSettingsPatch,
 } from "shared/tenantSettings";
 import { updateTenantSettings } from "../api/tenantSettings";
+
+function FieldLabelWithTooltip({ children, tooltip }: { children: ReactNode; tooltip: string }) {
+  const hintId = useId();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span className="studio-field-label-block">
+      <span className="dialog-field-label studio-field-label">
+        {children}
+        <button
+          type="button"
+          className="studio-field-hint"
+          title={tooltip}
+          aria-expanded={open}
+          aria-controls={hintId}
+          aria-label={`Hilfe: ${tooltip}`}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpen((prev) => !prev);
+          }}
+        >
+          ?
+        </button>
+      </span>
+      {open && (
+        <span id={hintId} role="note" className="studio-field-hint-popover">
+          {tooltip}
+        </span>
+      )}
+    </span>
+  );
+}
 
 type StudioSettingsSectionProps = {
   tenant: Tenant;
@@ -15,11 +50,13 @@ type StudioSettingsSectionProps = {
 export default function StudioSettingsSection({ tenant, onSaved }: StudioSettingsSectionProps) {
   const swapDefaults = resolveSwapWindow(tenant.settings);
   const graceDefault = resolveInactiveGraceDays(tenant.settings);
+  const excludeLockDefault = resolveRollingExcludeLockWeeks(tenant.settings);
 
   const [name, setName] = useState(tenant.name);
   const [inactiveGraceDays, setInactiveGraceDays] = useState(String(graceDefault));
   const [minOffsetDays, setMinOffsetDays] = useState(String(swapDefaults.minOffsetDays));
   const [maxOffsetDays, setMaxOffsetDays] = useState(String(swapDefaults.maxOffsetDays));
+  const [excludeLockWeeks, setExcludeLockWeeks] = useState(String(excludeLockDefault));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -30,6 +67,7 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
     setInactiveGraceDays(String(resolveInactiveGraceDays(tenant.settings)));
     setMinOffsetDays(String(swap.minOffsetDays));
     setMaxOffsetDays(String(swap.maxOffsetDays));
+    setExcludeLockWeeks(String(resolveRollingExcludeLockWeeks(tenant.settings)));
     setError(null);
     setSuccess(null);
   }, [tenant]);
@@ -40,6 +78,7 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
       inactiveGraceDaysAfterCourseEnd: Number.parseInt(inactiveGraceDays, 10),
       minOffsetDays: Number.parseInt(minOffsetDays, 10),
       maxOffsetDays: Number.parseInt(maxOffsetDays, 10),
+      excludeLockWeeks: Number.parseInt(excludeLockWeeks, 10),
     };
     const validationError = validateStudioSettingsPatch(patch);
     if (validationError) {
@@ -85,7 +124,9 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
         </label>
 
         <label className="dialog-field">
-          <span className="dialog-field-label">Nachlauf nach Kursende (Tage)</span>
+          <FieldLabelWithTooltip tooltip="Tage nach Kursende, in denen Teilnehmer noch tauschen dürfen. Sollte zur spätesten Tausch-Offset-Zahl passen (oft gleiche Anzahl Tage).">
+            Nachlauf nach Kursende (Tage)
+          </FieldLabelWithTooltip>
           <input
             type="number"
             min={0}
@@ -97,7 +138,9 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
         </label>
 
         <label className="dialog-field">
-          <span className="dialog-field-label">Tauschfenster: frühestens (Tage)</span>
+          <FieldLabelWithTooltip tooltip="Tage relativ zum gewählten Kurstermin: frühestens so viele Tage vor dem Termin ist ein Tausch möglich.">
+            Tauschfenster: frühestens (Tage)
+          </FieldLabelWithTooltip>
           <input
             type="number"
             min={-90}
@@ -109,7 +152,9 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
         </label>
 
         <label className="dialog-field">
-          <span className="dialog-field-label">Tauschfenster: spätestens (Tage)</span>
+          <FieldLabelWithTooltip tooltip="Tage relativ zum gewählten Kurstermin: spätestens so viele Tage vor dem Termin (negativ = nach dem Termin).">
+            Tauschfenster: spätestens (Tage)
+          </FieldLabelWithTooltip>
           <input
             type="number"
             min={-90}
@@ -119,12 +164,22 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
             disabled={saving}
           />
         </label>
-      </div>
 
-      <p className="course-editor-note">
-        Relativ zum gewählten Kurstermin. Der Nachlauf sollte zum spätesten Tauschtag passen (oft gleiche
-        Anzahl Tage).
-      </p>
+        <label className="dialog-field">
+          <FieldLabelWithTooltip tooltip="Für durchlaufende Kurse: innerhalb dieser Wochen ab heute im Kalender nur Absage, kein Ausschließen von Terminen. Das Sichtfenster muss mindestens so groß sein.">
+            Planungssperre für Durchlaufende Kurse (Wochen)
+          </FieldLabelWithTooltip>
+          <input
+            type="number"
+            min={1}
+            max={52}
+            value={excludeLockWeeks}
+            onChange={(e) => setExcludeLockWeeks(e.target.value)}
+            disabled={saving}
+            aria-label="Planungssperre für Durchlaufende Kurse in Wochen"
+          />
+        </label>
+      </div>
 
       {error && (
         <p className="form-error" role="alert">

--- a/app/src/components/courseDatesDialogUtils.ts
+++ b/app/src/components/courseDatesDialogUtils.ts
@@ -1,4 +1,5 @@
 import type { Course, CoursePlanningMode } from "shared/types";
+import { DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS as SHARED_DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS } from "shared/tenantSettings";
 import { deriveVisibleDates } from "../lib/courseSchedule";
 
 export type CourseDatesEditorState = {
@@ -73,7 +74,8 @@ export function dedupeAndSortDates(values: string[]): string[] {
 }
 
 export const DEFAULT_ROLLING_HORIZON_WEEKS = 10;
-export const DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS = 5;
+/** Fallback; Studio-Wert kommt aus `resolveRollingExcludeLockWeeks(tenantSettings)`. */
+export const DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS = SHARED_DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS;
 const DEFAULT_ROLLING_EXCLUDE_SELECTION_WEEKS = 156; // ~3 Jahre für langfristige Planung
 
 function normalizeHorizonWeeks(value: number | undefined): number {

--- a/app/src/data/swapSettings.ts
+++ b/app/src/data/swapSettings.ts
@@ -1,5 +1,0 @@
-import { resolveSwapWindow } from "shared/tenantSettings";
-import type { SwapSettings } from "../types";
-
-/** Fallback wenn kein Tenant-Kontext geladen ist (Tests, Storybook). */
-export const swapSettings: SwapSettings = resolveSwapWindow(undefined);

--- a/app/src/data/swapSettings.ts
+++ b/app/src/data/swapSettings.ts
@@ -1,7 +1,5 @@
+import { resolveSwapWindow } from "shared/tenantSettings";
 import type { SwapSettings } from "../types";
 
-export const swapSettings: SwapSettings =
-{
-  "minOffsetDays": -7,   // ab sofort
-  "maxOffsetDays": 7    // bis 30 Tage in die Zukunft
-}
+/** Fallback wenn kein Tenant-Kontext geladen ist (Tests, Storybook). */
+export const swapSettings: SwapSettings = resolveSwapWindow(undefined);

--- a/backend/src/lambdas/createCourse/index.test.ts
+++ b/backend/src/lambdas/createCourse/index.test.ts
@@ -15,6 +15,14 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
 
 const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
 
+const tenantSettingsLoadResponse = {};
+
+function mockAdminMembership() {
+  return mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } }).mockResolvedValueOnce(
+    tenantSettingsLoadResponse,
+  );
+}
+
 function makeEvent(body: unknown, headers?: Record<string, string>): APIGatewayProxyEvent {
   return {
     body: body == null ? null : JSON.stringify(body),
@@ -38,6 +46,7 @@ describe("createCourse Lambda", () => {
       ...OLD_ENV,
       COURSES_TABLE: "test-courses",
       MEMBERSHIPS_TABLE: "test-memberships",
+      TENANTS_TABLE: "test-tenants",
     };
     mockSend.mockReset();
   });
@@ -50,7 +59,7 @@ describe("createCourse Lambda", () => {
     delete process.env.COURSES_TABLE;
     const result = await handler(makeEvent({}));
     expect(result.statusCode).toBe(500);
-    expect(JSON.parse(result.body).error).toMatch(/COURSES_TABLE or MEMBERSHIPS_TABLE/);
+    expect(JSON.parse(result.body).error).toMatch(/COURSES_TABLE, MEMBERSHIPS_TABLE or TENANTS_TABLE/);
   });
 
   test("returns 403 when actor is missing", async () => {
@@ -93,8 +102,7 @@ describe("createCourse Lambda", () => {
   });
 
   test("creates course with default draft status", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Items: [{ courseId: { S: "1" } }, { id: { N: "4" } }],
       })
@@ -156,8 +164,7 @@ describe("createCourse Lambda", () => {
     const condErr = new Error("collision");
     (condErr as { name?: string }).name = "ConditionalCheckFailedException";
 
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Items: [] })
       .mockRejectedValueOnce(condErr);
 
@@ -169,10 +176,7 @@ describe("createCourse Lambda", () => {
   });
 
   test("creates course with scheduling model fields", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
-      .mockResolvedValueOnce({ Items: [] })
-      .mockResolvedValueOnce({});
+    mockAdminMembership().mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({});
 
     const result = await handler(
       makeEvent({
@@ -223,10 +227,7 @@ describe("createCourse Lambda", () => {
   });
 
   test("prunes bounded exceptions and auto-downgrades active course without future dates", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
-      .mockResolvedValueOnce({ Items: [] })
-      .mockResolvedValueOnce({});
+    mockAdminMembership().mockResolvedValueOnce({ Items: [] }).mockResolvedValueOnce({});
 
     const result = await handler(
       makeEvent({

--- a/backend/src/lambdas/createCourse/index.ts
+++ b/backend/src/lambdas/createCourse/index.ts
@@ -8,13 +8,15 @@ import {
   pruneScheduleExceptions,
 } from "../shared/courseDates";
 import { generateCourseUid } from "../shared/courseUid";
+import {
+  loadTenantSettings,
+  resolveRollingExcludeLockWeeks,
+} from "../shared/tenantSettingsLoader";
 
 const client = dynamoClient;
 const COURSE_STATUSES = new Set(["inactive", "draft", "active"]);
 const COURSE_PLANNING_MODES = new Set(["bounded_series", "rolling_continuous"]);
 const COURSE_VISIBILITY_MODES = new Set(["fixed_window", "rolling_horizon"]);
-const ROLLING_EXCLUDE_LOCK_WEEKS = 5;
-const MIN_ROLLING_HORIZON_WEEKS = ROLLING_EXCLUDE_LOCK_WEEKS;
 const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -63,10 +65,13 @@ function isValidDateRange(start?: string, end?: string): boolean {
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const coursesTable = process.env.COURSES_TABLE;
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
-  if (!coursesTable || !membershipsTable) {
+  const tenantsTable = process.env.TENANTS_TABLE;
+  if (!coursesTable || !membershipsTable || !tenantsTable) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: "COURSES_TABLE or MEMBERSHIPS_TABLE env var is not set" }),
+      body: JSON.stringify({
+        error: "COURSES_TABLE, MEMBERSHIPS_TABLE or TENANTS_TABLE env var is not set",
+      }),
     };
   }
 
@@ -139,17 +144,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }),
     };
   }
-  if (
-    (visibilityMode === "rolling_horizon" || visibilityHorizonWeeks != null) &&
-    (!Number.isInteger(visibilityHorizonWeeks) || (visibilityHorizonWeeks ?? 0) < MIN_ROLLING_HORIZON_WEEKS)
-  ) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({
-        error: `visibilityHorizonWeeks must be an integer >= ${MIN_ROLLING_HORIZON_WEEKS}`,
-      }),
-    };
-  }
   if (!excludedDatesInput || !includedDatesInput) {
     return {
       statusCode: 400,
@@ -171,6 +165,27 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const actorRole = membershipResp.Item?.role?.S;
     if (actorRole !== "admin") {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    let rollingExcludeLockWeeks = 5;
+    try {
+      const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
+      rollingExcludeLockWeeks = resolveRollingExcludeLockWeeks(tenantSettings);
+    } catch (error) {
+      console.error("Failed to load tenant settings for rolling lock weeks:", error);
+    }
+
+    if (
+      (visibilityMode === "rolling_horizon" || visibilityHorizonWeeks != null) &&
+      (!Number.isInteger(visibilityHorizonWeeks) ||
+        (visibilityHorizonWeeks ?? 0) < rollingExcludeLockWeeks)
+    ) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: `visibilityHorizonWeeks must be an integer >= ${rollingExcludeLockWeeks}`,
+        }),
+      };
     }
 
     const prunedExceptions = pruneScheduleExceptions({

--- a/backend/src/lambdas/shared/studioSettingsValidation.ts
+++ b/backend/src/lambdas/shared/studioSettingsValidation.ts
@@ -8,6 +8,7 @@ export type StudioSettingsPatch = {
   inactiveGraceDaysAfterCourseEnd?: number;
   minOffsetDays?: number;
   maxOffsetDays?: number;
+  excludeLockWeeks?: number;
 };
 
 export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
@@ -35,6 +36,12 @@ export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string 
     }
     if ((min as number) > (max as number)) {
       return "Tauschfenster: „frühestens“ darf nicht größer als „spätestens“ sein.";
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "excludeLockWeeks")) {
+    const weeks = patch.excludeLockWeeks;
+    if (!Number.isInteger(weeks) || (weeks ?? 0) < 1 || (weeks ?? 0) > 52) {
+      return "Planungssperre muss eine ganze Zahl zwischen 1 und 52 Wochen sein.";
     }
   }
   return null;

--- a/backend/src/lambdas/shared/studioSettingsValidation.ts
+++ b/backend/src/lambdas/shared/studioSettingsValidation.ts
@@ -1,0 +1,41 @@
+/**
+ * Technische Kopie von `shared/src/tenantSettings.ts` (validateStudioSettingsPatch).
+ * Grund: Value-Import aus `@yogaswap/shared` fuehrt im Backend-Build/Testsetup
+ * zu rootDir-/ESM-Problemen. Bei Aenderungen auch shared anpassen.
+ */
+export type StudioSettingsPatch = {
+  name?: string;
+  inactiveGraceDaysAfterCourseEnd?: number;
+  minOffsetDays?: number;
+  maxOffsetDays?: number;
+};
+
+export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
+  if (Object.prototype.hasOwnProperty.call(patch, "name")) {
+    const name = typeof patch.name === "string" ? patch.name.trim() : "";
+    if (!name) return "Bitte einen Studionamen eingeben.";
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "inactiveGraceDaysAfterCourseEnd")) {
+    const days = patch.inactiveGraceDaysAfterCourseEnd;
+    if (!Number.isInteger(days) || (days ?? 0) < 0 || (days ?? 0) > 90) {
+      return "Nachlauf muss eine ganze Zahl zwischen 0 und 90 sein.";
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(patch, "minOffsetDays") ||
+    Object.prototype.hasOwnProperty.call(patch, "maxOffsetDays")
+  ) {
+    const min = patch.minOffsetDays;
+    const max = patch.maxOffsetDays;
+    if (!Number.isInteger(min) || !Number.isInteger(max)) {
+      return "Tauschfenster: beide Werte müssen ganze Zahlen sein.";
+    }
+    if ((min ?? 0) < -90 || (min ?? 0) > 90 || (max ?? 0) < -90 || (max ?? 0) > 90) {
+      return "Tauschfenster: Werte müssen zwischen -90 und 90 liegen.";
+    }
+    if ((min as number) > (max as number)) {
+      return "Tauschfenster: „frühestens“ darf nicht größer als „spätestens“ sein.";
+    }
+  }
+  return null;
+}

--- a/backend/src/lambdas/shared/tenantSettingsLoader.ts
+++ b/backend/src/lambdas/shared/tenantSettingsLoader.ts
@@ -1,0 +1,30 @@
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import type { Tenant, TenantSettings } from "@yogaswap/shared";
+
+export async function loadTenantSettings(
+  client: DynamoDBClient,
+  tenantsTable: string,
+  tenantId: string,
+): Promise<TenantSettings | undefined> {
+  const resp = await client.send(
+    new GetItemCommand({
+      TableName: tenantsTable,
+      Key: { tenantId: { S: tenantId } },
+      ConsistentRead: true,
+    }),
+  );
+  if (!resp.Item) return undefined;
+  const tenant = unmarshall(resp.Item) as Tenant;
+  return tenant.settings;
+}
+
+/** Kopie von `shared/src/tenantSettings.ts` (resolveRollingExcludeLockWeeks). */
+export function resolveRollingExcludeLockWeeks(settings?: TenantSettings): number {
+  const value = settings?.excludeLockWeeks;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 52) {
+    return value;
+  }
+  return 5;
+}

--- a/backend/src/lambdas/updateCourse/index.test.ts
+++ b/backend/src/lambdas/updateCourse/index.test.ts
@@ -21,6 +21,15 @@ jest.mock("@aws-sdk/client-dynamodb", () => {
 
 const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
 
+/** Leerer Tenant-Load → Default excludeLockWeeks (5). */
+const tenantSettingsLoadResponse = {};
+
+function mockAdminMembership() {
+  return mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } }).mockResolvedValueOnce(
+    tenantSettingsLoadResponse,
+  );
+}
+
 function makeEvent(
   body: unknown,
   pathCourseId = "1",
@@ -75,6 +84,7 @@ describe("updateCourse Lambda", () => {
       MEMBERSHIPS_TABLE: "test-memberships",
       OVERRIDES_TABLE: "test-overrides",
       SWAPS_TABLE: "test-swaps",
+      TENANTS_TABLE: "test-tenants",
     };
     mockSend.mockReset();
     (GetItemCommand as unknown as jest.Mock).mockClear();
@@ -95,14 +105,13 @@ describe("updateCourse Lambda", () => {
   });
 
   test("returns 404 when course not found", async () => {
-    mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } }).mockResolvedValueOnce({});
+    mockAdminMembership().mockResolvedValueOnce({});
     const result = await handler(makeEvent({ name: "Neu" }));
     expect(result.statusCode).toBe(404);
   });
 
   test("updates editable fields and keeps participants/dates", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
       .mockResolvedValueOnce({});
 
@@ -134,8 +143,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("rejects invalid status transition inactive -> active", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("inactive") });
     const result = await handler(makeEvent({ status: "active" }));
     expect(result.statusCode).toBe(400);
@@ -143,8 +151,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("allows active -> draft for bounded_series without participants", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -159,8 +166,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("allows active -> draft for rolling course without participants", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -180,8 +186,7 @@ describe("updateCourse Lambda", () => {
   test("blocks active -> inactive when upcoming occurrences exist and course has participants", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -198,8 +203,7 @@ describe("updateCourse Lambda", () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowIso = tomorrow.toISOString().slice(0, 10);
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -219,8 +223,7 @@ describe("updateCourse Lambda", () => {
   test("allows active -> inactive without participants when override only has stale participants", async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -246,8 +249,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("blocks active -> inactive when open overrides exist", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("active") })
       .mockResolvedValueOnce({
         Items: [
@@ -267,8 +269,7 @@ describe("updateCourse Lambda", () => {
   test("allows active -> inactive when no open dates/refs", async () => {
     const oldDate = new Date();
     oldDate.setDate(oldDate.getDate() - 30);
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -291,8 +292,7 @@ describe("updateCourse Lambda", () => {
     allowed.setDate(allowed.getDate() + 50);
     const allowedIso = allowed.toISOString().slice(0, 10);
 
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
       .mockResolvedValueOnce({});
 
@@ -335,8 +335,7 @@ describe("updateCourse Lambda", () => {
     soon.setDate(soon.getDate() + 7);
     const soonIso = soon.toISOString().slice(0, 10);
 
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") });
 
     const result = await handler(
@@ -354,8 +353,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("rejects invalid fixed window range on update", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") });
 
     const result = await handler(
@@ -370,8 +368,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("updates course participants list", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
       .mockResolvedValueOnce({});
 
@@ -393,8 +390,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("prunes out-of-window exceptions for bounded_series", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({ Item: baseCourseItem("draft") })
       .mockResolvedValueOnce({});
 
@@ -428,8 +424,7 @@ describe("updateCourse Lambda", () => {
     stalePast.setDate(stalePast.getDate() - 40);
     const stalePastIso = stalePast.toISOString().slice(0, 10);
 
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("draft"),
@@ -465,8 +460,7 @@ describe("updateCourse Lambda", () => {
   });
 
   test("auto-sets active bounded_series to inactive when no future visible dates remain", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),
@@ -495,8 +489,7 @@ describe("updateCourse Lambda", () => {
     const futureDateIso = "2099-01-06";
     const pastDateIso = "2020-01-01";
 
-    mockSend
-      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+    mockAdminMembership()
       .mockResolvedValueOnce({
         Item: {
           ...baseCourseItem("active"),

--- a/backend/src/lambdas/updateCourse/index.ts
+++ b/backend/src/lambdas/updateCourse/index.ts
@@ -13,6 +13,10 @@ import {
   pruneScheduleExceptions,
 } from "../shared/courseDates";
 import { overrideBlocksCourseLifecycle, hasBlockingUpcomingCourseDates } from "../shared/courseLifecycle";
+import {
+  loadTenantSettings,
+  resolveRollingExcludeLockWeeks,
+} from "../shared/tenantSettingsLoader";
 import { generateCourseUid, resolveLegacyCourseIdFromPathSegment } from "../shared/courseUid";
 
 const client = dynamoClient;
@@ -21,8 +25,6 @@ const COURSE_PLANNING_MODES = new Set(["bounded_series", "rolling_continuous"]);
 const COURSE_VISIBILITY_MODES = new Set(["fixed_window", "rolling_horizon"]);
 const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-const ROLLING_EXCLUDE_LOCK_WEEKS = 5;
-const MIN_ROLLING_HORIZON_WEEKS = ROLLING_EXCLUDE_LOCK_WEEKS;
 const OVERRIDE_SYNC_TIME_BUFFER_MINUTES = 30;
 
 type UpdateCourseBody = {
@@ -102,9 +104,12 @@ function addDaysLocal(date: Date, days: number): Date {
   return next;
 }
 
-function getRollingExcludeLockBounds(now: Date): { startIso: string; endIso: string } {
+function getRollingExcludeLockBounds(
+  now: Date,
+  excludeLockWeeks: number,
+): { startIso: string; endIso: string } {
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const end = addDaysLocal(startOfToday, ROLLING_EXCLUDE_LOCK_WEEKS * 7);
+  const end = addDaysLocal(startOfToday, excludeLockWeeks * 7);
   return {
     startIso: toIsoDateOnlyLocal(startOfToday),
     endIso: toIsoDateOnlyLocal(end),
@@ -178,12 +183,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const membershipsTable = process.env.MEMBERSHIPS_TABLE;
   const overridesTable = process.env.OVERRIDES_TABLE;
   const swapsTable = process.env.SWAPS_TABLE;
-  if (!coursesTable || !membershipsTable || !overridesTable || !swapsTable) {
+  const tenantsTable = process.env.TENANTS_TABLE;
+  if (!coursesTable || !membershipsTable || !overridesTable || !swapsTable || !tenantsTable) {
     return {
       statusCode: 500,
       body: JSON.stringify({
         error:
-          "COURSES_TABLE, MEMBERSHIPS_TABLE, OVERRIDES_TABLE or SWAPS_TABLE env var is not set",
+          "COURSES_TABLE, MEMBERSHIPS_TABLE, OVERRIDES_TABLE, SWAPS_TABLE or TENANTS_TABLE env var is not set",
       }),
     };
   }
@@ -309,21 +315,6 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       body: JSON.stringify({ error: "participants must be an array of non-empty strings" }),
     };
   }
-  if (Object.prototype.hasOwnProperty.call(body, "visibilityHorizonWeeks")) {
-    if (
-      visibilityHorizonWeeks == null ||
-      !Number.isInteger(visibilityHorizonWeeks) ||
-      visibilityHorizonWeeks < MIN_ROLLING_HORIZON_WEEKS
-    ) {
-      return {
-        statusCode: 400,
-        body: JSON.stringify({
-          error: `visibilityHorizonWeeks must be an integer >= ${MIN_ROLLING_HORIZON_WEEKS}`,
-        }),
-      };
-    }
-  }
-
   try {
     const membershipResp = await client.send(
       new GetItemCommand({
@@ -338,6 +329,29 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const actorRole = membershipResp.Item?.role?.S;
     if (actorRole !== "admin") {
       return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    let rollingExcludeLockWeeks = 5;
+    try {
+      const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
+      rollingExcludeLockWeeks = resolveRollingExcludeLockWeeks(tenantSettings);
+    } catch (error) {
+      console.error("Failed to load tenant settings for rolling lock weeks:", error);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "visibilityHorizonWeeks")) {
+      if (
+        visibilityHorizonWeeks == null ||
+        !Number.isInteger(visibilityHorizonWeeks) ||
+        visibilityHorizonWeeks < rollingExcludeLockWeeks
+      ) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({
+            error: `visibilityHorizonWeeks must be an integer >= ${rollingExcludeLockWeeks}`,
+          }),
+        };
+      }
     }
 
     const courseResp = await client.send(
@@ -480,12 +494,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
     if (
       nextVisibilityMode === "rolling_horizon" &&
-      (!Number.isInteger(nextVisibilityHorizonWeeks) || (nextVisibilityHorizonWeeks ?? 0) < MIN_ROLLING_HORIZON_WEEKS)
+      (!Number.isInteger(nextVisibilityHorizonWeeks) ||
+        (nextVisibilityHorizonWeeks ?? 0) < rollingExcludeLockWeeks)
     ) {
       return {
         statusCode: 400,
         body: JSON.stringify({
-          error: `rolling_horizon requires visibilityHorizonWeeks >= ${MIN_ROLLING_HORIZON_WEEKS}`,
+          error: `rolling_horizon requires visibilityHorizonWeeks >= ${rollingExcludeLockWeeks}`,
         }),
       };
     }
@@ -493,7 +508,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     if (nextPlanningMode === "rolling_continuous") {
       const currentExcludedSet = new Set(currentExcludedDates);
       const addedExcludedDates = nextExcludedDates.filter((entry) => !currentExcludedSet.has(entry));
-      const lockBounds = getRollingExcludeLockBounds(new Date());
+      const lockBounds = getRollingExcludeLockBounds(new Date(), rollingExcludeLockWeeks);
       const hasLockedExcludedDate = addedExcludedDates.some(
         (entry) => entry >= lockBounds.startIso && entry <= lockBounds.endIso,
       );
@@ -501,7 +516,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         return {
           statusCode: 400,
           body: JSON.stringify({
-            error: `Termine innerhalb der nächsten ${ROLLING_EXCLUDE_LOCK_WEEKS} Wochen dürfen nicht ausgeschlossen werden. Bitte stattdessen absagen.`,
+            error: `Termine innerhalb der nächsten ${rollingExcludeLockWeeks} Wochen dürfen nicht ausgeschlossen werden. Bitte stattdessen absagen.`,
           }),
         };
       }

--- a/backend/src/lambdas/updateTenantSettings/index.test.ts
+++ b/backend/src/lambdas/updateTenantSettings/index.test.ts
@@ -71,6 +71,7 @@ describe("updateTenantSettings Lambda", () => {
         inactiveGraceDaysAfterCourseEnd: 10,
         minOffsetDays: -14,
         maxOffsetDays: 14,
+        excludeLockWeeks: 8,
       }),
     );
 
@@ -82,6 +83,7 @@ describe("updateTenantSettings Lambda", () => {
       inactiveGraceDaysAfterCourseEnd: 10,
       minOffsetDays: -14,
       maxOffsetDays: 14,
+      excludeLockWeeks: 8,
     });
     expect(PutItemCommand).toHaveBeenCalled();
   });

--- a/backend/src/lambdas/updateTenantSettings/index.test.ts
+++ b/backend/src/lambdas/updateTenantSettings/index.test.ts
@@ -1,0 +1,100 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { handler } from "./index";
+
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const mockSend = jest.fn();
+  return {
+    DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+    GetItemCommand: jest.fn((input) => input),
+    PutItemCommand: jest.fn((input) => input),
+    mockSend,
+  };
+});
+
+const { mockSend } = jest.requireMock("@aws-sdk/client-dynamodb");
+
+function makeEvent(body: unknown): APIGatewayProxyEvent {
+  return {
+    body: JSON.stringify(body),
+    headers: {},
+    requestContext: {
+      authorizer: { jwt: { claims: { nickname: "admin1" } } },
+    },
+  } as unknown as APIGatewayProxyEvent;
+}
+
+describe("updateTenantSettings Lambda", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...OLD_ENV,
+      TENANTS_TABLE: "test-tenants",
+      MEMBERSHIPS_TABLE: "test-memberships",
+    };
+    mockSend.mockReset();
+    (GetItemCommand as unknown as jest.Mock).mockClear();
+    (PutItemCommand as unknown as jest.Mock).mockClear();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("returns 403 for non-admin", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "instructor" } } });
+    const result = await handler(makeEvent({ name: "Studio" }));
+    expect(result.statusCode).toBe(403);
+  });
+
+  test("updates name and MVP settings while preserving other settings", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: { role: { S: "admin" } } })
+      .mockResolvedValueOnce({
+        Item: {
+          tenantId: { S: "default-tenant" },
+          name: { S: "Alt" },
+          settings: {
+            M: {
+              instructorCanSeeAllCourses: { BOOL: true },
+              inactiveGraceDaysAfterCourseEnd: { N: "7" },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const result = await handler(
+      makeEvent({
+        name: "Pilot Studio",
+        inactiveGraceDaysAfterCourseEnd: 10,
+        minOffsetDays: -14,
+        maxOffsetDays: 14,
+      }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.name).toBe("Pilot Studio");
+    expect(body.settings).toMatchObject({
+      instructorCanSeeAllCourses: true,
+      inactiveGraceDaysAfterCourseEnd: 10,
+      minOffsetDays: -14,
+      maxOffsetDays: 14,
+    });
+    expect(PutItemCommand).toHaveBeenCalled();
+  });
+
+  test("rejects invalid swap window", async () => {
+    mockSend.mockResolvedValueOnce({ Item: { role: { S: "admin" } } });
+    const result = await handler(
+      makeEvent({
+        minOffsetDays: 5,
+        maxOffsetDays: 2,
+      }),
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/frühestens/);
+  });
+});

--- a/backend/src/lambdas/updateTenantSettings/index.ts
+++ b/backend/src/lambdas/updateTenantSettings/index.ts
@@ -15,6 +15,7 @@ const MVP_SETTINGS_KEYS = [
   "inactiveGraceDaysAfterCourseEnd",
   "minOffsetDays",
   "maxOffsetDays",
+  "excludeLockWeeks",
 ] as const;
 
 function parseBody(event: APIGatewayProxyEvent): StudioSettingsPatch | null {

--- a/backend/src/lambdas/updateTenantSettings/index.ts
+++ b/backend/src/lambdas/updateTenantSettings/index.ts
@@ -1,0 +1,131 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import type { Tenant, TenantSettings } from "@yogaswap/shared";
+import {
+  validateStudioSettingsPatch,
+  type StudioSettingsPatch,
+} from "../shared/studioSettingsValidation";
+import { dynamoClient } from "../shared/dynamoClient";
+import { getTenantContext } from "../shared/tenantContext";
+
+const client = dynamoClient;
+
+const MVP_SETTINGS_KEYS = [
+  "inactiveGraceDaysAfterCourseEnd",
+  "minOffsetDays",
+  "maxOffsetDays",
+] as const;
+
+function parseBody(event: APIGatewayProxyEvent): StudioSettingsPatch | null {
+  if (!event.body) return null;
+  try {
+    const parsed = JSON.parse(event.body);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as StudioSettingsPatch;
+  } catch {
+    return null;
+  }
+}
+
+function mergeTenantSettings(
+  existing: TenantSettings | undefined,
+  patch: StudioSettingsPatch,
+): TenantSettings {
+  const next: TenantSettings = { ...(existing ?? {}) };
+  for (const key of MVP_SETTINGS_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(patch, key)) {
+      (next as Record<string, number>)[key] = patch[key] as number;
+    }
+  }
+  return next;
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const tenantsTable = process.env.TENANTS_TABLE;
+  const membershipsTable = process.env.MEMBERSHIPS_TABLE;
+  if (!tenantsTable || !membershipsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: "TENANTS_TABLE or MEMBERSHIPS_TABLE env var is not set",
+      }),
+    };
+  }
+
+  const body = parseBody(event);
+  if (!body) {
+    return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON body" }) };
+  }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(body, "name") &&
+    !MVP_SETTINGS_KEYS.some((key) => Object.prototype.hasOwnProperty.call(body, key))
+  ) {
+    return { statusCode: 400, body: JSON.stringify({ error: "No updatable fields provided" }) };
+  }
+
+  const validationError = validateStudioSettingsPatch(body);
+  if (validationError) {
+    return { statusCode: 400, body: JSON.stringify({ error: validationError }) };
+  }
+
+  const { tenantId, userId: actorUserId } = getTenantContext(event);
+  if (!actorUserId) {
+    return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+  }
+
+  try {
+    const membershipResp = await client.send(
+      new GetItemCommand({
+        TableName: membershipsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          userId: { S: actorUserId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    if (membershipResp.Item?.role?.S !== "admin") {
+      return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
+    }
+
+    const tenantResp = await client.send(
+      new GetItemCommand({
+        TableName: tenantsTable,
+        Key: { tenantId: { S: tenantId } },
+        ConsistentRead: true,
+      }),
+    );
+    if (!tenantResp.Item) {
+      return { statusCode: 404, body: JSON.stringify({ error: "Tenant not found" }) };
+    }
+
+    const existing = unmarshall(tenantResp.Item) as Tenant;
+    const nextName = Object.prototype.hasOwnProperty.call(body, "name")
+      ? body.name!.trim()
+      : existing.name;
+    const nextSettings = mergeTenantSettings(existing.settings, body);
+
+    const item: Tenant = {
+      tenantId: existing.tenantId,
+      name: nextName,
+      settings: nextSettings,
+    };
+
+    await client.send(
+      new PutItemCommand({
+        TableName: tenantsTable,
+        Item: marshall(item, { removeUndefinedValues: true }),
+      }),
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(item),
+    };
+  } catch (error) {
+    console.error("Error updating tenant settings:", error);
+    return { statusCode: 500, body: JSON.stringify({ error: "Failed to update tenant settings" }) };
+  }
+};

--- a/docs/course-status-visibility.md
+++ b/docs/course-status-visibility.md
@@ -12,7 +12,7 @@ Dokumentation zum Verhalten ab Issue [#149](https://github.com/CurlyKarin/yogasw
 | **Nachlauf** | Nach Kursende bleibt ein **`inactive`** Kurs für Teilnehmer:innen noch **X Kalendertage** sichtbar (Default **7**, UTC). |
 | **Lazy Reconcile** | Beim **`GET /courses`** (`get-courses` Lambda) werden Status und abgeleitete `dates` bei Bedarf in DynamoDB nachgezogen. |
 
-Studio-Konfiguration für den Nachlauf perspektivisch über Tenant-Settings ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)), siehe Abschnitt [Nachlauf und Tauschfenster](#nachlauf-und-tauschfenster).
+Studio-Konfiguration für Nachlauf und Tauschfenster über **Admin → Studio-Einstellungen** ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)): `inactiveGraceDaysAfterCourseEnd`, `minOffsetDays`, `maxOffsetDays` in `TenantSettings`. Siehe Abschnitt [Nachlauf und Tauschfenster](#nachlauf-und-tauschfenster).
 
 ---
 

--- a/docs/course-status-visibility.md
+++ b/docs/course-status-visibility.md
@@ -12,7 +12,7 @@ Dokumentation zum Verhalten ab Issue [#149](https://github.com/CurlyKarin/yogasw
 | **Nachlauf** | Nach Kursende bleibt ein **`inactive`** Kurs für Teilnehmer:innen noch **X Kalendertage** sichtbar (Default **7**, UTC). |
 | **Lazy Reconcile** | Beim **`GET /courses`** (`get-courses` Lambda) werden Status und abgeleitete `dates` bei Bedarf in DynamoDB nachgezogen. |
 
-Studio-Konfiguration für Nachlauf und Tauschfenster über **Admin → Studio-Einstellungen** ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)): `inactiveGraceDaysAfterCourseEnd`, `minOffsetDays`, `maxOffsetDays` in `TenantSettings`. Siehe Abschnitt [Nachlauf und Tauschfenster](#nachlauf-und-tauschfenster).
+Studio-Konfiguration für Nachlauf, Tauschfenster und Planungssperre (Rollkurse) über **Admin → Studio-Einstellungen** ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)): `inactiveGraceDaysAfterCourseEnd`, `minOffsetDays`, `maxOffsetDays`, `excludeLockWeeks` in `TenantSettings`. Siehe Abschnitt [Nachlauf und Tauschfenster](#nachlauf-und-tauschfenster).
 
 ---
 
@@ -120,9 +120,10 @@ letzterTagNachlauf = Kursende + inactiveGraceDaysAfterCourseEnd   (Kalendertage,
 | Einstellung | Ort (aktuell) | Default |
 |-------------|---------------|---------|
 | Nachlauf nach Kursende | `TenantSettings.inactiveGraceDaysAfterCourseEnd` | **7** |
-| Tauschfenster (App-Demo) | `app/src/data/swapSettings.ts` (`minOffsetDays` / `maxOffsetDays`) | **-7 / +7** |
+| Tauschfenster | `TenantSettings.minOffsetDays` / `maxOffsetDays` (`shared/tenantSettings.ts`) | **-7 / +7** |
+| Planungssperre (Rollkurs) | `TenantSettings.excludeLockWeeks` | **5** |
 
-**Produktentscheidung (#149):** Nachlauf und Swap-Fenster sollen **dieselbe Konfigurationsfamilie** nutzen (nicht zwei willkürlich getrennte Konstanten). Bis die Studio-UI ([#44](https://github.com/CurlyKarin/yogaswap/issues/44)) das abbildet, ist der Nachlauf-Default an `maxOffsetDays` angeglichen.
+**Produktentscheidung (#149):** Nachlauf und Swap-Fenster nutzen **dieselbe Konfigurationsfamilie** in `TenantSettings` (Studio-UI [#44](https://github.com/CurlyKarin/yogaswap/issues/44)). Der Code-Default für den Nachlauf ist an `DEFAULT_SWAP_MAX_OFFSET_DAYS` angeglichen.
 
 Im Nachlauf:
 
@@ -170,6 +171,6 @@ Extern: [mermaid.live](https://mermaid.live) oder GitHub nach Push.
 ## Siehe auch
 
 - [#149](https://github.com/CurlyKarin/yogaswap/issues/149) — Umsetzung Sichtbarkeit + Auto-Transition
-- [#44](https://github.com/CurlyKarin/yogaswap/issues/44) — Studio-Settings (Tauschfenster + geplanter Nachlauf)
+- [#44](https://github.com/CurlyKarin/yogaswap/issues/44) — Studio-Settings (Nachlauf, Tauschfenster, Planungssperre)
 - [#129](https://github.com/CurlyKarin/yogaswap/issues/129) — Lifecycle-Guardrails (`updateCourse` / Prune)
 - [#165](https://github.com/CurlyKarin/yogaswap/issues/165) — Rollende Kurse mit optionalem Ende

--- a/projects/modules/cloudfront/main.tf
+++ b/projects/modules/cloudfront/main.tf
@@ -98,6 +98,27 @@ resource "aws_cloudfront_distribution" "spa" {
     compress = true
   }
   ordered_cache_behavior {
+    path_pattern     = "/tenant-settings*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "api-gateway-backend"
+    viewer_protocol_policy = "redirect-to-https"
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "none"
+      }
+      headers = [
+        "Authorization",
+        "x-tenant-id",
+        "Origin",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+      ]
+    }
+    compress = true
+  }
+  ordered_cache_behavior {
     path_pattern     = "/course-overrides*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
     cached_methods   = ["GET", "HEAD"]

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -144,11 +144,12 @@ locals {
     "create_course" = {
       name             = "create-course"
       file_name        = "createCourse.zip"
-      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn]
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.tenants_table.table_arn]
       dynamodb_actions = ["dynamodb:Query", "dynamodb:GetItem", "dynamodb:PutItem"]
       tables = {
         "COURSES_TABLE"     = module.courses_table.table_name
         "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+        "TENANTS_TABLE"     = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -156,13 +157,14 @@ locals {
     "update_course" = {
       name             = "update-course"
       file_name        = "updateCourse.zip"
-      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn]
+      table_arns       = [module.courses_table.table_arn, module.memberships_table.table_arn, module.course_overrides_table.table_arn, module.swaps_table.table_arn, module.tenants_table.table_arn]
       dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query", "dynamodb:Scan"]
       tables = {
         "COURSES_TABLE"     = module.courses_table.table_name
         "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
         "OVERRIDES_TABLE"   = module.course_overrides_table.table_name
         "SWAPS_TABLE"       = module.swaps_table.table_name
+        "TENANTS_TABLE"     = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -390,6 +390,21 @@ locals {
       }
       s3_actions   = []
       s3_resources = []
+    },
+    "update_tenant_settings" = {
+      name      = "update-tenant-settings"
+      file_name = "updateTenantSettings.zip"
+      table_arns = [
+        module.tenants_table.table_arn,
+        module.memberships_table.table_arn,
+      ]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:PutItem"]
+      tables = {
+        "TENANTS_TABLE"     = module.tenants_table.table_name
+        "MEMBERSHIPS_TABLE" = module.memberships_table.table_name
+      }
+      s3_actions   = []
+      s3_resources = []
     }
     "start_password_reset_from_token" = {
       name             = "start-password-reset-from-token"
@@ -444,6 +459,7 @@ locals {
     "PUT /participants/{userId}"                 = "update_participant"
     "DELETE /participants/{userId}"              = "delete_participant"
     "GET /tenant-context"                        = "get_tenant_context"
+    "PUT /tenant-settings"                       = "update_tenant_settings"
   }
 
   build_files = fileset("../../app/build", "**")
@@ -471,6 +487,7 @@ module "yogaswap_api" {
     "POST /courses/{courseId}/dates/{date}/cancel",
     "DELETE /courses/{courseId}",
     "GET /tenant-context",
+    "PUT /tenant-settings",
   ]
 }
 #---------------cloudfront------------------

--- a/shared/src/courseStatus.ts
+++ b/shared/src/courseStatus.ts
@@ -1,6 +1,6 @@
 import type { Course, TenantSettings } from "./types";
 
-/** Default-Nachlauf in Tagen (an app swapSettings.maxOffsetDays angeglichen). */
+/** Default-Nachlauf in Tagen (fachlich an `DEFAULT_SWAP_MAX_OFFSET_DAYS` gekoppelt). */
 export const DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END = 7;
 
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 // shared/src/index.ts
 export * from './types';
 export * from './courseStatus';
+export * from './tenantSettings';
 export * from './lib/storage';
 export * from './data/mockUsers';

--- a/shared/src/tenantSettings.ts
+++ b/shared/src/tenantSettings.ts
@@ -3,6 +3,7 @@ import type { TenantSettings } from "./types";
 
 export const DEFAULT_SWAP_MIN_OFFSET_DAYS = -7;
 export const DEFAULT_SWAP_MAX_OFFSET_DAYS = 7;
+export const DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS = 5;
 
 export type SwapWindow = {
   minOffsetDays: number;
@@ -24,6 +25,14 @@ export function resolveSwapWindow(settings?: TenantSettings): SwapWindow {
   };
 }
 
+export function resolveRollingExcludeLockWeeks(settings?: TenantSettings): number {
+  const value = settings?.excludeLockWeeks;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 52) {
+    return value;
+  }
+  return DEFAULT_ROLLING_EXCLUDE_LOCK_WEEKS;
+}
+
 export function resolveInactiveGraceDays(settings?: TenantSettings): number {
   const value = settings?.inactiveGraceDaysAfterCourseEnd;
   return Number.isInteger(value) && (value ?? 0) >= 0
@@ -36,6 +45,7 @@ export type StudioSettingsPatch = {
   inactiveGraceDaysAfterCourseEnd?: number;
   minOffsetDays?: number;
   maxOffsetDays?: number;
+  excludeLockWeeks?: number;
 };
 
 export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
@@ -63,6 +73,12 @@ export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string 
     }
     if ((min as number) > (max as number)) {
       return "Tauschfenster: „frühestens“ darf nicht größer als „spätestens“ sein.";
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "excludeLockWeeks")) {
+    const weeks = patch.excludeLockWeeks;
+    if (!Number.isInteger(weeks) || (weeks ?? 0) < 1 || (weeks ?? 0) > 52) {
+      return "Planungssperre muss eine ganze Zahl zwischen 1 und 52 Wochen sein.";
     }
   }
   return null;

--- a/shared/src/tenantSettings.ts
+++ b/shared/src/tenantSettings.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END } from "./courseStatus";
+import type { TenantSettings } from "./types";
+
+export const DEFAULT_SWAP_MIN_OFFSET_DAYS = -7;
+export const DEFAULT_SWAP_MAX_OFFSET_DAYS = 7;
+
+export type SwapWindow = {
+  minOffsetDays: number;
+  maxOffsetDays: number;
+};
+
+export function resolveSwapWindow(settings?: TenantSettings): SwapWindow {
+  const min = settings?.minOffsetDays;
+  const max = settings?.maxOffsetDays;
+  return {
+    minOffsetDays:
+      typeof min === "number" && Number.isInteger(min)
+        ? min
+        : DEFAULT_SWAP_MIN_OFFSET_DAYS,
+    maxOffsetDays:
+      typeof max === "number" && Number.isInteger(max)
+        ? max
+        : DEFAULT_SWAP_MAX_OFFSET_DAYS,
+  };
+}
+
+export function resolveInactiveGraceDays(settings?: TenantSettings): number {
+  const value = settings?.inactiveGraceDaysAfterCourseEnd;
+  return Number.isInteger(value) && (value ?? 0) >= 0
+    ? (value as number)
+    : DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+}
+
+export type StudioSettingsPatch = {
+  name?: string;
+  inactiveGraceDaysAfterCourseEnd?: number;
+  minOffsetDays?: number;
+  maxOffsetDays?: number;
+};
+
+export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
+  if (Object.prototype.hasOwnProperty.call(patch, "name")) {
+    const name = typeof patch.name === "string" ? patch.name.trim() : "";
+    if (!name) return "Bitte einen Studionamen eingeben.";
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "inactiveGraceDaysAfterCourseEnd")) {
+    const days = patch.inactiveGraceDaysAfterCourseEnd;
+    if (!Number.isInteger(days) || (days ?? 0) < 0 || (days ?? 0) > 90) {
+      return "Nachlauf muss eine ganze Zahl zwischen 0 und 90 sein.";
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(patch, "minOffsetDays") ||
+    Object.prototype.hasOwnProperty.call(patch, "maxOffsetDays")
+  ) {
+    const min = patch.minOffsetDays;
+    const max = patch.maxOffsetDays;
+    if (!Number.isInteger(min) || !Number.isInteger(max)) {
+      return "Tauschfenster: beide Werte müssen ganze Zahlen sein.";
+    }
+    if ((min ?? 0) < -90 || (min ?? 0) > 90 || (max ?? 0) < -90 || (max ?? 0) > 90) {
+      return "Tauschfenster: Werte müssen zwischen -90 und 90 liegen.";
+    }
+    if ((min as number) > (max as number)) {
+      return "Tauschfenster: „frühestens“ darf nicht größer als „spätestens“ sein.";
+    }
+  }
+  return null;
+}

--- a/shared/src/types.js
+++ b/shared/src/types.js
@@ -1,5 +1,24 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DEFAULT_TENANT_ID = void 0;
+exports.getParticipantStatus = getParticipantStatus;
 /** Standard-Tenant-ID bis Multi-Tenancy vollständig aktiv ist */
 exports.DEFAULT_TENANT_ID = "default-tenant";
+/**
+ * Ableitung des Teilnehmer-Status aus Profilfeldern (ohne eigenes Status-Feld).
+ */
+function getParticipantStatus(profile) {
+    const auth = profile.authUserId?.trim();
+    const invitedFlag = profile.inviteSentAt?.trim();
+    const done = profile.inviteCompletedAt?.trim();
+    if (auth) {
+        if (done)
+            return "active";
+        if (!invitedFlag)
+            return "active";
+        return "invited";
+    }
+    if (invitedFlag)
+        return "invited";
+    return "no_login";
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -166,6 +166,16 @@ export interface TenantSettings {
    * bis Studio-Einstellungen das Feld setzen.
    */
   inactiveGraceDaysAfterCourseEnd?: number;
+  /**
+   * Tauschfenster: fruehestens X Kalendertage relativ zum Referenztermin (oft negativ).
+   * Default im Code: -7.
+   */
+  minOffsetDays?: number;
+  /**
+   * Tauschfenster: spaetestens X Kalendertage relativ zum Referenztermin.
+   * Default im Code: 7.
+   */
+  maxOffsetDays?: number;
 }
 
 // Verknüpfung zwischen User und Tenant inkl. Rolle und optionalen Overrides.

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -176,6 +176,12 @@ export interface TenantSettings {
    * Default im Code: 7.
    */
   maxOffsetDays?: number;
+  /**
+   * Rollkurs (`rolling_continuous`): Termine innerhalb der naechsten N Wochen
+   * duerfen nicht per `excludedDates` ausgeschlossen werden (nur Absage).
+   * Default im Code: 5.
+   */
+  excludeLockWeeks?: number;
 }
 
 // Verknüpfung zwischen User und Tenant inkl. Rolle und optionalen Overrides.


### PR DESCRIPTION
## Summary

- Adds **Admin → Studio-Einstellungen** for the current tenant: Studioname, Nachlauf nach Kursende, Tauschfenster (min/max Offset), and **Planungssperre für Durchlaufende Kurse** (`excludeLockWeeks`).
- New **`PUT /tenant-settings`** Lambda with shared validation; CloudFront route for `/tenant-settings*`.
- App uses `resolveSwapWindow`, `resolveInactiveGraceDays`, and `resolveRollingExcludeLockWeeks` from tenant context (`CourseCard`, `CourseDatesDialog`, `CourseList`).
- **`createCourse` / `updateCourse`** load tenant settings for rolling-course exclude-lock enforcement; Terraform grants `TENANTS_TABLE` read access.
- Removes unused `app/src/data/swapSettings.ts`; docs point to `TenantSettings` / `shared/tenantSettings.ts`.

Closes #44

## Test plan

- [ ] `npm run build --prefix shared`
- [ ] `npm test` in `backend/` and `app/`
- [ ] Deploy: `updateTenantSettings`, `createCourse`, `updateCourse` + Terraform (`projects/yogaswap`)
- [ ] Admin: save studio settings, reload — values persist in DynamoDB
- [ ] Participant: swap window on course card reflects saved offsets
- [ ] Rolling course: date dialog respects planning lock weeks; horizon min matches setting
- [ ] Mobile: tap `?` on studio field labels to show help text

## Out of scope (follow-up)

- Backend swap-window validation in `createSwap` (still frontend-only)
- Logo / Impressum / further studio branding (#87)


Made with [Cursor](https://cursor.com)