### PR TITLE
Kurzfristige Absage ohne Ersatztermin/Tausch (#167)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -199,6 +199,10 @@ body {
 .chip.swapped {
   background-color: #ffd54f; /* Gelb für Tausch */
 }
+.chip.short-notice {
+  background-color: #ffccbc; /* Kurzfristig abgesagt, Platz bleibt belegt */
+  text-decoration: line-through;
+}
 .chip.free {
   background-color: #c8e6c9; /* Grün für frei */
   font-style: italic;

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -117,9 +117,17 @@ export default function CourseCard({
       participants,
       originallyParticipant,
     });
-  /** RC: Rücknahme = wieder in participants (im Cutoff gesperrt). */
+  const hasActiveOriginSwapInPast = swaps.some(
+    (s) =>
+      s.user === userName &&
+      s.status === "active" &&
+      s.fromCourseId === course.id &&
+      s.fromDate === selectedDateKey &&
+      new Date(s.toDate) < new Date(),
+  );
+  /** RC: Rücknahme = wieder in participants (auch im Cutoff), außer historischem aktivem Swap. */
   const canUndoRegularAbsence =
-    hasCancelled && !isShortNotice && !originInCutoff && !isParticipant;
+    hasCancelled && !isShortNotice && !isParticipant && !hasActiveOriginSwapInPast;
 
   const pendingSwapsFromOrigin = useMemo(
     () =>

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -10,6 +10,13 @@ import {
   looksLikeAutomaticallyInactive,
 } from "shared/courseStatus";
 import { resolveSwapWindow } from "shared/tenantSettings";
+import {
+  canCreateSwapFromOrigin,
+  hasEffectiveCancellation,
+  isShortNoticeCancelled,
+  isWithinCancellationSwapCutoff,
+  resolveCancellationSwapCutoffMinutes,
+} from "shared/cancellationSwapCutoff";
 import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
 import type { SwapSettings } from "../types";
 
@@ -79,13 +86,42 @@ export default function CourseCard({
   const hasNoUpcomingDates = dates.length === 0;
   const participants = hasNoUpcomingDates ? course.participants : (override ? override.participants : course.participants);
   const swapped = hasNoUpcomingDates ? [] : (override?.swapped ?? []);
+  const shortNotice = hasNoUpcomingDates ? [] : (override?.shortNoticeCancellations ?? []);
   const freeSpots = course.capacity - participants.length;
   const waitlist = hasNoUpcomingDates ? [] : (override?.waitlist ?? []);
 
   const userNameLower = userName.toLowerCase();
   const isParticipant = participants.some((p) => p.toLowerCase() === userNameLower);
   const originallyParticipant = course.participants.some((p) => p.toLowerCase() === userNameLower);
-  const hasCancelled = originallyParticipant && !isParticipant;
+  const isShortNotice = isShortNoticeCancelled(override, userName);
+  const hasCancelled = hasEffectiveCancellation(
+    originallyParticipant,
+    override,
+    participants,
+    userName,
+  );
+  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+  const originInCutoff = isWithinCancellationSwapCutoff(
+    selectedDateKey,
+    course.time,
+    cutoffMinutes,
+  );
+  const canSwapFromOrigin =
+    (originallyParticipant || hasCancelled) &&
+    canCreateSwapFromOrigin({
+      isoDate: selectedDateKey,
+      courseTime: course.time,
+      tenantSettings,
+      override,
+      userName,
+      participants,
+      originallyParticipant,
+    });
+  /** SN: Rücknahme = Eintrag aus shortNotice entfernen (bleibt in participants). */
+  const canUndoShortNotice = isShortNotice && !originInCutoff;
+  /** RC: Rücknahme = wieder in participants. */
+  const canUndoRegularAbsence =
+    hasCancelled && !isShortNotice && !originInCutoff && !isParticipant;
 
   const pendingSwapsFromOrigin = useMemo(
     () =>
@@ -265,8 +301,19 @@ export default function CourseCard({
           {participants.length === 0 && <span className="chip">—</span>}
           {participants.map((name) => (
             <span
-              className={`chip ${swapped.includes(name) ? "swapped" : ""}`}
+              className={`chip ${
+                shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
+                  ? "short-notice"
+                  : swapped.includes(name)
+                    ? "swapped"
+                    : ""
+              }`}
               key={name}
+              title={
+                shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
+                  ? "Kurzfristig abgesagt — Platz bleibt belegt"
+                  : undefined
+              }
             >
               {name}
             </span>
@@ -330,27 +377,57 @@ export default function CourseCard({
               >
                 {swapForThisTerm.status === "pending"
                   ? "Tauschanfragen abbrechen"
-                  : "Tausch abbrechen"}
+                  : swapForThisTerm.status === "active" &&
+                      swapForThisTerm.toCourseId === course.id &&
+                      isWithinCancellationSwapCutoff(
+                        swapForThisTerm.toDate,
+                        allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
+                        cutoffMinutes,
+                      )
+                    ? isShortNoticeCancelled(
+                        overrides.find(
+                          (o) =>
+                            o.courseId === swapForThisTerm.toCourseId &&
+                            o.date === swapForThisTerm.toDate,
+                        ),
+                        userName,
+                      )
+                      ? "Tauschabsage zurücknehmen"
+                      : "Am Zieltermin kurzfristig absagen"
+                    : "Tausch abbrechen"}
               </button>
             </>
           ) : (
             <>
-              {isParticipant ? (
+              {isShortNotice ? (
+                canUndoShortNotice ? (
+                  <button
+                    className="danger"
+                    onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                  >
+                    Absage zurücknehmen
+                  </button>
+                ) : (
+                  <span className="muted small" role="status">
+                    Kurzfristige Absage — Rücknahme im Cutoff-Fenster nicht möglich.
+                  </span>
+                )
+              ) : isParticipant ? (
                 <button
                   className="danger"
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
                 >
                   Termin absagen
                 </button>
-              ) : hasCancelled ? (
+              ) : canUndoRegularAbsence ? (
                 <button onClick={() => onToggleAbsence(course, selectedDateKey, userName)}>
                   Absage zurücknehmen
                 </button>
-              ) : (
+              ) : hasCancelled ? null : (
                 <div className="muted">Nicht in diesem Termin eingetragen</div>
               )}
 
-              {(originallyParticipant || hasCancelled) && (
+              {canSwapFromOrigin && (
                 <button
                   className="secondary"
                   onClick={() => {
@@ -362,11 +439,16 @@ export default function CourseCard({
                   {hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen"}
                 </button>
               )}
-              
+              {originInCutoff && (originallyParticipant || hasCancelled) && !canSwapFromOrigin && (
+                <p className="muted small" role="status">
+                  Weniger als {cutoffMinutes} Minuten vor Termin — kein Tausch mehr möglich.
+                </p>
+              )}
+
             </>
           )}
           {/* 🆕 Wenn schon pending-Requests existieren: zusätzlicher Button */}
-              {hasPendingRequestsFromOrigin && (
+              {hasPendingRequestsFromOrigin && canSwapFromOrigin && (
                 <button
                   className="secondary"
                   onClick={() => {

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -117,9 +117,7 @@ export default function CourseCard({
       participants,
       originallyParticipant,
     });
-  /** SN: Rücknahme = Eintrag aus shortNotice entfernen (bleibt in participants). */
-  const canUndoShortNotice = isShortNotice && !originInCutoff;
-  /** RC: Rücknahme = wieder in participants. */
+  /** RC: Rücknahme = wieder in participants (im Cutoff gesperrt). */
   const canUndoRegularAbsence =
     hasCancelled && !isShortNotice && !originInCutoff && !isParticipant;
 
@@ -400,18 +398,12 @@ export default function CourseCard({
           ) : (
             <>
               {isShortNotice ? (
-                canUndoShortNotice ? (
-                  <button
-                    className="danger"
-                    onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                  >
-                    Absage zurücknehmen
-                  </button>
-                ) : (
-                  <span className="muted small" role="status">
-                    Kurzfristige Absage — Rücknahme im Cutoff-Fenster nicht möglich.
-                  </span>
-                )
+                <button
+                  className="danger"
+                  onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                >
+                  Absage zurücknehmen
+                </button>
               ) : isParticipant ? (
                 <button
                   className="danger"

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -317,6 +317,7 @@ export default function CourseList({
     setSwaps,
     currentUser,
     fetchData,
+    tenant?.settings,
   );
 
   // 👉 Debug-Ausgabe bei jedem Swaps-Update

--- a/app/src/components/StudioSettingsSection.tsx
+++ b/app/src/components/StudioSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
 import type { Tenant } from "shared/types";
 import {
+  resolveCancellationSwapCutoffMinutes,
   resolveInactiveGraceDays,
   resolveRollingPlanningHorizonWeeks,
   resolveSwapWindow,
@@ -51,12 +52,14 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
   const swapDefaults = resolveSwapWindow(tenant.settings);
   const graceDefault = resolveInactiveGraceDays(tenant.settings);
   const horizonDefault = resolveRollingPlanningHorizonWeeks(tenant.settings);
+  const cutoffDefault = resolveCancellationSwapCutoffMinutes(tenant.settings);
 
   const [name, setName] = useState(tenant.name);
   const [inactiveGraceDays, setInactiveGraceDays] = useState(String(graceDefault));
   const [minOffsetDays, setMinOffsetDays] = useState(String(swapDefaults.minOffsetDays));
   const [maxOffsetDays, setMaxOffsetDays] = useState(String(swapDefaults.maxOffsetDays));
   const [rollingPlanningHorizonWeeks, setRollingPlanningHorizonWeeks] = useState(String(horizonDefault));
+  const [cancellationSwapCutoffMinutes, setCancellationSwapCutoffMinutes] = useState(String(cutoffDefault));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -68,6 +71,7 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
     setMinOffsetDays(String(swap.minOffsetDays));
     setMaxOffsetDays(String(swap.maxOffsetDays));
     setRollingPlanningHorizonWeeks(String(resolveRollingPlanningHorizonWeeks(tenant.settings)));
+    setCancellationSwapCutoffMinutes(String(resolveCancellationSwapCutoffMinutes(tenant.settings)));
     setError(null);
     setSuccess(null);
   }, [tenant]);
@@ -79,6 +83,7 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
       minOffsetDays: Number.parseInt(minOffsetDays, 10),
       maxOffsetDays: Number.parseInt(maxOffsetDays, 10),
       rollingPlanningHorizonWeeks: Number.parseInt(rollingPlanningHorizonWeeks, 10),
+      cancellationSwapCutoffMinutesBeforeStart: Number.parseInt(cancellationSwapCutoffMinutes, 10),
     };
     const validationError = validateStudioSettingsPatch(patch);
     if (validationError) {
@@ -161,6 +166,21 @@ export default function StudioSettingsSection({ tenant, onSaved }: StudioSetting
             max={90}
             value={maxOffsetDays}
             onChange={(e) => setMaxOffsetDays(e.target.value)}
+            disabled={saving}
+          />
+        </label>
+
+        <label className="dialog-field">
+          <FieldLabelWithTooltip tooltip="Ab diesem Zeitpunkt vor Kursbeginn können Teilnehmer:innen nur noch kurzfristig absagen (Platz bleibt belegt), aber keinen neuen Tausch mehr vom Termin starten.">
+            Kurzfrist-Absage: Minuten vor Terminbeginn
+          </FieldLabelWithTooltip>
+          <input
+            type="number"
+            min={0}
+            max={1440}
+            step={15}
+            value={cancellationSwapCutoffMinutes}
+            onChange={(e) => setCancellationSwapCutoffMinutes(e.target.value)}
             disabled={saving}
           />
         </label>

--- a/app/src/components/useCourseSwaps.test.ts
+++ b/app/src/components/useCourseSwaps.test.ts
@@ -299,9 +299,165 @@ describe("useCourseSwaps", () => {
 
     expect(createSwap).toHaveBeenCalledTimes(1);
     expect(deleteSwap).toHaveBeenCalledTimes(2);
-    expect(updateOverride).toHaveBeenCalledWith(2, "2099-06-17", { waitlist: ["mia"] });
+    expect(updateOverride).toHaveBeenCalledWith(
+      2,
+      "2099-06-17",
+      expect.objectContaining({ waitlist: ["mia"] }),
+    );
     expect(updateOverride).toHaveBeenCalledWith(3, "2099-06-18", { waitlist: ["zoe"] });
     expect(processPromotions).toHaveBeenCalledTimes(1);
+  });
+
+  it("RC-Rücknahme mit pending Swaps zeigt Warnung und räumt Swaps auf", async () => {
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) =>
+      updater([
+        {
+          ...baseOverride,
+          participants: [], // RC: user ist ausgetragen
+        },
+        {
+          courseId: 2,
+          date: "2099-06-17",
+          participants: ["bob"],
+          swapped: [],
+          waitlist: ["alice", "mia"],
+        },
+      ]),
+    );
+    const setSwaps = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const pending: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: "2099-06-16",
+      toCourseId: 2,
+      toDate: "2099-06-17",
+      status: "pending",
+    };
+
+    (processPromotions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      swaps: [],
+      overrides: [],
+    });
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course],
+        [
+          { ...baseOverride, participants: [] },
+          { courseId: 2, date: "2099-06-17", participants: ["bob"], swapped: [], waitlist: ["alice", "mia"] },
+        ],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [pending],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.onToggleAbsence(course, "2099-06-16", baseUser.nickname);
+    });
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Offene Tauschanfragen (1) werden gelöscht."),
+    );
+    expect(deleteSwap).toHaveBeenCalledTimes(1);
+    expect(updateOverride).toHaveBeenCalledWith(
+      2,
+      "2099-06-17",
+      expect.objectContaining({ waitlist: ["mia"] }),
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it("RC-Rücknahme bricht bei Warnung-Abbruch ab", async () => {
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) =>
+      updater([{ ...baseOverride, participants: [] }]),
+    );
+    const setSwaps = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course],
+        [{ ...baseOverride, participants: [] }],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.onToggleAbsence(course, "2099-06-16", baseUser.nickname);
+    });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(processPromotions).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("RC-Rücknahme blockiert bei aktivem Swap in der Vergangenheit", async () => {
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) =>
+      updater([{ ...baseOverride, participants: [] }]),
+    );
+    const setSwaps = vi.fn();
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    const activePast: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: "2099-06-16",
+      toCourseId: 9,
+      toDate: "2000-01-01",
+      status: "active",
+    };
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course],
+        [{ ...baseOverride, participants: [] }],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [activePast],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.onToggleAbsence(course, "2099-06-16", baseUser.nickname);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Absagen nicht möglich, solange ein aktiver Tausch vom Ursprungstermin besteht.",
+    );
+    expect(processPromotions).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 });
 

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -2,10 +2,35 @@ import { useCallback, useEffect, useRef } from "react";
 import { getEffectiveWaitlist } from "../lib/waitlist";
 import { sameDayUTC } from "../lib/dates";
 import { overrideCourseUidFields, swapCourseUidFields } from "../lib/courseUid";
-import { Swap, CourseDateOverride, Course, User } from "shared/types";
+import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
+import {
+  addUserUniqueCaseInsensitive,
+  canCreateSwapFromOrigin,
+  includesUserCaseInsensitive,
+  isShortNoticeCancelled,
+  isWithinCancellationSwapCutoff,
+  removeUserCaseInsensitive,
+  resolveCancellationSwapCutoffMinutes,
+} from "shared/cancellationSwapCutoff";
 import { createSwap, deleteSwap, processPromotions } from "../api/swaps";
 import { createOverride, updateOverride } from "../api/overrides";
 
+/** Behält shortNotice, falls API-Antwort das Feld (noch) nicht liefert. */
+function mergeOverridesPreservingShortNotice(
+  prev: CourseDateOverride[],
+  next: CourseDateOverride[],
+): CourseDateOverride[] {
+  return next.map((o) => {
+    const prior = prev.find((p) => p.courseId === o.courseId && p.date === o.date);
+    if (
+      prior?.shortNoticeCancellations?.length &&
+      !o.shortNoticeCancellations?.length
+    ) {
+      return { ...o, shortNoticeCancellations: prior.shortNoticeCancellations };
+    }
+    return o;
+  });
+}
 
 export function useCourseSwaps(
   courses: Course[],
@@ -14,7 +39,8 @@ export function useCourseSwaps(
   swaps: Swap[], 
   setSwaps: React.Dispatch<React.SetStateAction<Swap[]>>, 
   currentUser: User,
-  fetchData: () => Promise<void>
+  fetchData: () => Promise<void>,
+  tenantSettings?: TenantSettings,
 ) {
   const equalsIgnoreCase = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
   const requestSwapRef = useRef<(fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => Promise<void>>(null!);
@@ -40,45 +66,112 @@ export function useCourseSwaps(
    * @param {string} dateIso - das Datum im ISO-Format, für den der Tausch erstellt werden soll
    * @param {string} userName - der Benutzername, unter dem der Tausch erstellt werden soll
    */
+  const cleanupPendingSwapsFromOrigin = useCallback(
+    async (fromCourseId: number, fromDateIso: string, userName: string) => {
+      const pendingFromOrigin = swaps.filter(
+        (s) =>
+          s.status === "pending" &&
+          equalsIgnoreCase(s.user, userName) &&
+          s.fromCourseId === fromCourseId &&
+          s.fromDate === fromDateIso,
+      );
+      if (pendingFromOrigin.length === 0) return;
+
+      await Promise.all(pendingFromOrigin.map((s) => deleteSwap(s)));
+      setSwaps((prev) =>
+        prev.filter(
+          (s) =>
+            !pendingFromOrigin.some(
+              (p) =>
+                p.fromCourseId === s.fromCourseId &&
+                p.fromDate === s.fromDate &&
+                p.toCourseId === s.toCourseId &&
+                p.toDate === s.toDate &&
+                equalsIgnoreCase(p.user, s.user),
+            ),
+        ),
+      );
+      setOverrides((prev) =>
+        prev.map((o) => {
+          const affected = pendingFromOrigin.filter(
+            (p) => p.toCourseId === o.courseId && p.toDate === o.date,
+          );
+          if (affected.length === 0) return o;
+          const usersToRemove = new Set(affected.map((p) => p.user.toLowerCase()));
+          const waitlistAfter = (o.waitlist ?? []).filter((u) => !usersToRemove.has(u.toLowerCase()));
+          if (waitlistAfter.length === (o.waitlist ?? []).length) return o;
+          updateOverride(o.courseId, o.date, { waitlist: waitlistAfter });
+          return { ...o, waitlist: waitlistAfter };
+        }),
+      );
+    },
+    [swaps, setOverrides, setSwaps],
+  );
+
   const onToggleAbsence = useCallback(
     async (course: Course, dateIso: string, userName: string) => {
       try {
-      // Absagen blockieren, wenn bereits aktiver Swap
-      // TODO: Prüfen, ob diese Prüfung notwendig ist (Kommentar im Originalcode)
-      const hasSwap = swaps.some(
+      const hasActiveSwapFromOrigin = swaps.some(
         (s: Swap) =>
-          s.user.toLowerCase() === userName.toLowerCase() &&
+          equalsIgnoreCase(s.user, userName) &&
           s.fromCourseId === course.id &&
           s.fromDate === dateIso &&
-          s.status === 'active'
+          s.status === "active",
       );
 
-      if (hasSwap) {
-        alert('Absagen nicht möglich, solange ein Tausch aktiv oder offen ist.');
+      if (hasActiveSwapFromOrigin) {
+        alert("Absagen nicht möglich, solange ein aktiver Tausch vom Ursprungstermin besteht.");
         return;
       }
 
-      // Warnung bei Warteliste
-      const waitlist = getEffectiveWaitlist(course, filteredOverrides, dateIso);
-      if (waitlist.length > 0) {
-        const proceed = confirm(
-          `Achtung: Für diesen Termin existiert eine Warteliste (${waitlist.length} Person(en)). ` +
-          `Deine Absage hat direkte Auswirkungen – jemand rückt automatisch nach. Möchtest du fortfahren?`
-        );
-        if (!proceed) return;
+      const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+      const inCutoff = isWithinCancellationSwapCutoff(dateIso, course.time, cutoffMinutes);
+
+      const existingOverride = filteredOverrides.find(
+        (o) => o.courseId === course.id && o.date === dateIso,
+      );
+      const isSn = isShortNoticeCancelled(existingOverride, userName);
+      const isIn = includesUserCaseInsensitive(
+        existingOverride?.participants ?? course.participants,
+        userName,
+      );
+
+      if (!isIn && !isSn && inCutoff) {
+        alert("Absage kann in diesem Zeitfenster nicht zurückgenommen werden.");
+        return;
       }
 
-      const updateOrCreateOverride = (
-        prev: CourseDateOverride[],
+      if (isSn && inCutoff) {
+        alert("Kurzfristige Absage kann in diesem Zeitfenster nicht zurückgenommen werden.");
+        return;
+      }
+
+      if (isIn && !isSn && !inCutoff) {
+        const waitlist = getEffectiveWaitlist(course, filteredOverrides, dateIso);
+        if (waitlist.length > 0) {
+          const proceed = confirm(
+            `Achtung: Für diesen Termin existiert eine Warteliste (${waitlist.length} Person(en)). ` +
+              `Deine Absage hat direkte Auswirkungen – jemand rückt automatisch nach. Möchtest du fortfahren?`,
+          );
+          if (!proceed) return;
+        }
+      }
+
+      const persistOverride = (
+        courseId: number,
+        dateKey: string,
         nextOverride: CourseDateOverride,
         idx: number,
-        courseId: number,
-        dateIso: string
+        prev: CourseDateOverride[],
       ) => {
         const updated = [...prev];
+        const payload = {
+          participants: nextOverride.participants,
+          shortNoticeCancellations: nextOverride.shortNoticeCancellations ?? [],
+        };
         if (idx >= 0) {
           updated[idx] = nextOverride;
-          updateOverride(courseId, dateIso, { participants: nextOverride.participants });
+          updateOverride(courseId, dateKey, payload);
         } else {
           updated.push(nextOverride);
           createOverride(nextOverride);
@@ -89,7 +182,7 @@ export function useCourseSwaps(
       setOverrides((prev: CourseDateOverride[]) => {
         const date = new Date(dateIso);
         const idx = prev.findIndex(
-          (o: CourseDateOverride) => o.courseId === course.id && sameDayUTC(new Date(o.date), date)
+          (o: CourseDateOverride) => o.courseId === course.id && sameDayUTC(new Date(o.date), date),
         );
 
         const baseOverride: CourseDateOverride =
@@ -101,38 +194,40 @@ export function useCourseSwaps(
                 participants: [...course.participants],
                 swapped: [],
                 waitlist: [],
+                shortNoticeCancellations: [],
                 ...overrideCourseUidFields(course),
               };
 
         const courseCapacity = course.capacity;
-        const userNameLower = userName.toLowerCase();
-        const isIn = baseOverride.participants.some((p) => p.toLowerCase() === userNameLower);
+        let nextParticipants = [...baseOverride.participants];
+        let nextShortNotice = [...(baseOverride.shortNoticeCancellations ?? [])];
 
-        let nextParticipants: string[];
-        if (isIn) {
-          // Absage: User entfernen
-          // Removal case-insensitive, damit gemischte Alt-Daten korrekt funktionieren.
-          nextParticipants = baseOverride.participants.filter((p) => p.toLowerCase() !== userNameLower);
+        if (isSn) {
+          nextShortNotice = removeUserCaseInsensitive(nextShortNotice, userName);
+        } else if (isIn && inCutoff) {
+          nextShortNotice = addUserUniqueCaseInsensitive(nextShortNotice, userName);
+        } else if (isIn) {
+          nextParticipants = removeUserCaseInsensitive(nextParticipants, userName);
         } else {
-          // Rücknahme: User hinzufügen, nur wenn Platz frei
-          if (baseOverride.participants.length >= courseCapacity) {
-            alert('Dieser Termin ist inzwischen voll – Rücknahme nicht möglich.');
+          if (nextParticipants.length >= courseCapacity) {
+            alert("Dieser Termin ist inzwischen voll – Rücknahme nicht möglich.");
             return prev;
           }
-          // Keine Duplikate durch unterschiedliche Schreibweise zulassen.
-          nextParticipants = [
-            ...baseOverride.participants.filter((p) => p.toLowerCase() !== userNameLower),
-            userName,
-          ];
+          nextParticipants = addUserUniqueCaseInsensitive(nextParticipants, userName);
         }
 
         const nextOverride: CourseDateOverride = {
           ...baseOverride,
           participants: nextParticipants,
+          shortNoticeCancellations: nextShortNotice,
         };
 
-        return updateOrCreateOverride(prev, nextOverride, idx, course.id, dateIso);
+        return persistOverride(course.id, dateIso, nextOverride, idx, prev);
       });
+
+      if (isIn && !isSn && inCutoff) {
+        await cleanupPendingSwapsFromOrigin(course.id, dateIso, userName);
+      }
 
       console.log('Calling processPromotions for onToggleAbsence...');
       const response = await processPromotions(); // Nachrücken übernehmen
@@ -140,7 +235,7 @@ export function useCourseSwaps(
 
       if (response && response.swaps && response.overrides) {
         setSwaps(response.swaps);
-        setOverrides(response.overrides);
+        setOverrides((prev) => mergeOverridesPreservingShortNotice(prev, response.overrides!));
       } else {
         console.warn('No valid response from processPromotions, falling back to fetchData');
         await fetchData();
@@ -152,7 +247,7 @@ export function useCourseSwaps(
     },
     // courses, currentUser.nickname kept so callback updates when they change
     // eslint-disable-next-line react-hooks/exhaustive-deps -- setOverrides/setSwaps stable; courses/nickname intentional
-    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps]
+    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings, cleanupPendingSwapsFromOrigin]
   );
 
   /**
@@ -164,9 +259,36 @@ export function useCourseSwaps(
    * @param {string} userName - der Name des Benutzers, der den Tausch durchführen soll
    * @returns {Promise<void>} - das zurückgegebene Promise
    */
+  const assertCanSwapFromOrigin = (fromCourse: Course, fromDateIso: string, userName: string) => {
+    const override = filteredOverrides.find(
+      (o) => o.courseId === fromCourse.id && o.date === fromDateIso,
+    );
+    const participants = override?.participants ?? fromCourse.participants;
+    const originallyParticipant = fromCourse.participants.some((p) =>
+      equalsIgnoreCase(p, userName),
+    );
+    if (
+      !canCreateSwapFromOrigin({
+        isoDate: fromDateIso,
+        courseTime: fromCourse.time,
+        tenantSettings,
+        override,
+        userName,
+        participants,
+        originallyParticipant,
+      })
+    ) {
+      alert("In diesem Zeitfenster ist kein Tausch vom Ursprungstermin mehr möglich.");
+      return false;
+    }
+    return true;
+  };
+
   const confirmSwap = useCallback(
     async (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => {
       try {
+        if (!assertCanSwapFromOrigin(fromCourse, fromDateIso, userName)) return;
+
         // Swap nur 1x aktiv pro User+Termin
         // TODO: nur zur Sicherheit hier drin, Prüfen!!!
         const existing = swaps.find(
@@ -342,7 +464,7 @@ export function useCourseSwaps(
 
         if (response && response.swaps && response.overrides) {
           setSwaps(response.swaps);
-          setOverrides(response.overrides);
+          setOverrides((prev) => mergeOverridesPreservingShortNotice(prev, response.overrides!));
         } else {
           console.warn('No valid response from processPromotions, falling back to fetchData');
           await fetchData();
@@ -355,7 +477,7 @@ export function useCourseSwaps(
     },
     // requestSwap via ref to avoid circular dependency (confirmSwap -> requestSwap)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps]
+    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings]
   );
 
   /**
@@ -371,6 +493,52 @@ export function useCourseSwaps(
       try {
         console.log("[cancelSwap use] START", { swap, clickedCourseId, swaps });
         const isOrigin = swap.fromCourseId === clickedCourseId;
+        const targetCourse = courses.find((c) => c.id === swap.toCourseId);
+        const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+        const targetInCutoff =
+          targetCourse &&
+          isWithinCancellationSwapCutoff(swap.toDate, targetCourse.time, cutoffMinutes);
+
+        if (swap.status === "active" && !isOrigin && targetInCutoff) {
+          const targetOverride = filteredOverrides.find(
+            (o) => o.courseId === swap.toCourseId && o.date === swap.toDate,
+          );
+          const isSn = isShortNoticeCancelled(targetOverride, swap.user);
+          const baseOverride: CourseDateOverride = targetOverride ?? {
+            courseId: swap.toCourseId,
+            date: swap.toDate,
+            participants: targetCourse?.participants ?? [],
+            swapped: [],
+            waitlist: [],
+            shortNoticeCancellations: [],
+            ...(targetCourse ? overrideCourseUidFields(targetCourse) : {}),
+          };
+          const nextShortNotice = isSn
+            ? removeUserCaseInsensitive(baseOverride.shortNoticeCancellations ?? [], swap.user)
+            : addUserUniqueCaseInsensitive(baseOverride.shortNoticeCancellations ?? [], swap.user);
+
+          const nextOverride: CourseDateOverride = {
+            ...baseOverride,
+            shortNoticeCancellations: nextShortNotice,
+          };
+          const idx = filteredOverrides.findIndex(
+            (o) => o.courseId === swap.toCourseId && o.date === swap.toDate,
+          );
+          setOverrides((prev) => {
+            const updated = [...prev];
+            if (idx >= 0) {
+              updated[idx] = nextOverride;
+              updateOverride(swap.toCourseId, swap.toDate, {
+                shortNoticeCancellations: nextShortNotice,
+              });
+            } else {
+              updated.push(nextOverride);
+              createOverride(nextOverride);
+            }
+            return updated;
+          });
+          return;
+        }
 
         console.log("[cancelSwap] START", { swap, clickedCourseId, isOrigin });
 
@@ -461,7 +629,7 @@ export function useCourseSwaps(
 
         if (response && response.swaps && response.overrides) {
           setSwaps(response.swaps);
-          setOverrides(response.overrides);
+          setOverrides((prev) => mergeOverridesPreservingShortNotice(prev, response.overrides!));
         } else {
           console.warn('No valid response from processPromotions, falling back to fetchData');
           await fetchData();
@@ -473,7 +641,7 @@ export function useCourseSwaps(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- currentUser.nickname intentional for refresh
-    [swaps, currentUser.nickname, fetchData, setOverrides, setSwaps]
+    [swaps, courses, filteredOverrides, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings]
   );
 
   /**
@@ -488,6 +656,8 @@ export function useCourseSwaps(
   const requestSwap = useCallback(
     async (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => {
       try {
+        if (!assertCanSwapFromOrigin(fromCourse, fromDateIso, userName)) return;
+
         // 1) prüfen, ob schon ein Swap existiert
         const existing = swaps.find(
           (s) =>
@@ -570,7 +740,7 @@ export function useCourseSwaps(
 
         if (response && response.swaps && response.overrides) {
           setSwaps(response.swaps);
-          setOverrides(response.overrides);
+          setOverrides((prev) => mergeOverridesPreservingShortNotice(prev, response.overrides!));
         } else {
           console.warn('No valid response from processPromotions, falling back to fetchData');
           await fetchData();
@@ -582,7 +752,7 @@ export function useCourseSwaps(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- currentUser.nickname intentional for refresh
-    [courses, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps]
+    [courses, swaps, filteredOverrides, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings]
   );
 
   requestSwapRef.current = requestSwap;

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -47,10 +47,6 @@ export function useCourseSwaps(
   // Filtere Overrides für aktuelle und zukünftige Termine
   // Fallback auf leeres Array, wenn overrides undefined oder kein Array ist
   const filteredOverrides = overrides;
-// const filteredOverrides = useMemo(
-//     () => overrides.filter((o) => courses.some((c) => c.id === o.courseId)),
-//     [overrides, courses]
-//   );
 
   useEffect(() => {
     console.log('🔄 Filtered Overrides:', filteredOverrides);
@@ -108,6 +104,71 @@ export function useCourseSwaps(
     [swaps, setOverrides, setSwaps],
   );
 
+  const cleanupAllSwapsFromOrigin = useCallback(
+    async (fromCourseId: number, fromDateIso: string, userName: string) => {
+      const originSwaps = swaps.filter(
+        (s) =>
+          equalsIgnoreCase(s.user, userName) &&
+          s.fromCourseId === fromCourseId &&
+          s.fromDate === fromDateIso,
+      );
+      if (originSwaps.length === 0) return;
+
+      await Promise.all(originSwaps.map((s) => deleteSwap(s)));
+      setSwaps((prev) =>
+        prev.filter(
+          (s) =>
+            !originSwaps.some(
+              (o) =>
+                equalsIgnoreCase(o.user, s.user) &&
+                o.fromCourseId === s.fromCourseId &&
+                o.fromDate === s.fromDate &&
+                o.toCourseId === s.toCourseId &&
+                o.toDate === s.toDate,
+            ),
+        ),
+      );
+
+      setOverrides((prev) =>
+        prev.map((o) => {
+          const next = { ...o };
+          const before = { ...o };
+          for (const swap of originSwaps) {
+            if (o.courseId === swap.fromCourseId && o.date === swap.fromDate) {
+              if (swap.status === "active") {
+                next.swapped = (next.swapped ?? []).filter((u) => !equalsIgnoreCase(u, swap.user));
+                next.participants = next.participants.filter((p) => !equalsIgnoreCase(p, swap.user));
+              } else {
+                next.waitlist = (next.waitlist ?? []).filter((u) => !equalsIgnoreCase(u, swap.user));
+              }
+            }
+            if (o.courseId === swap.toCourseId && o.date === swap.toDate) {
+              if (swap.status === "active") {
+                next.participants = next.participants.filter((p) => !equalsIgnoreCase(p, swap.user));
+                next.swapped = (next.swapped ?? []).filter((u) => !equalsIgnoreCase(u, swap.user));
+              } else {
+                next.waitlist = (next.waitlist ?? []).filter((u) => !equalsIgnoreCase(u, swap.user));
+              }
+            }
+          }
+          if (
+            JSON.stringify(before.participants) !== JSON.stringify(next.participants) ||
+            JSON.stringify(before.swapped) !== JSON.stringify(next.swapped) ||
+            JSON.stringify(before.waitlist) !== JSON.stringify(next.waitlist)
+          ) {
+            updateOverride(o.courseId, o.date, {
+              participants: next.participants,
+              swapped: next.swapped,
+              waitlist: next.waitlist,
+            });
+          }
+          return next;
+        }),
+      );
+    },
+    [swaps, setOverrides, setSwaps],
+  );
+
   const onToggleAbsence = useCallback(
     async (course: Course, dateIso: string, userName: string) => {
       try {
@@ -136,11 +197,6 @@ export function useCourseSwaps(
         userName,
       );
 
-      if (!isIn && !isSn && inCutoff) {
-        alert("Absage kann in diesem Zeitfenster nicht zurückgenommen werden.");
-        return;
-      }
-
       if (isIn && !isSn && !inCutoff) {
         const waitlist = getEffectiveWaitlist(course, filteredOverrides, dateIso);
         if (waitlist.length > 0) {
@@ -149,6 +205,42 @@ export function useCourseSwaps(
               `Deine Absage hat direkte Auswirkungen – jemand rückt automatisch nach. Möchtest du fortfahren?`,
           );
           if (!proceed) return;
+        }
+      }
+
+      const originSwaps = swaps.filter(
+        (s) =>
+          equalsIgnoreCase(s.user, userName) &&
+          s.fromCourseId === course.id &&
+          s.fromDate === dateIso,
+      );
+      const pendingCount = originSwaps.filter((s) => s.status === "pending").length;
+      const activeFutureCount = originSwaps.filter(
+        (s) => s.status === "active" && new Date(s.toDate) >= new Date(),
+      ).length;
+      const activePastCount = originSwaps.filter(
+        (s) => s.status === "active" && new Date(s.toDate) < new Date(),
+      ).length;
+
+      if (!isIn && !isSn) {
+        if (activePastCount > 0) {
+          alert("Diese Absage kann nicht mehr zurückgenommen werden, weil ein aktiver Tausch in der Vergangenheit liegt.");
+          return;
+        }
+        const warningParts: string[] = [
+          "Absage zurücknehmen und wieder am Termin teilnehmen?",
+          "Der Anspruch auf Ersatztermin erlischt.",
+        ];
+        if (pendingCount > 0) {
+          warningParts.push(`Offene Tauschanfragen (${pendingCount}) werden gelöscht.`);
+        }
+        if (activeFutureCount > 0) {
+          warningParts.push(`Aktive zukünftige Tausche (${activeFutureCount}) werden aufgehoben.`);
+        }
+        const proceed = confirm(warningParts.join(" "));
+        if (!proceed) return;
+        if (originSwaps.length > 0) {
+          await cleanupAllSwapsFromOrigin(course.id, dateIso, userName);
         }
       }
 
@@ -242,7 +334,7 @@ export function useCourseSwaps(
     },
     // courses, currentUser.nickname kept so callback updates when they change
     // eslint-disable-next-line react-hooks/exhaustive-deps -- setOverrides/setSwaps stable; courses/nickname intentional
-    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings, cleanupPendingSwapsFromOrigin]
+    [courses, filteredOverrides, swaps, currentUser.nickname, fetchData, setOverrides, setSwaps, tenantSettings, cleanupPendingSwapsFromOrigin, cleanupAllSwapsFromOrigin]
   );
 
   /**

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -141,11 +141,6 @@ export function useCourseSwaps(
         return;
       }
 
-      if (isSn && inCutoff) {
-        alert("Kurzfristige Absage kann in diesem Zeitfenster nicht zurückgenommen werden.");
-        return;
-      }
-
       if (isIn && !isSn && !inCutoff) {
         const waitlist = getEffectiveWaitlist(course, filteredOverrides, dateIso);
         if (waitlist.length > 0) {

--- a/app/src/shared/cancellationSwapCutoff.test.ts
+++ b/app/src/shared/cancellationSwapCutoff.test.ts
@@ -21,6 +21,24 @@ describe("cancellationSwapCutoff", () => {
     expect(isWithinCancellationSwapCutoff(isoDate, time, 60, new Date(atCutoff.getTime() - 1000))).toBe(false);
   });
 
+  it("cutoff 0 disables cutoff checks", () => {
+    const isoDate = "2099-06-15";
+    const time = "10:00";
+    const afterStart = new Date(2099, 5, 15, 10, 30);
+    expect(isWithinCancellationSwapCutoff(isoDate, time, 0, afterStart)).toBe(false);
+    expect(
+      canCreateSwapFromOrigin({
+        isoDate,
+        courseTime: time,
+        tenantSettings: { cancellationSwapCutoffMinutesBeforeStart: 0 },
+        userName: "alice",
+        participants: ["alice"],
+        originallyParticipant: true,
+        now: afterStart,
+      }),
+    ).toBe(true);
+  });
+
   it("canCreateSwapFromOrigin blocks SN", () => {
     const override = {
       courseId: 1,

--- a/app/src/shared/cancellationSwapCutoff.test.ts
+++ b/app/src/shared/cancellationSwapCutoff.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  canCreateSwapFromOrigin,
+  isShortNoticeCancelled,
+  isWithinCancellationSwapCutoff,
+  resolveCancellationSwapCutoffMinutes,
+} from "shared/cancellationSwapCutoff";
+
+describe("cancellationSwapCutoff", () => {
+  it("resolveCancellationSwapCutoffMinutes defaults to 60", () => {
+    expect(resolveCancellationSwapCutoffMinutes(undefined)).toBe(60);
+    expect(resolveCancellationSwapCutoffMinutes({ cancellationSwapCutoffMinutesBeforeStart: 30 })).toBe(30);
+  });
+
+  it("isWithinCancellationSwapCutoff uses course time", () => {
+    const isoDate = "2099-06-15";
+    const time = "10:00";
+    const start = new Date(2099, 5, 15, 10, 0);
+    const atCutoff = new Date(start.getTime() - 60 * 60 * 1000);
+    expect(isWithinCancellationSwapCutoff(isoDate, time, 60, atCutoff)).toBe(true);
+    expect(isWithinCancellationSwapCutoff(isoDate, time, 60, new Date(atCutoff.getTime() - 1000))).toBe(false);
+  });
+
+  it("canCreateSwapFromOrigin blocks SN", () => {
+    const override = {
+      courseId: 1,
+      date: "2099-06-15",
+      participants: ["alice"],
+      shortNoticeCancellations: ["alice"],
+    };
+    expect(
+      canCreateSwapFromOrigin({
+        isoDate: "2099-06-15",
+        courseTime: "10:00",
+        override,
+        userName: "alice",
+        participants: ["alice"],
+        originallyParticipant: true,
+        now: new Date(2099, 5, 15, 8, 0),
+      }),
+    ).toBe(false);
+  });
+
+  it("isShortNoticeCancelled is case-insensitive", () => {
+    expect(
+      isShortNoticeCancelled({ shortNoticeCancellations: ["Alice"] }, "alice"),
+    ).toBe(true);
+  });
+});

--- a/backend/src/lambdas/createOverride/index.ts
+++ b/backend/src/lambdas/createOverride/index.ts
@@ -32,6 +32,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const participants = override.participants || [];
     const swapped = override.swapped || [];
     const waitlist = override.waitlist || [];
+    const shortNoticeCancellations = override.shortNoticeCancellations || [];
 
     if (!Array.isArray(participants) || participants.some((p: any) => typeof p !== 'string')) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Invalid participants array' }) };
@@ -41,6 +42,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
     if (!Array.isArray(waitlist) || waitlist.some((w: any) => typeof w !== 'string')) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Invalid waitlist array' }) };
+    }
+    if (
+      !Array.isArray(shortNoticeCancellations) ||
+      shortNoticeCancellations.some((w: any) => typeof w !== 'string')
+    ) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Invalid shortNoticeCancellations array' }) };
     }
 
     const courseId_date = `${override.courseId}_${override.date}`;
@@ -55,6 +62,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       participants: { L: participants.map((p: string) => ({ S: p })) },
       swapped: { L: swapped.map((s: string) => ({ S: s })) },
       waitlist: { L: waitlist.map((w: string) => ({ S: w })) },
+      shortNoticeCancellations: { L: shortNoticeCancellations.map((w: string) => ({ S: w })) },
       actorUserId: userId ? { S: userId } : { NULL: true },
       actingForUserId: actingForUserId ? { S: actingForUserId } : { NULL: true },
       ...(courseUid ? { courseUid: { S: courseUid } } : {}),

--- a/backend/src/lambdas/createSwap/index.test.ts
+++ b/backend/src/lambdas/createSwap/index.test.ts
@@ -112,4 +112,76 @@ describe('createSwap Lambda', () => {
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body).error).toBe('Failed to create swap');
   });
+
+  test('returns 400 when origin is inside cutoff window', async () => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const fromDate = `${year}-${month}-${day}`;
+    const soon = new Date(now.getTime() + 30 * 60 * 1000);
+    const hh = String(soon.getHours()).padStart(2, '0');
+    const mm = String(soon.getMinutes()).padStart(2, '0');
+    const fromTime = `${hh}:${mm}`;
+
+    mockSend.mockResolvedValueOnce({
+      Item: {
+        time: { S: fromTime },
+        participants: { L: [{ S: 'Nia' }] },
+      },
+    });
+
+    const event = baseEvent({
+      user: 'Nia',
+      fromCourseId: 'c1',
+      fromDate,
+      toCourseId: 'c2',
+      toDate: '2099-06-20',
+      status: 'pending',
+    });
+
+    const result = await handler(event);
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toContain('kein Tausch');
+  });
+
+  test('returns 400 when origin has shortNotice cancellation marker', async () => {
+    process.env = {
+      ...process.env,
+      SWAPS_TABLE: 'test-swaps',
+      COURSES_TABLE: 'test-courses',
+      OVERRIDES_TABLE: 'test-overrides',
+    };
+
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          time: { S: '10:00' },
+          participants: { L: [{ S: 'Nia' }] },
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          courseId: { S: '1' },
+          date: { S: '2099-06-15' },
+          participants: { L: [{ S: 'Nia' }] },
+          swapped: { L: [] },
+          waitlist: { L: [] },
+          shortNoticeCancellations: { L: [{ S: 'Nia' }] },
+        },
+      });
+
+    const event = baseEvent({
+      user: 'Nia',
+      fromCourseId: '1',
+      fromDate: '2099-06-15',
+      toCourseId: '2',
+      toDate: '2099-06-20',
+      status: 'pending',
+    });
+
+    const result = await handler(event);
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toContain('kein Tausch');
+  });
 });

--- a/backend/src/lambdas/createSwap/index.test.ts
+++ b/backend/src/lambdas/createSwap/index.test.ts
@@ -42,15 +42,21 @@ describe('createSwap Lambda', () => {
 
   test('successfully creates a swap', async () => {
     mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          time: { S: '10:00' },
+          participants: { L: [{ S: 'Nia' }] },
+        },
+      })
       .mockResolvedValueOnce({ Item: { courseUid: { S: 'uid-from' } } })
       .mockResolvedValueOnce({ Item: { courseUid: { S: 'uid-to' } } })
       .mockResolvedValueOnce({});
     const event = baseEvent({
       user: 'Nia',
       fromCourseId: 'c1',
-      fromDate: '2025-10-01',
+      fromDate: '2099-06-15',
       toCourseId: 'c2',
-      toDate: '2025-10-05',
+      toDate: '2099-06-20',
       status: 'pending',
     });
 
@@ -64,7 +70,7 @@ describe('createSwap Lambda', () => {
         TableName: 'test-swaps',
         Item: expect.objectContaining({
           tenantId: { S: 'default-tenant' },
-          user_swapId: { S: 'Nia#2025-10-01_c1_2025-10-05_c2' },
+          user_swapId: { S: 'Nia#2099-06-15_c1_2099-06-20_c2' },
           user: { S: 'Nia' },
           fromCourseId: { S: 'c1' },
           toCourseId: { S: 'c2' },
@@ -95,9 +101,9 @@ describe('createSwap Lambda', () => {
     const event = baseEvent({
       user: 'Nia',
       fromCourseId: 'c1',
-      fromDate: '2025-10-01',
+      fromDate: '2099-06-15',
       toCourseId: 'c2',
-      toDate: '2025-10-05',
+      toDate: '2099-06-20',
       status: 'pending',
     });
 

--- a/backend/src/lambdas/createSwap/index.ts
+++ b/backend/src/lambdas/createSwap/index.ts
@@ -1,9 +1,12 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { GetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { canCreateSwapFromOrigin } from '@yogaswap/shared';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
 import { fetchCourseUidByLegacyCourseId } from '../shared/courseUid';
+import { loadTenantSettings } from '../shared/tenantSettingsLoader';
+import { mapOverrideItem, mapStringList } from '../shared/overrideDynamo';
 
 const client = dynamoClient;
 
@@ -19,6 +22,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   const tableName = process.env.SWAPS_TABLE;
   const coursesTable = process.env.COURSES_TABLE;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const tenantsTable = process.env.TENANTS_TABLE;
 
   try {
     if (!tableName) {
@@ -33,6 +38,60 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const fromLegacyId = swap.fromCourseId.toString();
+    const courseResp = await client.send(
+      new GetItemCommand({
+        TableName: coursesTable,
+        Key: { tenantId: { S: tenantId }, courseId: { S: fromLegacyId } },
+        ConsistentRead: true,
+      }),
+    );
+    if (!courseResp.Item) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Origin course not found' }) };
+    }
+    const courseTime = courseResp.Item.time?.S ?? '';
+    const baseParticipants = mapStringList(courseResp.Item.participants);
+
+    let override;
+    if (overridesTable) {
+      const courseId_date = `${fromLegacyId}_${swap.fromDate}`;
+      const overrideResp = await client.send(
+        new GetItemCommand({
+          TableName: overridesTable,
+          Key: { tenantId: { S: tenantId }, courseId_date: { S: courseId_date } },
+          ConsistentRead: true,
+        }),
+      );
+      if (overrideResp.Item) {
+        override = mapOverrideItem(overrideResp.Item);
+      }
+    }
+    const participants = override?.participants ?? baseParticipants;
+    const originallyParticipant = baseParticipants.some(
+      (p) => p.toLowerCase() === swap.user.toLowerCase(),
+    );
+    const tenantSettings = tenantsTable
+      ? await loadTenantSettings(client, tenantsTable, tenantId)
+      : undefined;
+
+    if (
+      !canCreateSwapFromOrigin({
+        isoDate: swap.fromDate,
+        courseTime,
+        tenantSettings,
+        override,
+        userName: swap.user,
+        participants,
+        originallyParticipant,
+      })
+    ) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'In diesem Zeitfenster ist kein Tausch vom Ursprungstermin mehr möglich.',
+        }),
+      };
+    }
+
     const toLegacyId = swap.toCourseId.toString();
     const [fromCourseUid, toCourseUid] = await Promise.all([
       fetchCourseUidByLegacyCourseId(client, coursesTable, tenantId, fromLegacyId),

--- a/backend/src/lambdas/getOverrides/index.test.ts
+++ b/backend/src/lambdas/getOverrides/index.test.ts
@@ -38,6 +38,7 @@ describe('getOverrides Lambda', () => {
         participants: ['Luna'],
         swapped: [],
         waitlist: [],
+        shortNoticeCancellations: [],
       },
     ]);
     expect(dynamoMock.calls()).toHaveLength(1);
@@ -76,6 +77,7 @@ describe('getOverrides Lambda', () => {
         participants: ['Luna'],
         swapped: [],
         waitlist: [],
+        shortNoticeCancellations: [],
       },
     ]);
     expect(dynamoMock.call(0).args[0].input).toMatchObject({
@@ -118,6 +120,7 @@ describe('getOverrides Lambda', () => {
         participants: ['Kai'],
         swapped: [],
         waitlist: [],
+        shortNoticeCancellations: [],
       },
     ]);
   });

--- a/backend/src/lambdas/getOverrides/index.ts
+++ b/backend/src/lambdas/getOverrides/index.ts
@@ -3,6 +3,7 @@ import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import type { CourseDateOverride } from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
+import { mapOverrideItem } from "../shared/overrideDynamo";
 
 const client = dynamoClient;
 
@@ -36,14 +37,7 @@ export const handler = async (
 
   try {
     const data = await client.send(command);
-    let items: CourseDateOverride[] = (data.Items || []).map((item) => ({
-      courseId: Number(item.courseId.S!),
-      ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
-      date: item.date.S!,
-      participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
-      swapped: item.swapped.L ? item.swapped.L.map((s: any) => s.S) : [],
-      waitlist: item.waitlist.L ? item.waitlist.L.map((w: any) => w.S) : [],
-    }));
+    let items: CourseDateOverride[] = (data.Items || []).map((item) => mapOverrideItem(item));
 
     if (sinceDate) {
       items = items.filter((o) => new Date(o.date) >= new Date(sinceDate));

--- a/backend/src/lambdas/getSwaps/index.ts
+++ b/backend/src/lambdas/getSwaps/index.ts
@@ -3,6 +3,7 @@ import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import { Swap } from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
+import { applySwapCutoffReconcileIfConfigured } from "../shared/applySwapCutoffReconcile";
 
 const client = dynamoClient;
 
@@ -88,8 +89,13 @@ export const handler = async (
       toDate: item.toDate.S!,
       status: item.status.S as Swap["status"],
     }));
-    console.log('getSwaps result:', items);
-    return { statusCode: 200, body: JSON.stringify(items) };
+    const reconciled = await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId,
+      swaps: items,
+    });
+    console.log('getSwaps result:', reconciled);
+    return { statusCode: 200, body: JSON.stringify(reconciled) };
   } catch (err) {
     console.error('Error querying swaps:', err);
     return { statusCode: 500, body: JSON.stringify({ error: 'Internal Server Error' }) };

--- a/backend/src/lambdas/getSwapsByStatus/index.ts
+++ b/backend/src/lambdas/getSwapsByStatus/index.ts
@@ -3,6 +3,7 @@ import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import { Swap } from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
+import { applySwapCutoffReconcileIfConfigured } from "../shared/applySwapCutoffReconcile";
 
 const client = dynamoClient;
 
@@ -52,8 +53,13 @@ export const handler = async (
       toDate: item.toDate.S!,
       status: item.status.S as Swap["status"],
     }));
-    console.log('getSwapsByStatus result:', items);
-    return { statusCode: 200, body: JSON.stringify(items) };
+    const reconciled = await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId,
+      swaps: items,
+    });
+    console.log('getSwapsByStatus result:', reconciled);
+    return { statusCode: 200, body: JSON.stringify(reconciled) };
   } catch (err) {
     console.error('Error querying swaps by status:', err);
     return { statusCode: 500, body: JSON.stringify({ error: 'Internal Server Error' }) };

--- a/backend/src/lambdas/processPromotions/index.test.ts
+++ b/backend/src/lambdas/processPromotions/index.test.ts
@@ -118,3 +118,62 @@ test("returns 200 and can promote when data is in the future (fixed now)", async
   expect(Array.isArray(body.swaps)).toBe(true);
   expect(Array.isArray(body.overrides)).toBe(true);
 });
+
+test("skips stale first waitlist entry and promotes next valid pending swap", async () => {
+  const pendingSwap = {
+    swapId: { S: "2025-10-01_1_2025-10-02_2" },
+    user: { S: "Alice" },
+    fromCourseId: { N: "1" },
+    fromDate: { S: "2025-10-01" },
+    toCourseId: { N: "2" },
+    toDate: { S: "2025-10-02" },
+    status: { S: "pending" },
+  };
+  const course = {
+    id: { N: "2" },
+    name: { S: "Yoga" },
+    weekday: { S: "Tuesday" },
+    time: { S: "10:00" },
+    capacity: { N: "2" },
+    participants: { L: [] },
+    dates: { L: [{ S: "2025-10-02" }] },
+  };
+  const overrideWithStaleFirstWaitlist = {
+    courseId: { S: "2" },
+    date: { S: "2025-10-02" },
+    participants: { L: [{ S: "Bob" }] },
+    swapped: { L: [] },
+    waitlist: { L: [{ S: "Ghost" }, { S: "Alice" }] },
+  };
+
+  ddbMock.on(UpdateItemCommand).resolves({});
+  ddbMock.on(PutItemCommand).resolves({});
+  ddbMock
+    .on(QueryCommand)
+    .resolvesOnce({ Items: [pendingSwap] })
+    .resolvesOnce({ Items: [course] })
+    .resolvesOnce({ Items: [overrideWithStaleFirstWaitlist] })
+    .resolvesOnce({ Items: [] })
+    .resolvesOnce({ Items: [course] })
+    .resolvesOnce({ Items: [overrideWithStaleFirstWaitlist] })
+    .resolvesOnce({
+      Items: [{ ...pendingSwap, status: { S: "active" } }],
+    })
+    .resolvesOnce({
+      Items: [
+        {
+          ...overrideWithStaleFirstWaitlist,
+          participants: { L: [{ S: "Bob" }, { S: "Alice" }] },
+          waitlist: { L: [{ S: "Ghost" }] },
+        },
+      ],
+    });
+
+  const event = makeEvent({ currentUser: "nobody" });
+  const result = await handler(event);
+
+  expect(result.statusCode).toBe(200);
+  const body = JSON.parse(result.body);
+  expect(body.promoted).toBe(1);
+  expect(Array.isArray(body.overrides)).toBe(true);
+});

--- a/backend/src/lambdas/processPromotions/index.test.ts
+++ b/backend/src/lambdas/processPromotions/index.test.ts
@@ -177,3 +177,48 @@ test("skips stale first waitlist entry and promotes next valid pending swap", as
   expect(body.promoted).toBe(1);
   expect(Array.isArray(body.overrides)).toBe(true);
 });
+
+test("does not promote when target term is inside cutoff window", async () => {
+  // TEST_NOW = 2025-09-01T06:00:00.000Z; target 06:30 lies inside default 60-minute cutoff.
+  const pendingSwap = {
+    swapId: { S: "2025-09-01_1_2025-09-01_2" },
+    user: { S: "Alice" },
+    fromCourseId: { N: "1" },
+    fromDate: { S: "2025-09-01" },
+    toCourseId: { N: "2" },
+    toDate: { S: "2025-09-01" },
+    status: { S: "pending" },
+  };
+  const course = {
+    id: { N: "2" },
+    name: { S: "Yoga" },
+    weekday: { S: "Monday" },
+    time: { S: "06:30" },
+    capacity: { N: "2" },
+    participants: { L: [] },
+    dates: { L: [{ S: "2025-09-01" }] },
+  };
+  const overrideWithWaitlist = {
+    courseId: { S: "2" },
+    date: { S: "2025-09-01" },
+    participants: { L: [{ S: "Bob" }] },
+    swapped: { L: [] },
+    waitlist: { L: [{ S: "Alice" }] },
+  };
+
+  ddbMock
+    .on(QueryCommand)
+    .resolvesOnce({ Items: [pendingSwap] })
+    .resolvesOnce({ Items: [course] })
+    .resolvesOnce({ Items: [overrideWithWaitlist] })
+    .resolvesOnce({ Items: [pendingSwap] }) // final swaps
+    .resolvesOnce({ Items: [overrideWithWaitlist] }); // final overrides
+
+  const event = makeEvent({ currentUser: "Alice" });
+  const result = await handler(event);
+
+  expect(result.statusCode).toBe(200);
+  const body = JSON.parse(result.body);
+  expect(body.promoted).toBe(0);
+  expect(ddbMock.commandCalls(UpdateItemCommand)).toHaveLength(0);
+});

--- a/backend/src/lambdas/processPromotions/index.ts
+++ b/backend/src/lambdas/processPromotions/index.ts
@@ -1,14 +1,19 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { QueryCommand, UpdateItemCommand, PutItemCommand, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
-import { Swap, CourseDateOverride, Course } from "@yogaswap/shared";
+import {
+  Swap,
+  CourseDateOverride,
+  Course,
+  resolveCancellationSwapCutoffMinutes,
+} from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 import { mapOverrideItem } from "../shared/overrideDynamo";
+import { loadTenantSettings } from "../shared/tenantSettingsLoader";
 
 const client = dynamoClient;
 
-// Hardcodierter Zeitpuffer (in Minuten) vor Kursbeginn für Nachrücken
-const PROMOTION_TIME_BUFFER_MINUTES = 30;
+const DEFAULT_NO_AUTOMATION_MINUTES = 60;
 
 function normalized(value: string): string {
   return value.trim().toLowerCase();
@@ -33,15 +38,20 @@ function addUserUniqueCaseInsensitive(values: string[] | undefined, user: string
 }
 
 // Hilfsfunktion: Prüft, ob ein Kursbeginn mindestens PROMOTION_TIME_BUFFER_MINUTES in der Zukunft liegt
-function isCourseInFuture(courseDate: string, courseTime: string, now: Date): boolean {
+function isCourseInFuture(
+  courseDate: string,
+  courseTime: string,
+  now: Date,
+  noAutomationMinutes: number,
+): boolean {
   try {
     // Kombiniere Datum (YYYY-MM-DD) und Uhrzeit (HH:mm) zu einem Date-Objekt
     const [year, month, day] = courseDate.split('-').map(Number);
     const [hours, minutes] = courseTime.split(':').map(Number);
     const courseStart = new Date(year, month - 1, day, hours, minutes);
     
-    // Aktuelle Zeit + Puffer
-    const bufferTime = new Date(now.getTime() + PROMOTION_TIME_BUFFER_MINUTES * 60 * 1000);
+    // Aktuelle Zeit + Sperrfenster für automatische Promotion
+    const bufferTime = new Date(now.getTime() + noAutomationMinutes * 60 * 1000);
     
     // Prüfe, ob Kursbeginn nach bufferTime liegt
     return courseStart >= bufferTime;
@@ -156,6 +166,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     // Extrahiere currentUser (anpassen je nach Auth-Setup)
     const currentUser = event.requestContext?.authorizer?.principalId || body.currentUser || null;
 
+    let noAutomationMinutes = DEFAULT_NO_AUTOMATION_MINUTES;
+    const tenantsTable = process.env.TENANTS_TABLE;
+    if (tenantsTable) {
+      const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
+      noAutomationMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+    }
+
     let iterations = 0;
     let changed = true;
     const maxIterations = 10;
@@ -221,7 +238,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       const futureOverrides = allOverrides.filter((o) => {
         const course = courses.find((c) => c.id === o.courseId);
         if (!course) return false;
-        return isCourseInFuture(o.date, course.time, now);
+        return isCourseInFuture(o.date, course.time, now, noAutomationMinutes);
       });
       console.log('futureOverrides:', futureOverrides);
 

--- a/backend/src/lambdas/processPromotions/index.ts
+++ b/backend/src/lambdas/processPromotions/index.ts
@@ -3,6 +3,7 @@ import { QueryCommand, UpdateItemCommand, PutItemCommand, DeleteItemCommand } fr
 import { Swap, CourseDateOverride, Course } from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
+import { mapOverrideItem } from "../shared/overrideDynamo";
 
 const client = dynamoClient;
 
@@ -126,6 +127,9 @@ async function createOverrideHelper(tenantId: string, override: CourseDateOverri
       participants: { L: (override.participants || []).map((p) => ({ S: p })) },
       swapped: { L: (override.swapped || []).map((s) => ({ S: s })) },
       waitlist: { L: (override.waitlist || []).map((w) => ({ S: w })) },
+      shortNoticeCancellations: {
+        L: (override.shortNoticeCancellations || []).map((w) => ({ S: w })),
+      },
     },
   });
 
@@ -208,13 +212,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         ConsistentRead: true,
       });
       const overridesData = await client.send(overridesCommand);
-      const allOverrides: CourseDateOverride[] = (overridesData.Items || []).map((item) => ({
-        courseId: Number(item.courseId.S!),
-        date: item.date.S!,
-        participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
-        swapped: item.swapped.L ? item.swapped.L.map((s: any) => s.S) : [],
-        waitlist: item.waitlist.L ? item.waitlist.L.map((w: any) => w.S) : [],
-      }));
+      const allOverrides: CourseDateOverride[] = (overridesData.Items || []).map((item) =>
+        mapOverrideItem(item),
+      );
 
       // Filtere Overrides: zukünftige Termine oder heutige Termine mit Puffer
       const now = new Date();
@@ -407,13 +407,9 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       ConsistentRead: true,
     });
     const updatedOverridesData = await client.send(updatedOverridesCommand);
-    const updatedOverrides: CourseDateOverride[] = (updatedOverridesData.Items || []).map((item) => ({
-      courseId: Number(item.courseId.S!),
-      date: item.date.S!,
-      participants: item.participants.L ? item.participants.L.map((p: any) => p.S) : [],
-      swapped: item.swapped.L ? item.swapped.L.map((s: any) => s.S) : [],
-      waitlist: item.waitlist.L ? item.waitlist.L.map((w: any) => w.S) : [],
-    }));
+    const updatedOverrides: CourseDateOverride[] = (updatedOverridesData.Items || []).map((item) =>
+      mapOverrideItem(item),
+    );
     console.log(`[processPromotions] Complete after ${iterations} iterations`);
     
     return {

--- a/backend/src/lambdas/processPromotions/index.ts
+++ b/backend/src/lambdas/processPromotions/index.ts
@@ -235,23 +235,41 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
         console.log('freeSpots:', freeSpots);
         if (freeSpots <= 0) continue;
 
-        // Wähle promotedUser: Priorisiere currentUser oder erste Person
-        let promotedUser: string | undefined;
-        if (currentUser && includesUserCaseInsensitive(override.waitlist, currentUser)) {
-          promotedUser = currentUser;
-        } else {
-          promotedUser = override.waitlist?.[0];
-        }
-        if (!promotedUser) continue;
+        // Wähle promotedUser: currentUser priorisieren, sonst ersten Waitlist-Eintrag
+        // mit passendem pending Swap (stale Waitlist-Einträge überspringen).
+        const waitlistCandidates = override.waitlist ?? [];
+        const prioritizedCandidates =
+          currentUser && includesUserCaseInsensitive(waitlistCandidates, currentUser)
+            ? [
+                currentUser,
+                ...waitlistCandidates.filter(
+                  (entry) => normalized(entry) !== normalized(currentUser),
+                ),
+              ]
+            : waitlistCandidates;
 
-        console.log('promotedUser:', promotedUser, 'override.courseId:', override.courseId, 'override.date:', override.date, 'override.waitlist:', override.waitlist);
-        const correspondingSwap = pendingSwaps.find(
-          (s) =>
-            normalized(s.user) === normalized(promotedUser) &&
-            s.toCourseId === override.courseId &&
-            s.toDate === override.date
+        let correspondingSwap: Swap | undefined;
+        for (const candidate of prioritizedCandidates) {
+          const match = pendingSwaps.find(
+            (s) =>
+              normalized(s.user) === normalized(candidate) &&
+              s.toCourseId === override.courseId &&
+              s.toDate === override.date,
+          );
+          if (match) {
+            correspondingSwap = match;
+            break;
+          }
+        }
+        console.log(
+          'promotion candidate resolution:',
+          {
+            overrideCourseId: override.courseId,
+            overrideDate: override.date,
+            waitlistCandidates: prioritizedCandidates,
+            correspondingSwap,
+          },
         );
-        console.log('Find in pendingSwaps:', pendingSwaps, 'correspondingSwap:', correspondingSwap);
         if (!correspondingSwap) continue;
 
         const promotedSwapUser = correspondingSwap.user;

--- a/backend/src/lambdas/shared/applySwapCutoffReconcile.ts
+++ b/backend/src/lambdas/shared/applySwapCutoffReconcile.ts
@@ -1,0 +1,40 @@
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import type { Swap } from "@yogaswap/shared";
+import { loadTenantSettings } from "./tenantSettingsLoader";
+import { loadCourseTimesByLegacyId, reconcilePendingSwapsPastOriginCutoff } from "./swapCutoffReconcile";
+
+export async function applySwapCutoffReconcileIfConfigured(input: {
+  client: DynamoDBClient;
+  tenantId: string;
+  swaps: Swap[];
+}): Promise<Swap[]> {
+  const { client, tenantId, swaps } = input;
+  const swapsTable = process.env.SWAPS_TABLE;
+  const overridesTable = process.env.OVERRIDES_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
+  const tenantsTable = process.env.TENANTS_TABLE;
+  if (!swapsTable || !overridesTable || !coursesTable || !tenantsTable) {
+    return swaps;
+  }
+
+  const pending = swaps.filter((s) => s.status === "pending");
+  if (pending.length === 0) return swaps;
+
+  const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
+  const courseTimes = await loadCourseTimesByLegacyId(
+    client,
+    coursesTable,
+    tenantId,
+    pending.map((s) => s.fromCourseId),
+  );
+
+  return reconcilePendingSwapsPastOriginCutoff({
+    client,
+    swapsTable,
+    overridesTable,
+    tenantId,
+    swaps,
+    courseTimes,
+    tenantSettings,
+  });
+}

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.ts
@@ -76,9 +76,7 @@ export function validateSelfServiceOverrideTransition(input: {
     return "Kurzfristige Absage erfordert einen Eintrag in der Teilnehmerliste.";
   }
 
-  if (wasSn && !isSn && inCutoff) {
-    return "Kurzfristige Absage kann in diesem Zeitfenster nicht zurückgenommen werden.";
-  }
+  // SN-Rücknahme ist immer erlaubt: Platz bleibt durch participants ohnehin belegt.
 
   if (!wasSn && isSn && !inCutoff) {
     return "Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.";

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.ts
@@ -1,0 +1,111 @@
+import type { CourseDateOverride, TenantSettings } from "@yogaswap/shared";
+import {
+  includesUserCaseInsensitive,
+  isWithinCancellationSwapCutoff,
+  resolveCancellationSwapCutoffMinutes,
+} from "@yogaswap/shared";
+
+export type OverrideUpdateBody = {
+  participants?: string[];
+  swapped?: string[];
+  waitlist?: string[];
+  shortNoticeCancellations?: string[];
+};
+
+export function mergeOverrideUpdate(
+  existing: CourseDateOverride | null,
+  baseParticipants: string[],
+  updates: OverrideUpdateBody,
+): CourseDateOverride {
+  const base: CourseDateOverride = existing ?? {
+    courseId: 0,
+    date: "",
+    participants: baseParticipants,
+    swapped: [],
+    waitlist: [],
+    shortNoticeCancellations: [],
+  };
+  return {
+    ...base,
+    participants: updates.participants ?? base.participants,
+    swapped: updates.swapped ?? base.swapped ?? [],
+    waitlist: updates.waitlist ?? base.waitlist ?? [],
+    shortNoticeCancellations:
+      updates.shortNoticeCancellations ?? base.shortNoticeCancellations ?? [],
+  };
+}
+
+export function validateShortNoticeParticipantsInvariant(override: CourseDateOverride): string | null {
+  for (const user of override.shortNoticeCancellations ?? []) {
+    if (!includesUserCaseInsensitive(override.participants, user)) {
+      return "Kurzfristig abgesagte Teilnehmer müssen in der Teilnehmerliste stehen.";
+    }
+  }
+  return null;
+}
+
+/**
+ * Self-service override updates: enforce SN/RC/cutoff rules for a single actor nickname.
+ */
+export function validateSelfServiceOverrideTransition(input: {
+  actorNickname: string;
+  courseTime: string;
+  dateIso: string;
+  tenantSettings?: TenantSettings;
+  before: CourseDateOverride | null;
+  after: CourseDateOverride;
+  baseParticipants: string[];
+  now?: Date;
+}): string | null {
+  const { actorNickname, courseTime, dateIso, tenantSettings, before, after, baseParticipants } = input;
+  const now = input.now ?? new Date();
+  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+  const inCutoff = isWithinCancellationSwapCutoff(dateIso, courseTime, cutoffMinutes, now);
+  const actor = actorNickname;
+  const wasParticipant =
+    includesUserCaseInsensitive(before?.participants, actor) ||
+    includesUserCaseInsensitive(baseParticipants, actor);
+  const isParticipant = includesUserCaseInsensitive(after.participants, actor);
+  const wasSn = includesUserCaseInsensitive(before?.shortNoticeCancellations, actor);
+  const isSn = includesUserCaseInsensitive(after.shortNoticeCancellations, actor);
+
+  const invariantError = validateShortNoticeParticipantsInvariant(after);
+  if (invariantError) return invariantError;
+
+  if (isSn && !isParticipant) {
+    return "Kurzfristige Absage erfordert einen Eintrag in der Teilnehmerliste.";
+  }
+
+  if (wasSn && !isSn && inCutoff) {
+    return "Kurzfristige Absage kann in diesem Zeitfenster nicht zurückgenommen werden.";
+  }
+
+  if (!wasSn && isSn && !inCutoff) {
+    return "Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.";
+  }
+
+  if (!wasSn && isSn && inCutoff && !isParticipant) {
+    return "Kurzfristige Absage erfordert einen Eintrag in der Teilnehmerliste.";
+  }
+
+  if (wasParticipant && !isParticipant && !isSn && inCutoff) {
+    return "In diesem Zeitfenster nur kurzfristige Absage möglich (Platz bleibt belegt).";
+  }
+
+  if (wasParticipant && !isParticipant && !isSn && !inCutoff) {
+    return null;
+  }
+
+  if (!wasParticipant && isParticipant && !wasSn && inCutoff) {
+    return "Absage kann in diesem Zeitfenster nicht zurückgenommen werden.";
+  }
+
+  if (!wasParticipant && isParticipant && !wasSn && !inCutoff) {
+    return null;
+  }
+
+  const actorUnchanged = wasParticipant === isParticipant && wasSn === isSn;
+  if (actorUnchanged) return null;
+
+  return "Diese Änderung ist im aktuellen Zeitfenster nicht erlaubt.";
+}

--- a/backend/src/lambdas/shared/overrideDynamo.ts
+++ b/backend/src/lambdas/shared/overrideDynamo.ts
@@ -1,0 +1,22 @@
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
+import type { CourseDateOverride } from "@yogaswap/shared";
+
+export function mapStringList(attr: AttributeValue | undefined): string[] {
+  return attr?.L ? attr.L.map((entry) => entry.S!).filter(Boolean) : [];
+}
+
+export function mapOverrideItem(item: Record<string, AttributeValue>): CourseDateOverride {
+  return {
+    courseId: Number(item.courseId.S!),
+    ...(item.courseUid?.S ? { courseUid: item.courseUid.S } : {}),
+    date: item.date.S!,
+    participants: mapStringList(item.participants),
+    swapped: mapStringList(item.swapped),
+    waitlist: mapStringList(item.waitlist),
+    shortNoticeCancellations: mapStringList(item.shortNoticeCancellations),
+  };
+}
+
+export function stringListAttribute(values: string[]): AttributeValue {
+  return { L: values.map((v) => ({ S: v })) };
+}

--- a/backend/src/lambdas/shared/studioSettingsValidation.ts
+++ b/backend/src/lambdas/shared/studioSettingsValidation.ts
@@ -9,6 +9,7 @@ export type StudioSettingsPatch = {
   minOffsetDays?: number;
   maxOffsetDays?: number;
   rollingPlanningHorizonWeeks?: number;
+  cancellationSwapCutoffMinutesBeforeStart?: number;
 };
 
 export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
@@ -42,6 +43,12 @@ export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string 
     const weeks = patch.rollingPlanningHorizonWeeks;
     if (!Number.isInteger(weeks) || (weeks ?? 0) < 1 || (weeks ?? 0) > 52) {
       return "Planungs- und Sichtfenster muss eine ganze Zahl zwischen 1 und 52 Wochen sein.";
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "cancellationSwapCutoffMinutesBeforeStart")) {
+    const minutes = patch.cancellationSwapCutoffMinutesBeforeStart;
+    if (!Number.isInteger(minutes) || (minutes ?? 0) < 0 || (minutes ?? 0) > 24 * 60) {
+      return "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.";
     }
   }
   return null;

--- a/backend/src/lambdas/shared/swapCutoffReconcile.test.ts
+++ b/backend/src/lambdas/shared/swapCutoffReconcile.test.ts
@@ -1,0 +1,64 @@
+import { reconcilePendingSwapsPastOriginCutoff } from "./swapCutoffReconcile";
+
+const send = jest.fn();
+
+describe("reconcilePendingSwapsPastOriginCutoff", () => {
+  beforeEach(() => {
+    send.mockReset();
+  });
+
+  it("deletes pending swaps when origin is in cutoff", async () => {
+    send.mockResolvedValueOnce({}).mockResolvedValueOnce({ Item: undefined });
+    const client = { send } as never;
+    const now = new Date(2099, 5, 15, 9, 30);
+    const swaps = [
+      {
+        user: "alice",
+        fromCourseId: 1,
+        fromDate: "2099-06-15",
+        toCourseId: 1,
+        toDate: "2099-06-20",
+        status: "pending" as const,
+      },
+    ];
+    const result = await reconcilePendingSwapsPastOriginCutoff({
+      client,
+      swapsTable: "swaps",
+      overridesTable: "overrides",
+      tenantId: "t1",
+      swaps,
+      courseTimes: new Map([[1, "10:00"]]),
+      tenantSettings: { cancellationSwapCutoffMinutesBeforeStart: 60 },
+      now,
+    });
+    expect(result).toEqual([]);
+    expect(send).toHaveBeenCalled();
+  });
+
+  it("keeps pending swaps outside cutoff", async () => {
+    const client = { send } as never;
+    const now = new Date(2099, 5, 15, 7, 0);
+    const swaps = [
+      {
+        user: "alice",
+        fromCourseId: 1,
+        fromDate: "2099-06-15",
+        toCourseId: 1,
+        toDate: "2099-06-20",
+        status: "pending" as const,
+      },
+    ];
+    const result = await reconcilePendingSwapsPastOriginCutoff({
+      client,
+      swapsTable: "swaps",
+      overridesTable: "overrides",
+      tenantId: "t1",
+      swaps,
+      courseTimes: new Map([[1, "10:00"]]),
+      tenantSettings: { cancellationSwapCutoffMinutesBeforeStart: 60 },
+      now,
+    });
+    expect(result).toEqual(swaps);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lambdas/shared/swapCutoffReconcile.ts
+++ b/backend/src/lambdas/shared/swapCutoffReconcile.ts
@@ -1,0 +1,118 @@
+import { DeleteItemCommand, GetItemCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import type { Swap, TenantSettings } from "@yogaswap/shared";
+import {
+  isWithinCancellationSwapCutoff,
+  removeUserCaseInsensitive,
+  resolveCancellationSwapCutoffMinutes,
+} from "@yogaswap/shared";
+import { mapOverrideItem, stringListAttribute } from "./overrideDynamo";
+
+type CourseTimeLookup = Map<number, string>;
+
+export async function loadCourseTimesByLegacyId(
+  client: DynamoDBClient,
+  coursesTable: string,
+  tenantId: string,
+  legacyCourseIds: number[],
+): Promise<CourseTimeLookup> {
+  const unique = [...new Set(legacyCourseIds)];
+  const map: CourseTimeLookup = new Map();
+  await Promise.all(
+    unique.map(async (courseId) => {
+      const resp = await client.send(
+        new GetItemCommand({
+          TableName: coursesTable,
+          Key: { tenantId: { S: tenantId }, courseId: { S: String(courseId) } },
+          ConsistentRead: true,
+        }),
+      );
+      const time = resp.Item?.time?.S ?? "";
+      map.set(courseId, time);
+    }),
+  );
+  return map;
+}
+
+async function removeUserFromTargetWaitlist(
+  client: DynamoDBClient,
+  overridesTable: string,
+  tenantId: string,
+  swap: Swap,
+): Promise<void> {
+  const courseId_date = `${swap.toCourseId}_${swap.toDate}`;
+  const resp = await client.send(
+    new GetItemCommand({
+      TableName: overridesTable,
+      Key: { tenantId: { S: tenantId }, courseId_date: { S: courseId_date } },
+      ConsistentRead: true,
+    }),
+  );
+  if (!resp.Item) return;
+  const override = mapOverrideItem(resp.Item);
+  const waitlist = removeUserCaseInsensitive(override.waitlist ?? [], swap.user);
+  if (waitlist.length === (override.waitlist ?? []).length) return;
+  await client.send(
+    new UpdateItemCommand({
+      TableName: overridesTable,
+      Key: { tenantId: { S: tenantId }, courseId_date: { S: courseId_date } },
+      UpdateExpression: "SET #waitlist = :waitlist",
+      ExpressionAttributeNames: { "#waitlist": "waitlist" },
+      ExpressionAttributeValues: { ":waitlist": stringListAttribute(waitlist) },
+    }),
+  );
+}
+
+/**
+ * Drops pending swaps whose origin occurrence is inside the cancellation cutoff.
+ */
+export async function reconcilePendingSwapsPastOriginCutoff(input: {
+  client: DynamoDBClient;
+  swapsTable: string;
+  overridesTable: string;
+  tenantId: string;
+  swaps: Swap[];
+  courseTimes: CourseTimeLookup;
+  tenantSettings?: TenantSettings;
+  now?: Date;
+}): Promise<Swap[]> {
+  const { client, swapsTable, overridesTable, tenantId, swaps, courseTimes, tenantSettings } = input;
+  const now = input.now ?? new Date();
+  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+  const kept: Swap[] = [];
+
+  for (const swap of swaps) {
+    if (swap.status !== "pending") {
+      kept.push(swap);
+      continue;
+    }
+    const courseTime = courseTimes.get(swap.fromCourseId) ?? "";
+    const inCutoff = isWithinCancellationSwapCutoff(swap.fromDate, courseTime, cutoffMinutes, now);
+    if (!inCutoff) {
+      kept.push(swap);
+      continue;
+    }
+
+    const swapId = `${swap.fromDate}_${swap.fromCourseId}_${swap.toDate}_${swap.toCourseId}`;
+    const user_swapId = `${swap.user}#${swapId}`;
+    await client.send(
+      new DeleteItemCommand({
+        TableName: swapsTable,
+        Key: { tenantId: { S: tenantId }, user_swapId: { S: user_swapId } },
+      }),
+    );
+    await removeUserFromTargetWaitlist(client, overridesTable, tenantId, swap);
+    console.info(
+      JSON.stringify({
+        source: "swapCutoffReconcile",
+        tenantId,
+        swapId,
+        user: swap.user,
+        fromCourseId: swap.fromCourseId,
+        fromDate: swap.fromDate,
+      }),
+    );
+  }
+
+  return kept;
+}

--- a/backend/src/lambdas/updateOverride/index.test.ts
+++ b/backend/src/lambdas/updateOverride/index.test.ts
@@ -1,6 +1,7 @@
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   DynamoDBClient,
+  GetItemCommand,
   QueryCommand,
   UpdateItemCommand,
   UpdateItemCommandInput,
@@ -10,6 +11,20 @@ import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 const dynamoMock = mockClient(DynamoDBClient);
 
+function mockCourseAndOverrideLookup() {
+  dynamoMock
+    .on(GetItemCommand)
+    .resolvesOnce({
+      Item: {
+        tenantId: { S: 'default-tenant' },
+        courseId: { S: '1' },
+        time: { S: '10:00' },
+        participants: { L: [{ S: 'Luna' }] },
+      },
+    })
+    .resolvesOnce({ Item: undefined });
+}
+
 beforeEach(() => {
   dynamoMock.reset();
   process.env.OVERRIDES_TABLE = 'yogaswap-backend-demo-courseOverrides-table';
@@ -18,6 +33,7 @@ beforeEach(() => {
 
 describe('updateOverride Lambda', () => {
   it('should update an override successfully', async () => {
+    mockCourseAndOverrideLookup();
     dynamoMock.on(UpdateItemCommand).resolves({});
 
     const event: APIGatewayProxyEvent = {
@@ -42,11 +58,12 @@ describe('updateOverride Lambda', () => {
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ message: 'Override updated' });
-    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.commandCalls(GetItemCommand)).toHaveLength(2);
+    expect(dynamoMock.commandCalls(UpdateItemCommand)).toHaveLength(1);
     expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(0);
 
     // Zugriff auf das Input-Objekt des Commands (typisiert!)
-    const call = dynamoMock.call(0).args[0].input as UpdateItemCommandInput;
+    const call = dynamoMock.commandCalls(UpdateItemCommand)[0].args[0].input as UpdateItemCommandInput;
 
     expect(call.TableName).toBe('yogaswap-backend-demo-courseOverrides-table');
     expect(call.Key).toEqual({
@@ -138,6 +155,7 @@ describe('updateOverride Lambda', () => {
   });
 
   it('should handle DynamoDB errors gracefully', async () => {
+    mockCourseAndOverrideLookup();
     dynamoMock.on(UpdateItemCommand).rejects(new Error('DynamoDB failure'));
 
     const event: APIGatewayProxyEvent = {
@@ -158,13 +176,24 @@ describe('updateOverride Lambda', () => {
     const result = await handler(event);
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body)).toEqual({ error: 'Failed to update override' });
-    expect(dynamoMock.calls()).toHaveLength(1);
+    expect(dynamoMock.commandCalls(UpdateItemCommand)).toHaveLength(1);
   });
 
   it('resolves courseUid path segment via GSI then updates override', async () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [{ courseId: { S: '42' }, courseUid: { S: '550e8400-e29b-41d4-a716-446655440000' } }],
     });
+    dynamoMock
+      .on(GetItemCommand)
+      .resolvesOnce({
+        Item: {
+          tenantId: { S: 'default-tenant' },
+          courseId: { S: '42' },
+          time: { S: '10:00' },
+          participants: { L: [{ S: 'Luna' }] },
+        },
+      })
+      .resolvesOnce({ Item: undefined });
     dynamoMock.on(UpdateItemCommand).resolves({});
 
     const uidPath = '550e8400-e29b-41d4-a716-446655440000';

--- a/backend/src/lambdas/updateOverride/index.ts
+++ b/backend/src/lambdas/updateOverride/index.ts
@@ -1,9 +1,17 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { GetItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
 import { resolveLegacyCourseIdFromPathSegment } from '../shared/courseUid';
+import { loadTenantSettings } from '../shared/tenantSettingsLoader';
+import {
+  mergeOverrideUpdate,
+  validateSelfServiceOverrideTransition,
+  validateShortNoticeParticipantsInvariant,
+  type OverrideUpdateBody,
+} from '../shared/cutoffOverrideValidation';
+import { mapOverrideItem, mapStringList, stringListAttribute } from '../shared/overrideDynamo';
 
 const client = dynamoClient;
 
@@ -18,6 +26,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (delegationErrorResponse) return delegationErrorResponse;
   const overridesTable = process.env.OVERRIDES_TABLE;
   const coursesTable = process.env.COURSES_TABLE;
+  const tenantsTable = process.env.TENANTS_TABLE;
   const rawCourseId = event.pathParameters?.courseId?.trim();
   const date = event.pathParameters?.date?.trim();
 
@@ -43,44 +52,122 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
     const legacyCourseId = resolvedPath.legacyCourseId;
 
-    const updates = JSON.parse(event.body || '{}');
+    const updates = JSON.parse(event.body || '{}') as OverrideUpdateBody;
+
+    const hasUpdatableField =
+      updates.participants !== undefined ||
+      updates.swapped !== undefined ||
+      updates.waitlist !== undefined ||
+      updates.shortNoticeCancellations !== undefined;
+    if (!hasUpdatableField) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'No fields to update' }) };
+    }
+
+    if (updates.participants) {
+      if (!Array.isArray(updates.participants) || updates.participants.some((p: unknown) => typeof p !== 'string')) {
+        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid participants array' }) };
+      }
+    }
+    if (updates.swapped) {
+      if (!Array.isArray(updates.swapped) || updates.swapped.some((s: unknown) => typeof s !== 'string')) {
+        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid swapped array' }) };
+      }
+    }
+    if (updates.waitlist) {
+      if (!Array.isArray(updates.waitlist) || updates.waitlist.some((w: unknown) => typeof w !== 'string')) {
+        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid waitlist array' }) };
+      }
+    }
+    if (updates.shortNoticeCancellations) {
+      if (
+        !Array.isArray(updates.shortNoticeCancellations) ||
+        updates.shortNoticeCancellations.some((w: unknown) => typeof w !== 'string')
+      ) {
+        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid shortNoticeCancellations array' }) };
+      }
+    }
+
+    const courseResp = await client.send(
+      new GetItemCommand({
+        TableName: coursesTable,
+        Key: { tenantId: { S: tenantId }, courseId: { S: legacyCourseId } },
+        ConsistentRead: true,
+      }),
+    );
+    if (!courseResp.Item) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Course not found' }) };
+    }
+    const courseTime = courseResp.Item.time?.S ?? '';
+    const baseParticipants = mapStringList(courseResp.Item.participants);
+
+    const courseId_date = `${legacyCourseId}_${date}`;
+    const existingResp = await client.send(
+      new GetItemCommand({
+        TableName: overridesTable,
+        Key: { tenantId: { S: tenantId }, courseId_date: { S: courseId_date } },
+        ConsistentRead: true,
+      }),
+    );
+    const before = existingResp.Item ? mapOverrideItem(existingResp.Item) : null;
+    if (before) {
+      before.courseId = Number(legacyCourseId);
+      before.date = date;
+    }
+
+    const touchesCutoffFields =
+      updates.participants !== undefined || updates.shortNoticeCancellations !== undefined;
+
+    if (touchesCutoffFields && userId && tenantsTable) {
+      const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
+      const merged = mergeOverrideUpdate(before, baseParticipants, updates);
+      merged.courseId = Number(legacyCourseId);
+      merged.date = date;
+
+      const invariantError = validateShortNoticeParticipantsInvariant(merged);
+      if (invariantError) {
+        return { statusCode: 400, body: JSON.stringify({ error: invariantError }) };
+      }
+
+      const transitionError = validateSelfServiceOverrideTransition({
+        actorNickname: userId,
+        courseTime,
+        dateIso: date,
+        tenantSettings,
+        before,
+        after: merged,
+        baseParticipants,
+      });
+      if (transitionError) {
+        return { statusCode: 400, body: JSON.stringify({ error: transitionError }) };
+      }
+    }
 
     let updateExpression = 'SET';
     const expressionAttributeValues: Record<string, any> = {};
     const expressionAttributeNames: Record<string, string> = {};
 
-    // Validierung und Mapping für participants
     if (updates.participants) {
-      if (!Array.isArray(updates.participants) || updates.participants.some((p: any) => typeof p !== 'string')) {
-        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid participants array' }) };
-      }
       updateExpression += ' #participants = :participants,';
       expressionAttributeNames['#participants'] = 'participants';
-      expressionAttributeValues[':participants'] = { L: updates.participants.map((p: string) => ({ S: p })) };
+      expressionAttributeValues[':participants'] = stringListAttribute(updates.participants);
     }
 
-    // Validierung und Mapping für swapped
     if (updates.swapped) {
-      if (!Array.isArray(updates.swapped) || updates.swapped.some((s: any) => typeof s !== 'string')) {
-        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid swapped array' }) };
-      }
       updateExpression += ' #swapped = :swapped,';
       expressionAttributeNames['#swapped'] = 'swapped';
-      expressionAttributeValues[':swapped'] = { L: updates.swapped.map((s: string) => ({ S: s })) };
+      expressionAttributeValues[':swapped'] = stringListAttribute(updates.swapped);
     }
 
-    // Validierung und Mapping für waitlist
     if (updates.waitlist) {
-      if (!Array.isArray(updates.waitlist) || updates.waitlist.some((w: any) => typeof w !== 'string')) {
-        return { statusCode: 400, body: JSON.stringify({ error: 'Invalid waitlist array' }) };
-      }
       updateExpression += ' #waitlist = :waitlist,';
       expressionAttributeNames['#waitlist'] = 'waitlist';
-      expressionAttributeValues[':waitlist'] = { L: updates.waitlist.map((w: string) => ({ S: w })) };
+      expressionAttributeValues[':waitlist'] = stringListAttribute(updates.waitlist);
     }
 
-    if (updateExpression === 'SET') {
-      return { statusCode: 400, body: JSON.stringify({ error: 'No fields to update' }) };
+    if (updates.shortNoticeCancellations) {
+      updateExpression += ' #shortNotice = :shortNotice,';
+      expressionAttributeNames['#shortNotice'] = 'shortNoticeCancellations';
+      expressionAttributeValues[':shortNotice'] = stringListAttribute(updates.shortNoticeCancellations);
     }
 
     updateExpression += ' #actorUserId = :actorUserId, #actingForUserId = :actingForUserId,';
@@ -89,9 +176,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     expressionAttributeValues[':actorUserId'] = userId ? { S: userId } : { NULL: true };
     expressionAttributeValues[':actingForUserId'] = actingForUserId ? { S: actingForUserId } : { NULL: true };
 
-    updateExpression = updateExpression.slice(0, -1); // Entferne letztes Komma
+    updateExpression = updateExpression.slice(0, -1);
 
-    const courseId_date = `${legacyCourseId}_${date}`;
     await client.send(
       new UpdateItemCommand({
         TableName: overridesTable,

--- a/backend/src/lambdas/updateTenantSettings/index.ts
+++ b/backend/src/lambdas/updateTenantSettings/index.ts
@@ -21,6 +21,7 @@ const MVP_SETTINGS_KEYS = [
   "minOffsetDays",
   "maxOffsetDays",
   "rollingPlanningHorizonWeeks",
+  "cancellationSwapCutoffMinutesBeforeStart",
 ] as const;
 
 function parseBody(event: APIGatewayProxyEvent): StudioSettingsPatch | null {

--- a/docs/short-notice-cancellation.md
+++ b/docs/short-notice-cancellation.md
@@ -1,0 +1,31 @@
+# Kurzfristige Absage ohne Tausch (#167)
+
+## Studio-Einstellung
+
+- `cancellationSwapCutoffMinutesBeforeStart` (Default: **60**)
+- Vergleich: Kursbeginn = `date` + `course.time` (lokal, wie `buildCourseOccurrenceLocal`)
+
+## Datenmodell (Variante B)
+
+`CourseDateOverride.shortNoticeCancellations`: Nicknames mit **kurzfristiger** Absage.
+
+- Nutzer **bleibt** in `participants` (Slot bleibt belegt, kein Nachrücken).
+- **Rechtzeitige** Absage: nur aus `participants`, nicht in SN — Tausch weiter möglich (auch wenn das Cutoff-Fenster später erreicht wird).
+
+## Abgrenzung
+
+| Thema | Feld / Logik |
+|--------|----------------|
+| Welche Zieltermine wählbar sind | `minOffsetDays` / `maxOffsetDays` |
+| Ob kurz vor Start noch getauscht werden darf | `cancellationSwapCutoffMinutesBeforeStart` |
+
+## Pending-Aufräumen
+
+Beim Laden (`getSwaps`, `getSwapsByStatus`): `pending`-Swaps, deren **Ursprung** im Cutoff liegt, werden entfernt und Wartelisten am Ziel bereinigt (`swapCutoffReconcile`).
+
+Bei kurzfristiger Absage am Ursprung: dieselbe Bereinigung in der App (`cleanupPendingSwapsFromOrigin`).
+
+## UI
+
+- Kurzfristig abgesagte: Chip-Klasse `short-notice` (analog `swapped`).
+- Validierung: UI + Backend (`createSwap`, `updateOverride`).

--- a/docs/short-notice-cancellation.md
+++ b/docs/short-notice-cancellation.md
@@ -26,7 +26,17 @@
 - Aktion: Eintrag aus `shortNoticeCancellations` entfernen; `participants` **unverändert** (Platz war ohnehin belegt).
 - UI: Button **„Absage zurücknehmen“** bei SN immer sichtbar.
 - **Kein** neuer Tausch vom Termin, solange die Person im Cutoff noch normal eingetragen ist und kein RC-Fall vorliegt (weiter `createSwap`-Sperre im Cutoff).
-- **RC** „Absage zurücknehmen“ (wieder in `participants` nach rechtzeitiger Absage) bleibt im Cutoff **gesperrt** (Platz könnte frei werden / Nachrücken).
+
+## RC-Rücknahme (rechtzeitig abgesagt)
+
+RC-Rücknahme ist möglich (auch im Cutoff), wenn noch Platz frei ist. Vor dem Ausführen erscheint ein Bestätigungsdialog.
+
+| Szenario | Verhalten |
+|--------|-----------|
+| RC + **pending** Swaps vorhanden | Warnung; bei Bestätigung werden pending Swaps vom Ursprung gelöscht (Anspruch auf Ersatz erlischt) |
+| RC + **keine** Swaps | Warnung; bei Bestätigung Rücknahme der Absage |
+| RC + **aktiver zukünftiger** Swap | Warnung; bei Bestätigung wird der aktive Swap aufgehoben |
+| RC + **aktiver vergangener** Swap | Kein Rücknahme-Button (auch außerhalb Cutoff) |
 
 ## Abgrenzung
 

--- a/docs/short-notice-cancellation.md
+++ b/docs/short-notice-cancellation.md
@@ -10,6 +10,7 @@
 ## Studio-Einstellung
 
 - `cancellationSwapCutoffMinutesBeforeStart` (Default: **60**)
+- `0` deaktiviert den Kurzfrist-Cutoff (keine automatische SN-Setzung, kein Cutoff-Block)
 - Vergleich: Kursbeginn = `date` + `course.time` (lokal, wie `buildCourseOccurrenceLocal`)
 
 ## Datenmodell (Variante B)

--- a/docs/short-notice-cancellation.md
+++ b/docs/short-notice-cancellation.md
@@ -1,5 +1,12 @@
 # Kurzfristige Absage ohne Tausch (#167)
 
+## Begriffe (nur Doku)
+
+| Kürzel | Bedeutung |
+|--------|-----------|
+| **SN** | Short notice — kurzfristige Absage (im Cutoff-Fenster); Feld `shortNoticeCancellations` |
+| **RC** | Regular cancellation — rechtzeitige Absage (vor Cutoff); nur aus `participants`, nicht in SN |
+
 ## Studio-Einstellung
 
 - `cancellationSwapCutoffMinutesBeforeStart` (Default: **60**)
@@ -10,7 +17,16 @@
 `CourseDateOverride.shortNoticeCancellations`: Nicknames mit **kurzfristiger** Absage.
 
 - Nutzer **bleibt** in `participants` (Slot bleibt belegt, kein Nachrücken).
-- **Rechtzeitige** Absage: nur aus `participants`, nicht in SN — Tausch weiter möglich (auch wenn das Cutoff-Fenster später erreicht wird).
+- **Rechtzeitige (RC) Absage:** nur aus `participants`, nicht in SN — Tausch weiter möglich (auch wenn das Cutoff-Fenster später erreicht wird).
+
+## SN-Rücknahme (Produktentscheidung)
+
+**Kurzfristige Absage kann jederzeit zurückgenommen werden** — auch im Cutoff.
+
+- Aktion: Eintrag aus `shortNoticeCancellations` entfernen; `participants` **unverändert** (Platz war ohnehin belegt).
+- UI: Button **„Absage zurücknehmen“** bei SN immer sichtbar.
+- **Kein** neuer Tausch vom Termin, solange die Person im Cutoff noch normal eingetragen ist und kein RC-Fall vorliegt (weiter `createSwap`-Sperre im Cutoff).
+- **RC** „Absage zurücknehmen“ (wieder in `participants` nach rechtzeitiger Absage) bleibt im Cutoff **gesperrt** (Platz könnte frei werden / Nachrücken).
 
 ## Abgrenzung
 

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -17,10 +17,18 @@ locals {
     "get_swaps" = {
       name             = var.lambdas["get_swaps"].name
       file_name        = var.lambdas["get_swaps"].file_name
-      table_arns       = [module.swaps_table.table_arn]
-      dynamodb_actions = var.lambdas["get_swaps"].dynamodb_actions
+      table_arns = [
+        module.swaps_table.table_arn,
+        module.courses_table.table_arn,
+        module.course_overrides_table.table_arn,
+        module.tenants_table.table_arn,
+      ]
+      dynamodb_actions = ["dynamodb:GetItem", "dynamodb:Scan", "dynamodb:Query", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
       tables = {
-        "SWAPS_TABLE" = module.swaps_table.table_name
+        "SWAPS_TABLE"     = module.swaps_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
+        "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "TENANTS_TABLE"   = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -28,10 +36,18 @@ locals {
     "get_swaps_by_status" = {
       name             = "get-swaps-by-status"
       file_name        = "getSwapsByStatus.zip"
-      table_arns       = [module.swaps_table.table_arn]
-      dynamodb_actions = ["dynamodb:Scan", "dynamodb:Query"]
+      table_arns = [
+        module.swaps_table.table_arn,
+        module.courses_table.table_arn,
+        module.course_overrides_table.table_arn,
+        module.tenants_table.table_arn,
+      ]
+      dynamodb_actions = ["dynamodb:Scan", "dynamodb:Query", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
       tables = {
-        "SWAPS_TABLE" = module.swaps_table.table_name
+        "SWAPS_TABLE"     = module.swaps_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
+        "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "TENANTS_TABLE"   = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -39,11 +55,18 @@ locals {
     "create_swap" = {
       name             = "create-swap"
       file_name        = "createSwap.zip"
-      table_arns       = [module.swaps_table.table_arn, module.courses_table.table_arn]
+      table_arns = [
+        module.swaps_table.table_arn,
+        module.courses_table.table_arn,
+        module.course_overrides_table.table_arn,
+        module.tenants_table.table_arn,
+      ]
       dynamodb_actions = ["dynamodb:PutItem", "dynamodb:GetItem"]
       tables = {
-        "SWAPS_TABLE"   = module.swaps_table.table_name
-        "COURSES_TABLE" = module.courses_table.table_name
+        "SWAPS_TABLE"     = module.swaps_table.table_name
+        "COURSES_TABLE"   = module.courses_table.table_name
+        "OVERRIDES_TABLE" = module.course_overrides_table.table_name
+        "TENANTS_TABLE"   = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []
@@ -96,11 +119,16 @@ locals {
     "update_override" = {
       name             = "update-override"
       file_name        = "updateOverride.zip"
-      table_arns       = [module.course_overrides_table.table_arn, module.courses_table.table_arn]
-      dynamodb_actions = ["dynamodb:UpdateItem", "dynamodb:Query"]
+      table_arns = [
+        module.course_overrides_table.table_arn,
+        module.courses_table.table_arn,
+        module.tenants_table.table_arn,
+      ]
+      dynamodb_actions = ["dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:GetItem"]
       tables = {
         "OVERRIDES_TABLE" = module.course_overrides_table.table_name
         "COURSES_TABLE"   = module.courses_table.table_name
+        "TENANTS_TABLE"   = module.tenants_table.table_name
       }
       s3_actions   = []
       s3_resources = []

--- a/shared/src/cancellationSwapCutoff.ts
+++ b/shared/src/cancellationSwapCutoff.ts
@@ -1,0 +1,95 @@
+import { buildCourseOccurrenceLocal } from "./courseStatus";
+import type { CourseDateOverride, TenantSettings } from "./types";
+
+export const DEFAULT_CANCELLATION_SWAP_CUTOFF_MINUTES = 60;
+const MAX_CUTOFF_MINUTES = 24 * 60;
+
+export function resolveCancellationSwapCutoffMinutes(settings?: TenantSettings): number {
+  const value = settings?.cancellationSwapCutoffMinutesBeforeStart;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= MAX_CUTOFF_MINUTES) {
+    return value;
+  }
+  return DEFAULT_CANCELLATION_SWAP_CUTOFF_MINUTES;
+}
+
+/** True when `now` is at or after (course start − cutoff minutes). */
+export function isWithinCancellationSwapCutoff(
+  isoDate: string,
+  courseTime: string,
+  cutoffMinutes: number,
+  now: Date = new Date(),
+): boolean {
+  if (cutoffMinutes <= 0) return false;
+  const start = buildCourseOccurrenceLocal(isoDate, courseTime);
+  if (!start) return false;
+  const cutoffStart = new Date(start.getTime() - cutoffMinutes * 60 * 1000);
+  return now >= cutoffStart;
+}
+
+export function includesUserCaseInsensitive(list: string[] | undefined, user: string): boolean {
+  const needle = user.toLowerCase();
+  return (list ?? []).some((entry) => entry.toLowerCase() === needle);
+}
+
+export function isShortNoticeCancelled(
+  override: Pick<CourseDateOverride, "shortNoticeCancellations"> | undefined,
+  userName: string,
+): boolean {
+  return includesUserCaseInsensitive(override?.shortNoticeCancellations, userName);
+}
+
+/** RC: rechtzeitig abgesagt (nicht in participants, nicht SN). */
+export function isRegularCancellation(
+  originallyParticipant: boolean,
+  override: CourseDateOverride | undefined,
+  participants: string[],
+  userName: string,
+): boolean {
+  return (
+    originallyParticipant &&
+    !includesUserCaseInsensitive(participants, userName) &&
+    !isShortNoticeCancelled(override, userName)
+  );
+}
+
+/** Für UI/Buttons: kurzfristig SN oder klassische RC-Absage. */
+export function hasEffectiveCancellation(
+  originallyParticipant: boolean,
+  override: CourseDateOverride | undefined,
+  participants: string[],
+  userName: string,
+): boolean {
+  return (
+    isShortNoticeCancelled(override, userName) ||
+    isRegularCancellation(originallyParticipant, override, participants, userName)
+  );
+}
+
+export function canCreateSwapFromOrigin(input: {
+  isoDate: string;
+  courseTime: string;
+  tenantSettings?: TenantSettings;
+  override?: CourseDateOverride;
+  userName: string;
+  participants: string[];
+  originallyParticipant: boolean;
+  now?: Date;
+}): boolean {
+  const { isoDate, courseTime, tenantSettings, override, userName, participants, originallyParticipant } =
+    input;
+  if (isShortNoticeCancelled(override, userName)) return false;
+  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+  if (!isWithinCancellationSwapCutoff(isoDate, courseTime, cutoffMinutes, input.now)) return true;
+  if (isRegularCancellation(originallyParticipant, override, participants, userName)) return true;
+  return false;
+}
+
+export function addUserUniqueCaseInsensitive(list: string[], user: string): string[] {
+  if (includesUserCaseInsensitive(list, user)) return list;
+  return [...list, user];
+}
+
+export function removeUserCaseInsensitive(list: string[], user: string): string[] {
+  const needle = user.toLowerCase();
+  return list.filter((entry) => entry.toLowerCase() !== needle);
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,5 +4,6 @@ export * from './courseStatus';
 export * from './courseEditPolicy';
 export * from './tenantSettings';
 export * from './rollingHorizonShrink';
+export * from './cancellationSwapCutoff';
 export * from './lib/storage';
 export * from './data/mockUsers';

--- a/shared/src/tenantSettings.ts
+++ b/shared/src/tenantSettings.ts
@@ -4,6 +4,7 @@ import type { TenantSettings } from "./types";
 export const DEFAULT_SWAP_MIN_OFFSET_DAYS = -7;
 export const DEFAULT_SWAP_MAX_OFFSET_DAYS = 7;
 export const DEFAULT_ROLLING_PLANNING_HORIZON_WEEKS = 5;
+export { DEFAULT_CANCELLATION_SWAP_CUTOFF_MINUTES, resolveCancellationSwapCutoffMinutes } from "./cancellationSwapCutoff";
 
 export type SwapWindow = {
   minOffsetDays: number;
@@ -46,6 +47,7 @@ export type StudioSettingsPatch = {
   minOffsetDays?: number;
   maxOffsetDays?: number;
   rollingPlanningHorizonWeeks?: number;
+  cancellationSwapCutoffMinutesBeforeStart?: number;
 };
 
 export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string | null {
@@ -79,6 +81,12 @@ export function validateStudioSettingsPatch(patch: StudioSettingsPatch): string 
     const weeks = patch.rollingPlanningHorizonWeeks;
     if (!Number.isInteger(weeks) || (weeks ?? 0) < 1 || (weeks ?? 0) > 52) {
       return "Planungs- und Sichtfenster muss eine ganze Zahl zwischen 1 und 52 Wochen sein.";
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "cancellationSwapCutoffMinutesBeforeStart")) {
+    const minutes = patch.cancellationSwapCutoffMinutesBeforeStart;
+    if (!Number.isInteger(minutes) || (minutes ?? 0) < 0 || (minutes ?? 0) > 24 * 60) {
+      return "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.";
     }
   }
   return null;

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -17,6 +17,8 @@ export type CourseDateOverride = {
   participants: string[];
   swapped?: string[]; // aktive Tausch-Teilnehmer
   waitlist?: string[]; // Nachrücker für volle Termine
+  /** Kurzfristig abgesagt — bleiben in {@link participants} (Slot bleibt belegt). */
+  shortNoticeCancellations?: string[];
   // Anonyme Schnupperteilnehmer / Blocker ohne expliziten User
   // Belegt Kapazität, ohne eine konkrete Person zu modellieren
   anonymousTrialCount?: number;
@@ -186,6 +188,12 @@ export interface TenantSettings {
    * welcher Frist nur Absage statt Ausschliessen moeglich ist. Default: 5.
    */
   rollingPlanningHorizonWeeks?: number;
+  /**
+   * Minuten vor Kursbeginn: ab dann kein neuer Tausch vom Termin (Self-Service);
+   * kurzfristige Absage über {@link CourseDateOverride.shortNoticeCancellations}.
+   * Default im Code: 60.
+   */
+  cancellationSwapCutoffMinutesBeforeStart?: number;
 }
 
 // Verknüpfung zwischen User und Tenant inkl. Rolle und optionalen Overrides.


### PR DESCRIPTION
## Summary
- führt tenant-seitigen Kurzfrist-Cutoff in Minuten ein (`cancellationSwapCutoffMinutesBeforeStart`, Default 60) und ergänzt `shortNoticeCancellations` auf Overrides (Variante B)
- erzwingt Cutoff-Regeln in App + Backend (`createSwap`, `updateOverride`) inkl. RC-/SN-Rücknahmeverhalten, Warn-Dialogen und Cleanup von Origin-Swaps
- ergänzt Reconcile/Promotion-Härtung: pending mit Ursprung im Cutoff werden bereinigt; stale Waitlist-Einträge werden übersprungen; zusätzlich kein Auto-Nachrücken am Zieltermin im Cutoff
- erweitert Tests und Doku (`docs/short-notice-cancellation.md`) inkl. Edgecase `cutoff=0` (deaktiviert Cutoff)

## Test plan
- [x] `npm test --prefix backend`
- [x] `npm test --prefix app`
- [x] `npm test --prefix backend -- processPromotions`
- [x] `npm test --prefix backend -- createSwap`
- [x] `npm test --prefix app -- useCourseSwaps`
- [x] `npm test --prefix app -- src/shared/cancellationSwapCutoff.test.ts`
- [ ] Manuell: RC-Rücknahme im Cutoff mit pending/active-Swaps (Warnung + Cleanup)
- [ ] Manuell: SN-Rücknahme im Cutoff (Marker entfernen, Teilnehmer bleibt eingetragen)
- [ ] Manuell: kein Auto-Nachrücken für Zieltermine im Cutoff

Made with [Cursor](https://cursor.com)