### PR TITLE
Test-Hardening für Kurzfrist-Absage Cutoff (#176)

### DIFF
--- a/app/src/components/StudioSettingsSection.test.tsx
+++ b/app/src/components/StudioSettingsSection.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import React from "react";
+import StudioSettingsSection from "./StudioSettingsSection";
+import { updateTenantSettings } from "../api/tenantSettings";
+import type { Tenant } from "shared/types";
+
+vi.mock("../api/tenantSettings", () => ({
+  updateTenantSettings: vi.fn(),
+}));
+
+const mockedUpdateTenantSettings = updateTenantSettings as unknown as ReturnType<typeof vi.fn>;
+
+function makeTenant(settings: Tenant["settings"] = {}): Tenant {
+  return {
+    tenantId: "default-tenant",
+    name: "Yoga Studio",
+    settings,
+  };
+}
+
+function getCutoffInput(): HTMLInputElement {
+  const input = document.querySelector(
+    'input[type="number"][min="0"][max="1440"]',
+  ) as HTMLInputElement | null;
+  if (!input) throw new Error("Cutoff input not found");
+  return input;
+}
+
+describe("StudioSettingsSection", () => {
+  beforeEach(() => {
+    mockedUpdateTenantSettings.mockReset();
+    cleanup();
+  });
+
+  it("zeigt das Cutoff-Feld mit Defaultwert 60", () => {
+    render(<StudioSettingsSection tenant={makeTenant()} onSaved={vi.fn()} />);
+    const cutoffInput = getCutoffInput();
+    expect(cutoffInput).toHaveValue(60);
+  });
+
+  it("zeigt den geladenen Cutoff-Wert aus Tenant-Settings", () => {
+    render(
+      <StudioSettingsSection
+        tenant={makeTenant({ cancellationSwapCutoffMinutesBeforeStart: 30 })}
+        onSaved={vi.fn()}
+      />,
+    );
+    const cutoffInput = getCutoffInput();
+    expect(cutoffInput).toHaveValue(30);
+  });
+
+  it("sendet Cutoff-Wert beim Speichern korrekt im Patch", async () => {
+    const onSaved = vi.fn();
+    const updatedTenant = makeTenant({ cancellationSwapCutoffMinutesBeforeStart: 45 });
+    mockedUpdateTenantSettings.mockResolvedValue(updatedTenant);
+    render(<StudioSettingsSection tenant={makeTenant()} onSaved={onSaved} />);
+
+    fireEvent.change(getCutoffInput(), { target: { value: "45" } });
+    fireEvent.click(screen.getByRole("button", { name: /studio-einstellungen speichern/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateTenantSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cancellationSwapCutoffMinutesBeforeStart: 45,
+        }),
+      );
+    });
+    expect(onSaved).toHaveBeenCalledWith(updatedTenant);
+  });
+
+  it("zeigt Validierungsfehler bei ungültigem Cutoff-Wert", async () => {
+    render(<StudioSettingsSection tenant={makeTenant()} onSaved={vi.fn()} />);
+    fireEvent.change(getCutoffInput(), { target: { value: "1500" } });
+    fireEvent.click(screen.getByRole("button", { name: /studio-einstellungen speichern/i }));
+
+    expect(
+      await screen.findByText(
+        "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockedUpdateTenantSettings).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lambdas/shared/applySwapCutoffReconcile.test.ts
+++ b/backend/src/lambdas/shared/applySwapCutoffReconcile.test.ts
@@ -1,0 +1,114 @@
+import type { Swap } from "@yogaswap/shared";
+import { applySwapCutoffReconcileIfConfigured } from "./applySwapCutoffReconcile";
+import { loadTenantSettings } from "./tenantSettingsLoader";
+import { loadCourseTimesByLegacyId, reconcilePendingSwapsPastOriginCutoff } from "./swapCutoffReconcile";
+
+jest.mock("./tenantSettingsLoader", () => ({
+  loadTenantSettings: jest.fn(),
+}));
+
+jest.mock("./swapCutoffReconcile", () => ({
+  loadCourseTimesByLegacyId: jest.fn(),
+  reconcilePendingSwapsPastOriginCutoff: jest.fn(),
+}));
+
+const mockedLoadTenantSettings = loadTenantSettings as jest.MockedFunction<typeof loadTenantSettings>;
+const mockedLoadCourseTimesByLegacyId = loadCourseTimesByLegacyId as jest.MockedFunction<
+  typeof loadCourseTimesByLegacyId
+>;
+const mockedReconcile = reconcilePendingSwapsPastOriginCutoff as jest.MockedFunction<
+  typeof reconcilePendingSwapsPastOriginCutoff
+>;
+
+describe("applySwapCutoffReconcileIfConfigured", () => {
+  const oldEnv = process.env;
+  const client = { send: jest.fn() } as never;
+  const pendingSwap: Swap = {
+    user: "alice",
+    fromCourseId: 1,
+    fromDate: "2099-06-15",
+    toCourseId: 2,
+    toDate: "2099-06-20",
+    status: "pending",
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = {
+      ...oldEnv,
+      SWAPS_TABLE: "swaps",
+      OVERRIDES_TABLE: "overrides",
+      COURSES_TABLE: "courses",
+      TENANTS_TABLE: "tenants",
+    };
+  });
+
+  afterAll(() => {
+    process.env = oldEnv;
+  });
+
+  it("macht no-op bei fehlender ENV-Konfiguration", async () => {
+    delete process.env.TENANTS_TABLE;
+    const swaps = [pendingSwap];
+    const result = await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId: "t1",
+      swaps,
+    });
+    expect(result).toBe(swaps);
+    expect(mockedLoadTenantSettings).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+  });
+
+  it("macht no-op ohne pending swaps", async () => {
+    const swaps: Swap[] = [{ ...pendingSwap, status: "active" }];
+    const result = await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId: "t1",
+      swaps,
+    });
+    expect(result).toBe(swaps);
+    expect(mockedLoadTenantSettings).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+  });
+
+  it("lädt Settings + CourseTimes und ruft reconcile auf", async () => {
+    mockedLoadTenantSettings.mockResolvedValue({ cancellationSwapCutoffMinutesBeforeStart: 60 });
+    const courseTimes = new Map<number, string>([[1, "10:00"]]);
+    mockedLoadCourseTimesByLegacyId.mockResolvedValue(courseTimes);
+    mockedReconcile.mockResolvedValue([]);
+    const swaps = [pendingSwap, { ...pendingSwap, status: "active" as const }];
+
+    await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId: "tenant-1",
+      swaps,
+    });
+
+    expect(mockedLoadTenantSettings).toHaveBeenCalledWith(client, "tenants", "tenant-1");
+    expect(mockedLoadCourseTimesByLegacyId).toHaveBeenCalledWith(client, "courses", "tenant-1", [1]);
+    expect(mockedReconcile).toHaveBeenCalledWith({
+      client,
+      swapsTable: "swaps",
+      overridesTable: "overrides",
+      tenantId: "tenant-1",
+      swaps,
+      courseTimes,
+      tenantSettings: { cancellationSwapCutoffMinutesBeforeStart: 60 },
+    });
+  });
+
+  it("gibt das reconcile-Ergebnis durch", async () => {
+    mockedLoadTenantSettings.mockResolvedValue(undefined);
+    mockedLoadCourseTimesByLegacyId.mockResolvedValue(new Map());
+    const reconciled: Swap[] = [{ ...pendingSwap, status: "active" }];
+    mockedReconcile.mockResolvedValue(reconciled);
+
+    const result = await applySwapCutoffReconcileIfConfigured({
+      client,
+      tenantId: "t1",
+      swaps: [pendingSwap],
+    });
+    expect(result).toEqual(reconciled);
+  });
+});

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.test.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.test.ts
@@ -1,0 +1,85 @@
+import type { CourseDateOverride } from "@yogaswap/shared";
+import {
+  validateSelfServiceOverrideTransition,
+  validateShortNoticeParticipantsInvariant,
+} from "./cutoffOverrideValidation";
+
+function makeOverride(partial: Partial<CourseDateOverride> = {}): CourseDateOverride {
+  return {
+    courseId: 1,
+    date: "2099-06-15",
+    participants: ["alice"],
+    swapped: [],
+    waitlist: [],
+    shortNoticeCancellations: [],
+    ...partial,
+  };
+}
+
+describe("cutoffOverrideValidation", () => {
+  const baseInput = {
+    actorNickname: "alice",
+    courseTime: "10:00",
+    dateIso: "2099-06-15",
+    tenantSettings: { cancellationSwapCutoffMinutesBeforeStart: 60 },
+    baseParticipants: ["alice"],
+  };
+
+  it("fordert für SN-Einträge auch participants", () => {
+    const error = validateShortNoticeParticipantsInvariant(
+      makeOverride({
+        participants: [],
+        shortNoticeCancellations: ["alice"],
+      }),
+    );
+    expect(error).toBe("Kurzfristig abgesagte Teilnehmer müssen in der Teilnehmerliste stehen.");
+  });
+
+  it("blockiert SN-Setzen außerhalb des Cutoff", () => {
+    const before = makeOverride();
+    const after = makeOverride({ shortNoticeCancellations: ["alice"] });
+    const error = validateSelfServiceOverrideTransition({
+      ...baseInput,
+      before,
+      after,
+      now: new Date(2099, 5, 15, 8, 0),
+    });
+    expect(error).toBe("Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.");
+  });
+
+  it("erlaubt SN-Rücknahme innerhalb des Cutoff", () => {
+    const before = makeOverride({ shortNoticeCancellations: ["alice"] });
+    const after = makeOverride({ shortNoticeCancellations: [] });
+    const error = validateSelfServiceOverrideTransition({
+      ...baseInput,
+      before,
+      after,
+      now: new Date(2099, 5, 15, 9, 30),
+    });
+    expect(error).toBeNull();
+  });
+
+  it("sperrt RC-Entfernung aus participants im Cutoff", () => {
+    const before = makeOverride();
+    const after = makeOverride({ participants: [] });
+    const error = validateSelfServiceOverrideTransition({
+      ...baseInput,
+      before,
+      after,
+      now: new Date(2099, 5, 15, 9, 30),
+    });
+    expect(error).toBe("In diesem Zeitfenster nur kurzfristige Absage möglich (Platz bleibt belegt).");
+  });
+
+  it("erlaubt unveränderte Actor-Werte", () => {
+    const before = makeOverride();
+    const after = makeOverride({ waitlist: ["mia"] });
+    const error = validateSelfServiceOverrideTransition({
+      ...baseInput,
+      before,
+      after,
+      now: new Date(2099, 5, 15, 9, 30),
+    });
+    expect(error).toBeNull();
+  });
+});

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.ts
@@ -77,6 +77,9 @@ export function validateSelfServiceOverrideTransition(input: {
   }
 
   // SN-Rücknahme ist immer erlaubt: Platz bleibt durch participants ohnehin belegt.
+  if (wasSn && !isSn && isParticipant) {
+    return null;
+  }
 
   if (!wasSn && isSn && !inCutoff) {
     return "Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.";

--- a/backend/src/lambdas/shared/overrideDynamo.test.ts
+++ b/backend/src/lambdas/shared/overrideDynamo.test.ts
@@ -1,0 +1,25 @@
+import { mapOverrideItem, mapStringList, stringListAttribute } from "./overrideDynamo";
+
+describe("overrideDynamo", () => {
+  it("mappt shortNoticeCancellations korrekt aus Dynamo-Item", () => {
+    const mapped = mapOverrideItem({
+      courseId: { S: "12" },
+      date: { S: "2099-06-15" },
+      participants: { L: [{ S: "alice" }] },
+      swapped: { L: [] },
+      waitlist: { L: [{ S: "mia" }] },
+      shortNoticeCancellations: { L: [{ S: "Alice" }] },
+    });
+    expect(mapped.shortNoticeCancellations).toEqual(["Alice"]);
+  });
+
+  it("liefert leere Liste wenn String-List fehlt", () => {
+    expect(mapStringList(undefined)).toEqual([]);
+  });
+
+  it("baut Dynamo-Stringliste für Update korrekt", () => {
+    expect(stringListAttribute(["alice", "mia"])).toEqual({
+      L: [{ S: "alice" }, { S: "mia" }],
+    });
+  });
+});

--- a/backend/src/lambdas/shared/studioSettingsValidation.test.ts
+++ b/backend/src/lambdas/shared/studioSettingsValidation.test.ts
@@ -1,0 +1,24 @@
+import { validateStudioSettingsPatch } from "./studioSettingsValidation";
+
+describe("validateStudioSettingsPatch", () => {
+  it("akzeptiert cutoff im erlaubten Bereich", () => {
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: 0 })).toBeNull();
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: 1440 })).toBeNull();
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: 60 })).toBeNull();
+  });
+
+  it("liefert Fehler bei cutoff außerhalb 0..1440", () => {
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: -1 })).toBe(
+      "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.",
+    );
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: 1441 })).toBe(
+      "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.",
+    );
+  });
+
+  it("liefert Fehler bei nicht-ganzzahligem cutoff", () => {
+    expect(validateStudioSettingsPatch({ cancellationSwapCutoffMinutesBeforeStart: 30.5 })).toBe(
+      "Kurzfrist-Absage: Minuten vor Terminbeginn müssen eine ganze Zahl zwischen 0 und 1440 sein.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ergänzt gezielte Backend-Tests für Cutoff-Policy und Reconcile-Orchestrierung (`cutoffOverrideValidation`, `applySwapCutoffReconcile`)
- ergänzt fehlende Abdeckung für optionale Shared-Helfer (`studioSettingsValidation`, `overrideDynamo`) und UI-Settings (`StudioSettingsSection`)
- schließt eine aufgedeckte Regel-Lücke: SN-Rücknahme im Cutoff wird in `validateSelfServiceOverrideTransition` explizit erlaubt

## Test plan
- [x] `npm test --prefix backend -- cutoffOverrideValidation applySwapCutoffReconcile studioSettingsValidation overrideDynamo`
- [x] `npm test --prefix app -- StudioSettingsSection.test.tsx`
- [ ] Optional manuell: SN im Cutoff setzen und direkt wieder zurücknehmen (kein 4xx, Marker entfernt)

Made with [Cursor](https://cursor.com)