### PR TITLE
Wochenansicht mit Kursübersicht-Toggle (#164)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -339,6 +339,12 @@ body {
   color: #92400e;
 }
 
+.course-term-visual-marker--excluded {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+
 .course-status-badge {
   flex-shrink: 0;
   font-size: 11px;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -299,6 +299,62 @@ body {
   min-width: 0;
 }
 
+.course-head-meta {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.course-week-view-legend {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 10px;
+  color: #4b5563;
+  font-size: 12px;
+}
+
+.course-week-view-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.course-week-view-faded-hint {
+  margin: 0 0 12px;
+}
+
+.course-term-visual-markers {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.course-term-visual-marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.course-term-visual-marker--past {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #4b5563;
+}
+
+.course-term-visual-marker--cutoff {
+  background: #fef3c7;
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
 .course-status-badge {
   flex-shrink: 0;
   font-size: 11px;
@@ -1127,9 +1183,17 @@ a:focus-visible {
     max-height: 300px;
   }
   .course-head {
-    flex-direction: column;
+    flex-direction: row;
     align-items: flex-start;
-    gap: 0.25rem;
+    gap: 0.5rem;
+  }
+  .course-head-title {
+    flex: 1;
+    min-width: 0;
+  }
+  .course-head-meta {
+    margin-left: auto;
+    align-items: flex-end;
   }
   .course-row {
     flex-direction: column;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -31,6 +31,100 @@ body {
   margin-top: 1.5rem;
 }
 
+.course-views-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 16px;
+  text-align: left;
+}
+
+.course-views-toggle {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.course-views-toggle-btn {
+  border: none;
+  background: transparent;
+  padding: 8px 14px;
+  font-size: 14px;
+  cursor: pointer;
+  color: #374151;
+}
+
+.course-views-toggle-btn.is-active {
+  background: #111827;
+  color: #fff;
+}
+
+.course-views-toggle-btn:not(.is-active):hover {
+  background: #f3f4f6;
+}
+
+.course-week-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.course-week-nav-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  min-width: 12rem;
+  text-align: center;
+}
+
+.course-week-nav-btn,
+.course-week-nav-today {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #374151;
+}
+
+.course-week-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 6px;
+}
+
+.course-week-nav-today {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.course-week-nav-btn:hover,
+.course-week-nav-today:hover {
+  background: #f3f4f6;
+}
+
+.course-views-hint {
+  text-align: center;
+  margin: 0 0 16px;
+}
+
+.course-week-view--stub {
+  padding: 1.5rem;
+  border: 1px dashed #d1d5db;
+  border-radius: 8px;
+  background: #fafafa;
+  text-align: center;
+}
+
+.course-week-view-stub-note {
+  margin: 0 0 12px;
+}
+
 .course-management-toolbar {
   display: flex;
   justify-content: space-between;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1107,6 +1107,32 @@ a:focus-visible {
   cursor: help;
 }
 
+.swap-modal-section-head {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.85rem;
+  margin-bottom: 0.2rem;
+}
+
+.swap-modal-section-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.swap-modal-hint-wrap {
+  display: inline-flex;
+  align-items: flex-start;
+}
+
+.swap-modal-hint-popover {
+  max-width: 22rem;
+}
+
+.swap-modal-hint-popover p {
+  margin: 0;
+}
+
 /* Responsive */
 @media (max-width: 1023px) {
   .grid { grid-template-columns: repeat(2, 1fr); }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -416,16 +416,39 @@ body {
   padding: 4px 8px;
   font-size: 12px;
 }
-.chip.swapped {
-  background-color: #ffd54f; /* Gelb für Tausch */
+.chip.swapped:not(.chip-self) {
+  background-color: #fff9c4; /* Dezentes Gelb — getauschte andere Teilnehmer */
+  color: #5d4e37;
 }
-.chip.short-notice {
-  background-color: #ffccbc; /* Kurzfristig abgesagt, Platz bleibt belegt */
+.chip.swapped.chip-self {
+  background-color: #ffd54f;
+  color: inherit;
+  font-weight: 600;
+}
+/* Kurzfristig abgesagt (SN): andere = blass rot, eigener Chip = kräftig rot */
+.chip.short-notice:not(.chip-self) {
+  background-color: #ffebee;
+  color: #8d4a4a;
   text-decoration: line-through;
+  text-decoration-color: #c62828;
+}
+.chip.short-notice.chip-self {
+  background-color: #c62828;
+  color: #fff;
+  text-decoration: line-through;
+  text-decoration-color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
 }
 .chip.free {
   background-color: #c8e6c9; /* Grün für frei */
   font-style: italic;
+}
+
+/* Eingeloggte:r User in Teilnehmer- oder Warteliste (intensiver als „frei“) */
+.chip.chip-self:not(.short-notice):not(.swapped) {
+  background-color: #2e7d32;
+  color: #fff;
+  font-weight: 600;
 }
 
 .chip.overbook-free {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -307,22 +307,6 @@ body {
   flex-shrink: 0;
 }
 
-.course-week-view-legend {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 10px;
-  margin: 0 0 10px;
-  color: #4b5563;
-  font-size: 12px;
-}
-
-.course-week-view-legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .course-week-view-faded-hint {
   margin: 0 0 12px;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1196,13 +1196,22 @@ a:focus-visible {
     align-items: flex-end;
   }
   .course-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .course-row:not(.list-row) > :last-child {
+    margin-left: auto;
+    text-align: right;
   }
   .course-row.list-row .label {
-    min-width: 0;
+    min-width: 82px;
     padding-top: 0;
+  }
+  .course-row.list-row .chips {
+    flex: 1;
+    min-width: 0;
   }
   .course-card select,
   .course-card button {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -113,16 +113,96 @@ body {
   margin: 0 0 16px;
 }
 
-.course-week-view--stub {
-  padding: 1.5rem;
-  border: 1px dashed #d1d5db;
-  border-radius: 8px;
-  background: #fafafa;
-  text-align: center;
+.course-week-view {
+  text-align: left;
 }
 
-.course-week-view-stub-note {
-  margin: 0 0 12px;
+.course-week-view-empty,
+.course-week-view-error {
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.course-week-view-error {
+  color: #b91c1c;
+}
+
+.course-week-day-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.course-week-day-title {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.course-week-occurrence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.course-week-occurrence-btn {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.course-week-occurrence-btn:hover {
+  background: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.course-week-occurrence--excluded .course-week-occurrence-btn {
+  background: #f9fafb;
+  border-style: dashed;
+  opacity: 0.92;
+}
+
+.course-week-occurrence-time {
+  font-weight: 600;
+  min-width: 3rem;
+}
+
+.course-week-occurrence-name {
+  flex: 1;
+  font-weight: 500;
+}
+
+.course-week-occurrence-badge {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.course-week-occurrence-meta {
+  font-size: 12px;
+  width: 100%;
 }
 
 .course-management-toolbar {

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -6,16 +6,16 @@ import App from "./App";
 import { getActingForUserId, setActingForUserId, setActorUserId } from "./api/delegation";
 import { canManageParticipants } from "shared/permissions";
 
-const courseListMock = vi.fn<(props: unknown) => void>();
+const coursesShellMock = vi.fn<(props: unknown) => void>();
 
 vi.mock("./components/Login", () => ({
   default: () => <div>Login Mock</div>,
 }));
 
-vi.mock("./components/CourseList", () => ({
+vi.mock("./components/CoursesShell", () => ({
   default: (props: unknown) => {
-    courseListMock(props);
-    return <div>CourseList Mock</div>;
+    coursesShellMock(props);
+    return <div>CoursesShell Mock</div>;
   },
 }));
 
@@ -78,7 +78,7 @@ describe("App delegation mode", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
-    courseListMock.mockClear();
+    coursesShellMock.mockClear();
     vi.mocked(canManageParticipants).mockReturnValue(true);
     setActingForUserId(null);
     setActorUserId(null);
@@ -131,7 +131,7 @@ describe("App delegation mode", () => {
     expect(screen.getByText(/vertretung aktiv:/i)).toBeInTheDocument();
     expect(screen.getByText(/du handelst im auftrag von/i)).toBeInTheDocument();
     expect(screen.queryByText(/AdminPanel Mock/i)).not.toBeInTheDocument();
-    expect(courseListMock).toHaveBeenLastCalledWith(
+    expect(coursesShellMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ forceParticipantView: true }),
     );
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import "./App.css";
 import Login from "./components/Login";
-import CourseList from "./components/CourseList";
+import CoursesShell from "./components/CoursesShell";
 import AdminPanel from "./components/AdminPanel";
 import Invite from "./components/Invite";
 import ForgotPassword from "./components/ForgotPassword";
@@ -247,10 +247,7 @@ function MainApp() {
         <section
           className={`main-section main-section-courses${actingForUserIdState ? " is-delegation-active" : ""}`}
         >
-          <p className="muted" style={{ textAlign: "center", marginBottom: 16 }}>
-            Klicke in deinen Kursen auf <em>„Termin absagen“</em> oder <em>„Tauschen anfragen“</em>.
-          </p>
-          <CourseList
+          <CoursesShell
             currentUser={effectiveUser}
             tenant={tenant ?? undefined}
             membership={membership ?? undefined}

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -88,6 +88,27 @@ describe("CourseCard", () => {
     expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
   });
 
+  it("kennzeichnet vom Studio abgesagte Termine in der Wochenansicht", () => {
+    const weekCourse: Course = {
+      ...baseCourse,
+      dates: ["2099-06-16", "2099-06-18"],
+      excludedDates: ["2099-06-16"],
+    };
+
+    renderCourseCard({
+      course: weekCourse,
+      dates: [new Date("2099-06-16T10:00:00Z"), new Date("2099-06-18T10:00:00Z")],
+      includePastTermsInSelect: true,
+      initialSelectedDate: new Date("2099-06-16T10:00:00Z"),
+    });
+
+    expect(screen.getByTitle(/Termin entfällt/i)).toBeInTheDocument();
+    expect(screen.getByText(/vom Studio abgesagt/i)).toBeInTheDocument();
+    expect(screen.getByText("entfällt")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /6\/16\/2099 \(entfällt\)/i })).toBeInTheDocument();
+  });
+
   it("deaktiviert Datumsauswahl, wenn keine zukünftigen Termine vorhanden sind", () => {
     const courseWithoutFutureDates: Course = {
       ...baseCourse,

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -179,6 +179,32 @@ describe("CourseCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("zeigt im Swap-Modal den Titel „Anderen Termin wählen“ nach eigener Absage", () => {
+    const cancelledOverride: CourseDateOverride = {
+      courseId: 1,
+      date: "2099-06-16",
+      participants: [],
+      swapped: [],
+      waitlist: [],
+    };
+    const alternativeCourse: Course = {
+      ...baseCourse,
+      id: 2,
+      name: "Yoga Abend",
+      dates: ["2099-06-20"],
+      participants: [],
+    };
+
+    renderCourseCard({
+      allCourses: [baseCourse, alternativeCourse],
+      overrides: [cancelledOverride],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Anderen Termin wählen/i }));
+    expect(screen.getByRole("heading", { name: /Anderen Termin wählen/i })).toBeInTheDocument();
+    expect(screen.queryByText(/folgt/i)).not.toBeInTheDocument();
+  });
+
   it("öffnet das Swap-Modal und ruft confirmSwap bzw. requestSwap korrekt auf", () => {
     const confirmSwap = vi.fn();
     const requestSwap = vi.fn();

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -68,6 +68,54 @@ describe("CourseCard", () => {
     cleanup();
   });
 
+  it("markiert eigene kurzfristige Absage mit chip-self und short-notice", () => {
+    const overrideSn: CourseDateOverride = {
+      ...baseOverride,
+      participants: ["alice"],
+      shortNoticeCancellations: ["alice"],
+    };
+
+    const { container } = renderCourseCard({ overrides: [overrideSn] });
+
+    const selfSn = container.querySelector(".chip.chip-self.short-notice");
+    expect(selfSn).toHaveTextContent("alice");
+    expect(selfSn?.getAttribute("title")).toMatch(/Du — kurzfristig abgesagt/i);
+  });
+
+  it("zeigt getauschte und kurzfristig abgesagte andere Teilnehmer dezenter als den eigenen Chip", () => {
+    const overrideMixed: CourseDateOverride = {
+      ...baseOverride,
+      participants: ["alice", "bob", "carol"],
+      swapped: ["bob"],
+      shortNoticeCancellations: ["carol"],
+    };
+
+    const { container } = renderCourseCard({ overrides: [overrideMixed] });
+
+    expect(container.querySelector(".chip.chip-self")).toHaveTextContent("alice");
+    expect(screen.getByText("bob").closest(".chip")).toHaveClass("swapped");
+    expect(screen.getByText("bob").closest(".chip")).not.toHaveClass("chip-self");
+    expect(screen.getByText("carol").closest(".chip")).toHaveClass("short-notice");
+    expect(screen.getByText("carol").closest(".chip")).not.toHaveClass("chip-self");
+  });
+
+  it("hebt den eigenen Chip in Teilnehmer- und Warteliste grün hervor", () => {
+    const overrideWithWaitlist: CourseDateOverride = {
+      ...baseOverride,
+      participants: ["alice", "bob"],
+      waitlist: ["alice"],
+    };
+
+    const { container } = renderCourseCard({ overrides: [overrideWithWaitlist] });
+
+    const selfChips = container.querySelectorAll(".chip.chip-self");
+    expect(selfChips).toHaveLength(2);
+    expect(selfChips[0]).toHaveTextContent("alice");
+    expect(selfChips[0]).toHaveAttribute("title", "Du");
+    expect(container.querySelector(".chip.wait.chip-self")).toHaveAttribute("title", "Du (Warteliste)");
+    expect(screen.getByText("bob").closest(".chip")).not.toHaveClass("chip-self");
+  });
+
   it("zeigt Badge und Hinweis bei gesperrter Teilnehmer-Ansicht für inaktiven Kurs", () => {
     const inactiveCourse: Course = {
       ...baseCourse,

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -193,6 +193,12 @@ describe("CourseCard", () => {
 
     // Es gibt mindestens einen freien Ersatztermin
     expect(screen.getByText(/Es stehen 1 freie Termin\(e\) zur Auswahl\./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hilfe: Warteliste im Tauschdialog/i })).toBeInTheDocument();
+
+    const freeSlotsHint = screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i });
+    fireEvent.click(freeSlotsHint);
+    expect(screen.getByRole("note")).toHaveTextContent(/gleichzeitig von deinem aktuellen Termin ab/i);
 
     // Button ist deaktiviert und bleibt es auch, da keine Auswahl möglich ist
     const confirmButton = screen.getByRole("button", { name: /Bestätigen/i });

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -88,7 +88,7 @@ describe("CourseCard", () => {
     expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
   });
 
-  it("zeigt Hinweis, wenn keine zukünftigen Termine vorhanden sind", () => {
+  it("deaktiviert Datumsauswahl, wenn keine zukünftigen Termine vorhanden sind", () => {
     const courseWithoutFutureDates: Course = {
       ...baseCourse,
       dates: ["2000-01-01"],
@@ -100,9 +100,6 @@ describe("CourseCard", () => {
       overrides: [],
     });
 
-    expect(
-      screen.getByText(/Zur Zeit sind keine zukünftigen Termine für diesen Kurs geplant\./i),
-    ).toBeInTheDocument();
     const select = screen.getByRole("combobox");
     expect(select).toBeDisabled();
   });

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
   buildCourseOccurrenceLocal,
@@ -246,6 +247,8 @@ export default function CourseCard({
     [swaps, userName, course.id],
   );
   const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
+  const showPastGraceMarker = includePastTermsInSelect && isPastOccurrence;
+  const showCutoffMarker = includePastTermsInSelect && !isPastOccurrence && originInCutoff;
   const canUseFullTermActions =
     !participantActionsLocked &&
     hasUpcomingDates &&
@@ -300,19 +303,41 @@ export default function CourseCard({
             {course.weekday} · {course.time}
           </div>
         </div>
-        {participantActionsLocked && (
-          <span
-            className={`course-status-badge ${
-              showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
-                ? "course-status-badge--auto"
-                : "course-status-badge--inactive"
-            }`}
-          >
-            {showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
-              ? "Automatisch inaktiv"
-              : "Inaktiv"}
-          </span>
-        )}
+        <div className="course-head-meta">
+          {(showPastGraceMarker || showCutoffMarker) && (
+            <div className="course-term-visual-markers" role="status">
+              {showPastGraceMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--past"
+                  title="Vergangener Termin im Nachlauf"
+                >
+                  <History size={12} aria-hidden="true" />
+                </span>
+              )}
+              {showCutoffMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--cutoff"
+                  title="Kurz vor Termin (Cutoff)"
+                >
+                  <Clock3 size={12} aria-hidden="true" />
+                </span>
+              )}
+            </div>
+          )}
+          {participantActionsLocked && (
+            <span
+              className={`course-status-badge ${
+                showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+                  ? "course-status-badge--auto"
+                  : "course-status-badge--inactive"
+              }`}
+            >
+              {showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+                ? "Automatisch inaktiv"
+                : "Inaktiv"}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="course-row">

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import { Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -55,6 +55,37 @@ function sameDayUTC(a: Date, b: Date) {
     a.getUTCFullYear() === b.getUTCFullYear() &&
     a.getUTCMonth() === b.getUTCMonth() &&
     a.getUTCDate() === b.getUTCDate()
+  );
+}
+
+function SwapModalHint({ label, children }: { label: string; children: ReactNode }) {
+  const hintId = useId();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span className="swap-modal-hint-wrap">
+      <button
+        type="button"
+        className="studio-field-hint"
+        title={label}
+        aria-expanded={open}
+        aria-controls={hintId}
+        aria-label={`Hilfe: ${label}`}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+      >
+        ?
+      </button>
+      {open && (
+        <div id={hintId} role="note" className="studio-field-hint-popover swap-modal-hint-popover">
+          {children}
+        </div>
+      )}
+    </span>
   );
 }
 
@@ -673,58 +704,97 @@ export default function CourseCard({
               · {course.name}
             </p>
 
-            {availableSwapDates.length > 0 ? (
+            {availableSwapDates.length > 0 || waitlistDates.length > 0 ? (
               <>
-                <p className="muted">
-                  Es stehen {availableSwapDates.length} freie Termin(e) zur Auswahl.
-                </p>
-                <select
-                  value={swapDateIso ?? ""} // 
-                  onChange={(e) => {
-                    setSwapDateIso(e.target.value || null);
-                    setSwapDateIsoWaitlist(null) // andere Auswahl zuruecksetzen
-                  }}
-                >
-                  <option value="" disabled>
-                    Bitte freien Termin auswählen…
-                  </option>
-                  {availableSwapDates.map((swapDate, idx) => (
-                    <option key={idx} value={swapDate.date.toISOString()}>
-                      {new Intl.DateTimeFormat("de-DE", {
-                        year: "numeric",
-                        month: "2-digit",
-                        day: "2-digit",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      }).format(swapDate.date)}
-                    </option>
-                  ))}
-                </select>
-                <p className="muted" style={{ marginTop: "1em" }}>
-                  Oder Wunsch auf die Warteliste setzen ({waitlistDates.length} mögliche):
-                </p>
-                <select
-                  value={swapDateIsoWaitlist ?? ""}
-                  onChange={(e) => {
-                    setSwapDateIsoWaitlist(e.target.value || null);
-                    setSwapDateIso(null); // andere Auswahl zurücksetzen
-                  }}
-                >
-                  <option value="" disabled>
-                    Bitte belegten Termin wählen…
-                  </option>
-                  {waitlistDates.map((waitlistDate, idx) => (
-                    <option key={idx} value={waitlistDate.date.toISOString()}>
-                      {new Intl.DateTimeFormat("de-DE", {
-                        year: "numeric",
-                        month: "2-digit",
-                        day: "2-digit",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      }).format(waitlistDate.date)}
-                    </option>
-                  ))}
-                </select>
+                <div className="swap-modal-section-head">
+                  <span className="swap-modal-section-title">Freie Termine</span>
+                  <SwapModalHint label="Freie Tauschtermine">
+                    <p>
+                      Termine mit freien Plätzen zwischen{" "}
+                      <strong>
+                        {swapWindow.minOffsetDays} und {swapWindow.maxOffsetDays} Tagen
+                      </strong>{" "}
+                      nach deinem Kurstermin (nur in der Zukunft). Mit der Bestätigung eines Zieltermins
+                      meldest du dich gleichzeitig von deinem aktuellen Termin ab.
+                    </p>
+                  </SwapModalHint>
+                </div>
+                {availableSwapDates.length > 0 ? (
+                  <>
+                    <p className="muted">
+                      Es stehen {availableSwapDates.length} freie Termin(e) zur Auswahl.
+                    </p>
+                    <select
+                      value={swapDateIso ?? ""}
+                      onChange={(e) => {
+                        setSwapDateIso(e.target.value || null);
+                        setSwapDateIsoWaitlist(null);
+                      }}
+                    >
+                      <option value="" disabled>
+                        Bitte freien Termin auswählen…
+                      </option>
+                      {availableSwapDates.map((swapDate, idx) => (
+                        <option key={idx} value={swapDate.date.toISOString()}>
+                          {new Intl.DateTimeFormat("de-DE", {
+                            year: "numeric",
+                            month: "2-digit",
+                            day: "2-digit",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          }).format(swapDate.date)}
+                        </option>
+                      ))}
+                    </select>
+                  </>
+                ) : (
+                  <p className="muted">Derzeit keine freien Termine im Tauschfenster.</p>
+                )}
+
+                <div className="swap-modal-section-head">
+                  <span className="swap-modal-section-title">Warteliste</span>
+                  <SwapModalHint label="Warteliste im Tauschdialog">
+                    <p>
+                      Ausgebuchte Termine im gleichen Zeitfenster (
+                      <strong>
+                        {swapWindow.minOffsetDays} bis {swapWindow.maxOffsetDays} Tage
+                      </strong>{" "}
+                      nach deinem Kurstermin). Die Anfrage landet auf der Warteliste — noch ohne feste
+                      Buchung.
+                    </p>
+                  </SwapModalHint>
+                </div>
+                {waitlistDates.length > 0 ? (
+                  <>
+                    <p className="muted">
+                      {waitlistDates.length} belegte Termin(e) mit Wartelisten-Option:
+                    </p>
+                    <select
+                      value={swapDateIsoWaitlist ?? ""}
+                      onChange={(e) => {
+                        setSwapDateIsoWaitlist(e.target.value || null);
+                        setSwapDateIso(null);
+                      }}
+                    >
+                      <option value="" disabled>
+                        Bitte belegten Termin wählen…
+                      </option>
+                      {waitlistDates.map((waitlistDate, idx) => (
+                        <option key={idx} value={waitlistDate.date.toISOString()}>
+                          {new Intl.DateTimeFormat("de-DE", {
+                            year: "numeric",
+                            month: "2-digit",
+                            day: "2-digit",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          }).format(waitlistDate.date)}
+                        </option>
+                      ))}
+                    </select>
+                  </>
+                ) : (
+                  <p className="muted">Derzeit keine belegten Termine mit Wartelisten-Option.</p>
+                )}
               </>
             ) : (
               <p className="muted">Keine passenden Ersatztermine verfügbar</p>

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -751,9 +751,7 @@ export default function CourseCard({
         <div className="modal-backdrop">
           <div className="modal">
             <h4>
-              {hasCancelled
-                ? "Freien Termin auswählen (folgt)"
-                : "Tauschanfrage starten"}
+              {hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten"}
             </h4>
             <p>
               Ausgewählter Termin:{" "}

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -278,6 +278,9 @@ export default function CourseCard({
         ? `Dieser Kurs ist inaktiv. Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
         : "Dieser Kurs ist inaktiv. Du kannst nur noch bestehende Tausche verwalten."
     : null;
+  const notEnrolledInTermHint = (
+    <div className="muted">Nicht in diesem Termin eingetragen</div>
+  );
 
   useEffect(() => {
     if (includePastTermsInSelect) return;
@@ -436,12 +439,6 @@ export default function CourseCard({
         </div>
       </div>
 
-      {hasNoUpcomingDates && !participantActionsLocked && (
-        <div className="course-row">
-          <span className="muted small">Zur Zeit sind keine zukünftigen Termine für diesen Kurs geplant.</span>
-        </div>
-      )}
-
       {inactiveNotice && (
         <div className="course-row course-inactive-notice" role="status">
           <span className="muted small">{inactiveNotice}</span>
@@ -511,7 +508,7 @@ export default function CourseCard({
                   Absage zurücknehmen
                 </button>
               ) : hasCancelled ? null : (
-                <div className="muted">Nicht in diesem Termin eingetragen</div>
+                notEnrolledInTermHint
               )}
 
               {canSwapFromOrigin && (
@@ -606,7 +603,7 @@ export default function CourseCard({
               </button>
             </div>
           ) : (
-            <div className="muted">Nicht in diesem Termin eingetragen</div>
+            notEnrolledInTermHint
           )}
         </>
       ) : null}

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -19,6 +19,10 @@ import {
 } from "shared/cancellationSwapCutoff";
 import { resolveMaxCapacity, resolveOverbookLimit } from "shared/courseCapacity";
 import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
+import {
+  canRequestSwapFromPastCancelledOrigin,
+  isOccurrenceInPast,
+} from "../lib/courseTermActions";
 import type { SwapSettings } from "../types";
 
 type Props = {
@@ -241,8 +245,26 @@ export default function CourseCard({
       ),
     [swaps, userName, course.id],
   );
-  const canUseTermActions =
-    !participantActionsLocked && hasUpcomingDates && (isParticipant || originallyParticipant);
+  const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
+  const canUseFullTermActions =
+    !participantActionsLocked &&
+    hasUpcomingDates &&
+    (isParticipant || originallyParticipant) &&
+    !isPastOccurrence;
+  const canSwapFromPastCancelled = canRequestSwapFromPastCancelledOrigin({
+    isoDate: selectedDateKey,
+    courseTime: course.time,
+    tenantSettings,
+    override,
+    userName,
+    participants,
+    originallyParticipant,
+  });
+  const showPastTermSwapActions =
+    !participantActionsLocked &&
+    isPastOccurrence &&
+    (isParticipant || originallyParticipant || hasCancelled) &&
+    (swapForThisTerm != null || canSwapFromPastCancelled);
 
   const inactiveNotice = participantActionsLocked
     ? showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
@@ -401,7 +423,7 @@ export default function CourseCard({
         </div>
       )}
 
-      {canUseTermActions ? (
+      {canUseFullTermActions ? (
         <div className="actions">
           {swapForThisTerm ? (
             <>
@@ -504,6 +526,49 @@ export default function CourseCard({
               )}
         </div>
 
+      ) : showPastTermSwapActions ? (
+        <div className="actions">
+          {swapForThisTerm ? (
+            <button
+              className="secondary danger"
+              onClick={() => cancelSwap(swapForThisTerm, course.id)}
+            >
+              {swapForThisTerm.status === "pending"
+                ? "Tauschanfragen abbrechen"
+                : "Tausch abbrechen"}
+            </button>
+          ) : canSwapFromPastCancelled ? (
+            <>
+              <button
+                className="secondary"
+                onClick={() => {
+                  setSwapDateIso(null);
+                  setSwapDateIsoWaitlist(null);
+                  setShowSwapModal(true);
+                }}
+              >
+                Anderen Termin wählen
+              </button>
+              {hasPendingRequestsFromOrigin && (
+                <button
+                  className="secondary"
+                  onClick={() => {
+                    setSwapDateIso(null);
+                    setSwapDateIsoWaitlist(null);
+                    setShowSwapModal(true);
+                  }}
+                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
+                >
+                  Weitere Tauschanfrage
+                </button>
+              )}
+            </>
+          ) : null}
+        </div>
+      ) : isPastOccurrence && !participantActionsLocked ? (
+        <p className="muted small course-past-term-note" role="status">
+          Vergangener Termin — keine Änderungen mehr möglich.
+        </p>
       ) : !participantActionsLocked && !hasNoUpcomingDates ? (
         <>
           {swapForWaitlist ? (
@@ -570,7 +635,7 @@ export default function CourseCard({
         </div>
       )}
       {/* Swap-Modal */}
-      {canUseTermActions && showSwapModal && (
+      {(canUseFullTermActions || canSwapFromPastCancelled) && showSwapModal && (
         <div className="modal-backdrop">
           <div className="modal">
             <h4>

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -36,6 +36,12 @@ type Props = {
   confirmSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
   requestSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
   cancelSwap: (swap: Swap, clickedCourseId: number) => void;
+  /** Wochenansicht: vorausgewählter Termin beim Wechsel der Kalenderwoche. */
+  initialSelectedDate?: Date;
+  /** Wochenansicht: z. B. Kalenderwoche anpassen, wenn ein anderer Termin gewählt wird. */
+  onDateChange?: (date: Date) => void;
+  /** Wochenansicht: Termine der angezeigten KW auch in der Vergangenheit im Dropdown. */
+  includePastTermsInSelect?: boolean;
 };
 
 
@@ -61,6 +67,9 @@ export default function CourseCard({
   confirmSwap,
   requestSwap,
   cancelSwap,
+  initialSelectedDate,
+  onDateChange,
+  includePastTermsInSelect = false,
 }: Props) {
   const swapWindow: SwapSettings = useMemo(
     () => resolveSwapWindow(tenantSettings),
@@ -68,7 +77,7 @@ export default function CourseCard({
   );
 
   const [selectedDate, setSelectedDate] = useState<string>(
-    dates[0]?.toISOString() || ""
+    () => (initialSelectedDate ?? dates[0])?.toISOString() || "",
   );
   const [swapDateIso, setSwapDateIso] = useState<string | null>(null);
   const [swapDateIsoWaitlist, setSwapDateIsoWaitlist] = useState<string | null>(null);
@@ -246,10 +255,17 @@ export default function CourseCard({
     : null;
 
   useEffect(() => {
+    if (includePastTermsInSelect) return;
     if (showLastTermInSelect && lastOccurrenceDate) {
       setSelectedDate(lastOccurrenceDate.toISOString());
     }
-  }, [showLastTermInSelect, lastOccurrenceIso, course.time, lastOccurrenceDate]);
+  }, [includePastTermsInSelect, showLastTermInSelect, lastOccurrenceIso, course.time, lastOccurrenceDate]);
+
+  const initialSelectedTime = initialSelectedDate?.getTime();
+  useEffect(() => {
+    if (initialSelectedTime == null) return;
+    setSelectedDate(new Date(initialSelectedTime).toISOString());
+  }, [initialSelectedTime]);
 
   return (
     <div
@@ -289,7 +305,11 @@ export default function CourseCard({
         <div className="muted">Termine:</div>
         <select
           value={hasNoUpcomingDates && !showLastTermInSelect ? "" : selectedDate}
-          onChange={(e) => setSelectedDate(e.target.value)}
+          onChange={(e) => {
+            const next = new Date(e.target.value);
+            setSelectedDate(e.target.value);
+            onDateChange?.(next);
+          }}
           disabled={hasNoUpcomingDates && !showLastTermInSelect}
         >
           {showLastTermInSelect && lastOccurrenceDate ? (
@@ -299,13 +319,13 @@ export default function CourseCard({
           ) : hasNoUpcomingDates ? (
             <option value="">—</option>
           ) : (
-            dates
-              .filter((d) => d >= new Date())
-              .map((date, index) => (
+            (includePastTermsInSelect ? dates : dates.filter((d) => d >= new Date())).map(
+              (date, index) => (
                 <option key={index} value={date.toISOString()}>
                   {date.toLocaleDateString()}
                 </option>
-              ))
+              ),
+            )
           )}
         </select>
       </div>

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
-import { Clock3, History } from "lucide-react";
+import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
   buildCourseOccurrenceLocal,
@@ -24,6 +24,7 @@ import {
   canRequestSwapFromPastCancelledOrigin,
   isOccurrenceInPast,
 } from "../lib/courseTermActions";
+import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
 import type { SwapSettings } from "../types";
 
 type Props = {
@@ -278,13 +279,21 @@ export default function CourseCard({
     [swaps, userName, course.id],
   );
   const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
-  const showPastGraceMarker = includePastTermsInSelect && isPastOccurrence;
-  const showCutoffMarker = includePastTermsInSelect && !isPastOccurrence && originInCutoff;
+  const isSelectedTermExcluded = isExcludedCourseDate(course, selectedDateKey);
+  const showPastGraceMarker =
+    includePastTermsInSelect && isPastOccurrence && !isSelectedTermExcluded;
+  const showCutoffMarker =
+    includePastTermsInSelect &&
+    !isPastOccurrence &&
+    !isSelectedTermExcluded &&
+    originInCutoff;
+  const showExcludedTermMarker = includePastTermsInSelect && isSelectedTermExcluded;
   const canUseFullTermActions =
     !participantActionsLocked &&
     hasUpcomingDates &&
     (isParticipant || originallyParticipant) &&
-    !isPastOccurrence;
+    !isPastOccurrence &&
+    !isSelectedTermExcluded;
   const canSwapFromPastCancelled = canRequestSwapFromPastCancelledOrigin({
     isoDate: selectedDateKey,
     courseTime: course.time,
@@ -296,9 +305,13 @@ export default function CourseCard({
   });
   const showPastTermSwapActions =
     !participantActionsLocked &&
+    !isSelectedTermExcluded &&
     isPastOccurrence &&
     (isParticipant || originallyParticipant || hasCancelled) &&
     (swapForThisTerm != null || canSwapFromPastCancelled);
+  const excludedTermNotice = showExcludedTermMarker
+    ? "Dieser Termin entfällt — vom Studio abgesagt."
+    : null;
 
   const inactiveNotice = participantActionsLocked
     ? showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
@@ -338,8 +351,16 @@ export default function CourseCard({
           </div>
         </div>
         <div className="course-head-meta">
-          {(showPastGraceMarker || showCutoffMarker) && (
+          {(showPastGraceMarker || showCutoffMarker || showExcludedTermMarker) && (
             <div className="course-term-visual-markers" role="status">
+              {showExcludedTermMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--excluded"
+                  title="Termin entfällt (vom Studio abgesagt)"
+                >
+                  <CalendarX size={12} aria-hidden="true" />
+                </span>
+              )}
               {showPastGraceMarker && (
                 <span
                   className="course-term-visual-marker course-term-visual-marker--past"
@@ -377,8 +398,14 @@ export default function CourseCard({
       <div className="course-row">
         <div className="muted">Kapazität</div>
         <div>
-          {participants.length}/{course.capacity}
-          {showOverbookingDetails && overbookLimit > 0 && ` (+${overbookLimit})`}
+          {showExcludedTermMarker ? (
+            <span className="muted">entfällt</span>
+          ) : (
+            <>
+              {participants.length}/{course.capacity}
+              {showOverbookingDetails && overbookLimit > 0 && ` (+${overbookLimit})`}
+            </>
+          )}
         </div>
       </div>
 
@@ -401,11 +428,16 @@ export default function CourseCard({
             <option value="">—</option>
           ) : (
             (includePastTermsInSelect ? dates : dates.filter((d) => d >= new Date())).map(
-              (date, index) => (
-                <option key={index} value={date.toISOString()}>
-                  {date.toLocaleDateString()}
-                </option>
-              ),
+              (date, index) => {
+                const dateIso = toDateKey(date);
+                const excludedLabel = isExcludedCourseDate(course, dateIso) ? " (entfällt)" : "";
+                return (
+                  <option key={index} value={date.toISOString()}>
+                    {date.toLocaleDateString()}
+                    {excludedLabel}
+                  </option>
+                );
+              },
             )
           )}
         </select>
@@ -414,43 +446,49 @@ export default function CourseCard({
       <div className="course-row list-row">
         <div className="label muted">Teilnehmer</div>
         <div className="chips">
-          {participants.length === 0 && <span className="chip">—</span>}
-          {participants.map((name) => (
-            <span
-              className={`chip ${
-                shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
-                  ? "short-notice"
-                  : swapped.includes(name)
-                    ? "swapped"
-                    : ""
-              }`}
-              key={name}
-              title={
-                shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
-                  ? "Kurzfristig abgesagt — Platz bleibt belegt"
-                  : undefined
-              }
-            >
-              {name}
-            </span>
-          ))}
-          {visibleFreeSpots > 0 &&
-            Array.from({ length: regularFreeSpots }).map((_, idx) => (
-              <span className="chip free" key={`free-${idx}`}>
-                frei
-              </span>
-            ))}
-          {showOverbookingDetails &&
-            overbookFreeSpots > 0 &&
-            Array.from({ length: overbookFreeSpots }).map((_, idx) => (
-              <span
-                className="chip overbook-free"
-                key={`overbook-free-${idx}`}
-                title="Platz in der Überplanung"
-              >
-                +frei
-              </span>
-            ))}
+          {showExcludedTermMarker ? (
+            <span className="chip muted small">—</span>
+          ) : (
+            <>
+              {participants.length === 0 && <span className="chip">—</span>}
+              {participants.map((name) => (
+                <span
+                  className={`chip ${
+                    shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
+                      ? "short-notice"
+                      : swapped.includes(name)
+                        ? "swapped"
+                        : ""
+                  }`}
+                  key={name}
+                  title={
+                    shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
+                      ? "Kurzfristig abgesagt — Platz bleibt belegt"
+                      : undefined
+                  }
+                >
+                  {name}
+                </span>
+              ))}
+              {visibleFreeSpots > 0 &&
+                Array.from({ length: regularFreeSpots }).map((_, idx) => (
+                  <span className="chip free" key={`free-${idx}`}>
+                    frei
+                  </span>
+                ))}
+              {showOverbookingDetails &&
+                overbookFreeSpots > 0 &&
+                Array.from({ length: overbookFreeSpots }).map((_, idx) => (
+                  <span
+                    className="chip overbook-free"
+                    key={`overbook-free-${idx}`}
+                    title="Platz in der Überplanung"
+                  >
+                    +frei
+                  </span>
+                ))}
+            </>
+          )}
         </div>
       </div>
 
@@ -458,7 +496,9 @@ export default function CourseCard({
       <div className="course-row list-row">
         <div className="label muted">Warteliste</div>
         <div className="chips">
-          {waitlist.length === 0 ? (
+          {showExcludedTermMarker ? (
+            <span className="chip muted small">—</span>
+          ) : waitlist.length === 0 ? (
             <span className="chip muted small">Keine Anfragen</span>
           ) : (
             waitlist.map((name) => (
@@ -473,6 +513,12 @@ export default function CourseCard({
       {inactiveNotice && (
         <div className="course-row course-inactive-notice" role="status">
           <span className="muted small">{inactiveNotice}</span>
+        </div>
+      )}
+
+      {excludedTermNotice && (
+        <div className="course-row course-excluded-term-notice" role="status">
+          <span className="muted small">{excludedTermNotice}</span>
         </div>
       )}
 
@@ -618,6 +664,19 @@ export default function CourseCard({
             </>
           ) : null}
         </div>
+      ) : isSelectedTermExcluded && includePastTermsInSelect ? (
+        swapForThisTerm ? (
+          <div className="actions">
+            <button
+              className="secondary danger"
+              onClick={() => cancelSwap(swapForThisTerm, course.id)}
+            >
+              {swapForThisTerm.status === "pending"
+                ? "Tauschanfrage abbrechen"
+                : "Tausch abbrechen"}
+            </button>
+          </div>
+        ) : null
       ) : isPastOccurrence && !participantActionsLocked ? (
         <p className="muted small course-past-term-note" role="status">
           Vergangener Termin — keine Änderungen mehr möglich.

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -451,25 +451,30 @@ export default function CourseCard({
           ) : (
             <>
               {participants.length === 0 && <span className="chip">—</span>}
-              {participants.map((name) => (
-                <span
-                  className={`chip ${
-                    shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
-                      ? "short-notice"
-                      : swapped.includes(name)
-                        ? "swapped"
-                        : ""
-                  }`}
-                  key={name}
-                  title={
-                    shortNotice.some((n) => n.toLowerCase() === name.toLowerCase())
-                      ? "Kurzfristig abgesagt — Platz bleibt belegt"
-                      : undefined
-                  }
-                >
-                  {name}
-                </span>
-              ))}
+              {participants.map((name) => {
+                const isSelf = name.toLowerCase() === userNameLower;
+                const isSn = shortNotice.some((n) => n.toLowerCase() === name.toLowerCase());
+                const isSwapped = swapped.includes(name);
+                return (
+                  <span
+                    className={`chip${isSelf ? " chip-self" : ""}${
+                      isSn ? " short-notice" : isSwapped ? " swapped" : ""
+                    }`}
+                    key={name}
+                    title={
+                      isSn && isSelf
+                        ? "Du — kurzfristig abgesagt, Platz bleibt belegt"
+                        : isSn
+                          ? "Kurzfristig abgesagt — Platz bleibt belegt"
+                          : isSelf
+                            ? "Du"
+                            : undefined
+                    }
+                  >
+                    {name}
+                  </span>
+                );
+              })}
               {visibleFreeSpots > 0 &&
                 Array.from({ length: regularFreeSpots }).map((_, idx) => (
                   <span className="chip free" key={`free-${idx}`}>
@@ -501,11 +506,18 @@ export default function CourseCard({
           ) : waitlist.length === 0 ? (
             <span className="chip muted small">Keine Anfragen</span>
           ) : (
-            waitlist.map((name) => (
-              <span className="chip wait" key={name}>
-                {name}
-              </span>
-            ))
+            waitlist.map((name) => {
+              const isSelf = name.toLowerCase() === userNameLower;
+              return (
+                <span
+                  className={`chip wait${isSelf ? " chip-self" : ""}`}
+                  key={name}
+                  title={isSelf ? "Du (Warteliste)" : undefined}
+                >
+                  {name}
+                </span>
+              );
+            })
           )}
         </div>
       </div>

--- a/app/src/components/CourseWeekView.test.tsx
+++ b/app/src/components/CourseWeekView.test.tsx
@@ -37,6 +37,7 @@ const baseProps = {
   loading: false,
   error: null as string | null,
   courses: [sampleCourse],
+  hiddenPastCourseCount: 0,
   overrides: [],
   swaps: [],
   currentUser: baseUser,
@@ -66,9 +67,12 @@ describe("CourseWeekView", () => {
       />,
     );
 
-    expect(screen.getByRole("region", { name: /wochenansicht/i })).toHaveClass("grid");
+    const weekRegion = screen.getByRole("region", { name: /wochenansicht/i });
+    expect(weekRegion).toBeInTheDocument();
+    expect(weekRegion.querySelector(".grid")).toBeTruthy();
     expect(screen.getByTestId("course-card-mock")).toBeInTheDocument();
-    expect(courseCardMock).toHaveBeenCalledWith(
+    const firstCallProps = courseCardMock.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(firstCallProps).toEqual(
       expect.objectContaining({
         course: sampleCourse,
         onDateChange: expect.any(Function),
@@ -96,5 +100,16 @@ describe("CourseWeekView", () => {
   it("shows empty state when no courses in week", () => {
     render(<CourseWeekView {...baseProps} rows={[]} />);
     expect(screen.getByText("In dieser Kalenderwoche sind keine Termine sichtbar.")).toBeInTheDocument();
+  });
+
+  it("shows hint when past courses are hidden outside grace", () => {
+    render(
+      <CourseWeekView
+        {...baseProps}
+        hiddenPastCourseCount={2}
+        rows={[{ course: sampleCourse, occurrences: [{ dateIso: "2099-06-08", kind: "scheduled" }] }]}
+      />,
+    );
+    expect(screen.getByText(/2 weitere Kurse/i)).toBeInTheDocument();
   });
 });

--- a/app/src/components/CourseWeekView.test.tsx
+++ b/app/src/components/CourseWeekView.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import CourseWeekView from "./CourseWeekView";
+import type { Course, User } from "shared/types";
+
+const courseCardMock = vi.fn();
+
+vi.mock("./CourseCard", () => ({
+  default: (props: unknown) => {
+    courseCardMock(props);
+    return <div data-testid="course-card-mock">CourseCard</div>;
+  },
+}));
+
+const baseUser: User = {
+  nickname: "maya",
+  email: "maya@example.com",
+  role: "participant",
+};
+
+const sampleCourse: Course = {
+  id: 1,
+  name: "Morgen Yoga",
+  weekday: "Mon",
+  time: "10:00",
+  capacity: 8,
+  participants: ["maya"],
+  dates: ["2099-06-01", "2099-06-08"],
+  excludedDates: [],
+};
+
+const noop = () => {};
+
+const baseProps = {
+  weekAnchor: new Date(2099, 5, 2),
+  onWeekAnchorChange: vi.fn(),
+  loading: false,
+  error: null as string | null,
+  courses: [sampleCourse],
+  overrides: [],
+  swaps: [],
+  currentUser: baseUser,
+  canSeeCourseManagement: false,
+  onToggleAbsence: noop,
+  confirmSwap: noop,
+  requestSwap: noop,
+  cancelSwap: noop,
+};
+
+describe("CourseWeekView", () => {
+  beforeEach(() => {
+    cleanup();
+    courseCardMock.mockReset();
+    courseCardMock.mockImplementation(() => <div data-testid="course-card-mock">CourseCard</div>);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders course cards in a grid for the week", () => {
+    render(
+      <CourseWeekView
+        {...baseProps}
+        rows={[{ course: sampleCourse, occurrences: [{ dateIso: "2099-06-08", kind: "scheduled" }] }]}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: /wochenansicht/i })).toHaveClass("grid");
+    expect(screen.getByTestId("course-card-mock")).toBeInTheDocument();
+    expect(courseCardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        course: sampleCourse,
+        onDateChange: expect.any(Function),
+        initialSelectedDate: expect.any(Date),
+      }),
+    );
+  });
+
+  it("changes week anchor when a date outside the current week is selected", () => {
+    const onWeekAnchorChange = vi.fn();
+
+    render(
+      <CourseWeekView
+        {...baseProps}
+        onWeekAnchorChange={onWeekAnchorChange}
+        rows={[{ course: sampleCourse, occurrences: [{ dateIso: "2099-06-08", kind: "scheduled" }] }]}
+      />,
+    );
+
+    const props = courseCardMock.mock.calls[0]?.[0] as { onDateChange?: (d: Date) => void };
+    props.onDateChange?.(new Date(2099, 5, 22));
+    expect(onWeekAnchorChange).toHaveBeenCalled();
+  });
+
+  it("shows empty state when no courses in week", () => {
+    render(<CourseWeekView {...baseProps} rows={[]} />);
+    expect(screen.getByText("In dieser Kalenderwoche sind keine Termine sichtbar.")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -15,6 +15,7 @@ type Props = {
   loading: boolean;
   error: string | null;
   rows: WeekCourseRow[];
+  hiddenPastCourseCount?: number;
   courses: Course[];
   overrides: CourseDateOverride[];
   swaps: Swap[];
@@ -45,6 +46,7 @@ export default function CourseWeekView({
   loading,
   error,
   rows,
+  hiddenPastCourseCount = 0,
   courses,
   overrides,
   swaps,
@@ -91,38 +93,57 @@ export default function CourseWeekView({
   }
 
   return (
-    <div className="course-week-view grid" role="region" aria-label="Wochenansicht">
-      {rows.map(({ course }) => {
-        const cardDates = getWeekViewCardDates(course, weekAnchor);
-        const initialSelectedDate = preferredWeekCardDate(course, weekAnchor);
+    <div className="course-week-view" role="region" aria-label="Wochenansicht">
+      <div className="course-week-view-legend" aria-label="Status-Legende Wochenansicht">
+        <span className="course-week-view-legend-item">
+          <span className="course-term-visual-marker course-term-visual-marker--past" aria-hidden="true">N</span>
+          <span>Nachlauf</span>
+        </span>
+        <span className="course-week-view-legend-item">
+          <span className="course-term-visual-marker course-term-visual-marker--cutoff" aria-hidden="true">C</span>
+          <span>Cutoff</span>
+        </span>
+      </div>
+      {hiddenPastCourseCount > 0 && (
+        <p className="course-week-view-faded-hint muted" role="status">
+          {hiddenPastCourseCount} weitere
+          {hiddenPastCourseCount === 1 ? "r Kurs" : " Kurse"} in dieser Woche
+          {hiddenPastCourseCount === 1 ? " ist" : " sind"} bereits abgelaufen und nicht mehr im Nachlauf.
+        </p>
+      )}
+      <div className="grid">
+        {rows.map(({ course }) => {
+          const cardDates = getWeekViewCardDates(course, weekAnchor);
+          const initialSelectedDate = preferredWeekCardDate(course, weekAnchor);
 
-        return (
-          <div key={`${course.id}-${weekAnchor.getTime()}`}>
-            <CourseCard
-              course={course}
-              allCourses={courses}
-              currentUser={currentUser}
-              showOverbookingDetails={canSeeCourseManagement}
-              dates={cardDates}
-              overrides={overrides}
-              swaps={swaps}
-              participantActionsLocked={
-                !canSeeCourseManagement &&
-                ((course.status ?? "active") === "inactive" ||
-                  isWithinPostCourseEndGrace(course, tenantSettings))
-              }
-              tenantSettings={tenantSettings}
-              initialSelectedDate={initialSelectedDate}
-              includePastTermsInSelect
-              onDateChange={handleDateChange}
-              onToggleAbsence={onToggleAbsence}
-              confirmSwap={confirmSwap}
-              requestSwap={requestSwap}
-              cancelSwap={cancelSwap}
-            />
-          </div>
-        );
-      })}
+          return (
+            <div key={`${course.id}-${weekAnchor.getTime()}`}>
+              <CourseCard
+                course={course}
+                allCourses={courses}
+                currentUser={currentUser}
+                showOverbookingDetails={canSeeCourseManagement}
+                dates={cardDates}
+                overrides={overrides}
+                swaps={swaps}
+                participantActionsLocked={
+                  !canSeeCourseManagement &&
+                  ((course.status ?? "active") === "inactive" ||
+                    isWithinPostCourseEndGrace(course, tenantSettings))
+                }
+                tenantSettings={tenantSettings}
+                initialSelectedDate={initialSelectedDate}
+                includePastTermsInSelect
+                onDateChange={handleDateChange}
+                onToggleAbsence={onToggleAbsence}
+                confirmSwap={confirmSwap}
+                requestSwap={requestSwap}
+                cancelSwap={cancelSwap}
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -1,0 +1,29 @@
+import { weekAnchorForOccurrence } from "../lib/courseWeek";
+
+type Props = {
+  weekAnchor: Date;
+  onWeekAnchorChange: (weekStart: Date) => void;
+};
+
+/**
+ * Platzhalter für #164 — Termine pro Kalenderwoche, Absagen/Ausschlüsse, Swap-Kontext.
+ */
+export default function CourseWeekView({ weekAnchor, onWeekAnchorChange }: Props) {
+  const handleStubOccurrenceClick = () => {
+    const outsideWeek = new Date(weekAnchor);
+    outsideWeek.setDate(outsideWeek.getDate() + 14);
+    onWeekAnchorChange(weekAnchorForOccurrence(outsideWeek, weekAnchor));
+  };
+
+  return (
+    <div className="course-week-view course-week-view--stub" role="region" aria-label="Wochenansicht">
+      <p className="muted course-week-view-stub-note">
+        Wochenansicht (#164) — hier erscheinen Termine aller sichtbaren Kurse für die gewählte
+        Kalenderwoche (inkl. abgesagter und ausgeschlossener Termine).
+      </p>
+      <button type="button" className="modal-action-btn" onClick={handleStubOccurrenceClick}>
+        Stub: +2 Wochen springen
+      </button>
+    </div>
+  );
+};

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -1,29 +1,128 @@
+import { useCallback } from "react";
+import type { Course, CourseDateOverride, Swap, TenantSettings, User } from "shared/types";
+import { isWithinPostCourseEndGrace } from "shared/courseStatus";
 import { weekAnchorForOccurrence } from "../lib/courseWeek";
+import {
+  getWeekViewCardDates,
+  preferredWeekCardDate,
+  type WeekCourseRow,
+} from "../lib/courseWeekOccurrences";
+import CourseCard from "./CourseCard";
 
 type Props = {
   weekAnchor: Date;
   onWeekAnchorChange: (weekStart: Date) => void;
+  loading: boolean;
+  error: string | null;
+  rows: WeekCourseRow[];
+  courses: Course[];
+  overrides: CourseDateOverride[];
+  swaps: Swap[];
+  currentUser: User;
+  canSeeCourseManagement: boolean;
+  tenantSettings?: TenantSettings;
+  onToggleAbsence: (course: Course, dateIso: string, userName: string) => void;
+  confirmSwap: (
+    fromCourse: Course,
+    fromDateIso: string,
+    toCourseId: number,
+    toDateIso: string,
+    userName: string,
+  ) => void;
+  requestSwap: (
+    fromCourse: Course,
+    fromDateIso: string,
+    toCourseId: number,
+    toDateIso: string,
+    userName: string,
+  ) => void;
+  cancelSwap: (swap: Swap, clickedCourseId: number) => void;
 };
 
-/**
- * Platzhalter für #164 — Termine pro Kalenderwoche, Absagen/Ausschlüsse, Swap-Kontext.
- */
-export default function CourseWeekView({ weekAnchor, onWeekAnchorChange }: Props) {
-  const handleStubOccurrenceClick = () => {
-    const outsideWeek = new Date(weekAnchor);
-    outsideWeek.setDate(outsideWeek.getDate() + 14);
-    onWeekAnchorChange(weekAnchorForOccurrence(outsideWeek, weekAnchor));
-  };
+export default function CourseWeekView({
+  weekAnchor,
+  onWeekAnchorChange,
+  loading,
+  error,
+  rows,
+  courses,
+  overrides,
+  swaps,
+  currentUser,
+  canSeeCourseManagement,
+  tenantSettings,
+  onToggleAbsence,
+  confirmSwap,
+  requestSwap,
+  cancelSwap,
+}: Props) {
+  const handleDateChange = useCallback(
+    (date: Date) => {
+      const nextAnchor = weekAnchorForOccurrence(date, weekAnchor);
+      if (nextAnchor.getTime() !== weekAnchor.getTime()) {
+        onWeekAnchorChange(nextAnchor);
+      }
+    },
+    [weekAnchor, onWeekAnchorChange],
+  );
+
+  if (loading) {
+    return (
+      <div className="course-week-view" role="status" aria-live="polite">
+        Loading...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="course-week-view" role="alert">
+        {error}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="course-week-view muted" role="status" style={{ textAlign: "center", padding: "2rem" }}>
+        In dieser Kalenderwoche sind keine Termine sichtbar.
+      </div>
+    );
+  }
 
   return (
-    <div className="course-week-view course-week-view--stub" role="region" aria-label="Wochenansicht">
-      <p className="muted course-week-view-stub-note">
-        Wochenansicht (#164) — hier erscheinen Termine aller sichtbaren Kurse für die gewählte
-        Kalenderwoche (inkl. abgesagter und ausgeschlossener Termine).
-      </p>
-      <button type="button" className="modal-action-btn" onClick={handleStubOccurrenceClick}>
-        Stub: +2 Wochen springen
-      </button>
+    <div className="course-week-view grid" role="region" aria-label="Wochenansicht">
+      {rows.map(({ course }) => {
+        const cardDates = getWeekViewCardDates(course, weekAnchor);
+        const initialSelectedDate = preferredWeekCardDate(course, weekAnchor);
+
+        return (
+          <div key={`${course.id}-${weekAnchor.getTime()}`}>
+            <CourseCard
+              course={course}
+              allCourses={courses}
+              currentUser={currentUser}
+              showOverbookingDetails={canSeeCourseManagement}
+              dates={cardDates}
+              overrides={overrides}
+              swaps={swaps}
+              participantActionsLocked={
+                !canSeeCourseManagement &&
+                ((course.status ?? "active") === "inactive" ||
+                  isWithinPostCourseEndGrace(course, tenantSettings))
+              }
+              tenantSettings={tenantSettings}
+              initialSelectedDate={initialSelectedDate}
+              includePastTermsInSelect
+              onDateChange={handleDateChange}
+              onToggleAbsence={onToggleAbsence}
+              confirmSwap={confirmSwap}
+              requestSwap={requestSwap}
+              cancelSwap={cancelSwap}
+            />
+          </div>
+        );
+      })}
     </div>
   );
-};
+}

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -103,7 +103,7 @@ export default function CourseWeekView({
       )}
       <div className="grid">
         {rows.map(({ course }) => {
-          const cardDates = getWeekViewCardDates(course, weekAnchor);
+          const cardDates = getWeekViewCardDates(course, weekAnchor, tenantSettings);
           const initialSelectedDate = preferredWeekCardDate(course, weekAnchor);
 
           return (

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -94,16 +94,6 @@ export default function CourseWeekView({
 
   return (
     <div className="course-week-view" role="region" aria-label="Wochenansicht">
-      <div className="course-week-view-legend" aria-label="Status-Legende Wochenansicht">
-        <span className="course-week-view-legend-item">
-          <span className="course-term-visual-marker course-term-visual-marker--past" aria-hidden="true">N</span>
-          <span>Nachlauf</span>
-        </span>
-        <span className="course-week-view-legend-item">
-          <span className="course-term-visual-marker course-term-visual-marker--cutoff" aria-hidden="true">C</span>
-          <span>Cutoff</span>
-        </span>
-      </div>
       {hiddenPastCourseCount > 0 && (
         <p className="course-week-view-faded-hint muted" role="status">
           {hiddenPastCourseCount} weitere

--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CoursesShell from "./CoursesShell";
+import { User, Tenant, UserTenantMembership } from "shared/types";
+
+vi.mock("./CourseList", () => ({
+  default: () => <div>CourseList Mock</div>,
+}));
+
+vi.mock("./CourseWeekView", () => ({
+  default: () => <div>CourseWeekView Mock</div>,
+}));
+
+const baseUser: User = {
+  nickname: "maya",
+  email: "maya@example.com",
+  role: "participant",
+};
+
+const baseTenant: Tenant = {
+  tenantId: "default-tenant",
+  name: "Default",
+};
+
+const participantMembership: UserTenantMembership = {
+  tenantId: "default-tenant",
+  userId: "maya",
+  role: "participant",
+};
+
+const adminMembership: UserTenantMembership = {
+  tenantId: "default-tenant",
+  userId: "admin",
+  role: "admin",
+};
+
+describe("CoursesShell", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows week view by default for participants without view toggle", () => {
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /kursansicht/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: /kalenderwoche/i })).toBeInTheDocument();
+  });
+
+  it("lets admin switch between week and course overview", async () => {
+    const user = userEvent.setup();
+    render(
+      <CoursesShell
+        currentUser={{ ...baseUser, nickname: "admin", role: "admin" }}
+        tenant={baseTenant}
+        membership={adminMembership}
+      />,
+    );
+
+    expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /kursübersicht/i }));
+    expect(screen.getByText("CourseList Mock")).toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: /kalenderwoche/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /wochenansicht/i }));
+    expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
+  });
+
+  it("updates week label when navigating weeks", async () => {
+    const user = userEvent.setup();
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
+    const label = within(nav).getByText(/^KW \d+ · /);
+    const before = label.textContent;
+    await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
+    expect(label.textContent).not.toBe(before);
+  });
+});

--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../hooks/useCoursesData", () => ({
     loading: false,
     error: null,
     weekCourseRows: [],
+    hiddenPastCourseCount: 0,
     overrides: [],
     earliestWeekAnchor: new Date(2026, 0, 5),
   }),

--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -8,6 +8,15 @@ vi.mock("./CourseList", () => ({
   default: () => <div>CourseList Mock</div>,
 }));
 
+vi.mock("../hooks/useCoursesData", () => ({
+  useCoursesData: () => ({
+    loading: false,
+    error: null,
+    weekCourseRows: [],
+    overrides: [],
+  }),
+}));
+
 vi.mock("./CourseWeekView", () => ({
   default: () => <div>CourseWeekView Mock</div>,
 }));

--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../hooks/useCoursesData", () => ({
     error: null,
     weekCourseRows: [],
     overrides: [],
+    earliestWeekAnchor: new Date(2026, 0, 5),
   }),
 }));
 

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -41,6 +41,7 @@ export default function CoursesShell({
     error,
     courses,
     weekCourseRows,
+    hiddenPastCourseCount,
     overrides,
     swaps,
     confirmSwap,
@@ -136,6 +137,7 @@ export default function CoursesShell({
             loading={loading}
             error={error}
             rows={weekCourseRows}
+            hiddenPastCourseCount={hiddenPastCourseCount}
             courses={courses}
             overrides={overrides}
             swaps={swaps}

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -47,6 +47,7 @@ export default function CoursesShell({
     requestSwap,
     cancelSwap,
     onToggleAbsence,
+    earliestWeekAnchor,
   } = useCoursesData({
     currentUser,
     tenant,
@@ -62,6 +63,7 @@ export default function CoursesShell({
   }, [canSeeCourseManagement, viewMode]);
 
   const weekLabel = formatWeekNavLabel(weekAnchor);
+  const canGoToPreviousWeek = weekAnchor.getTime() > earliestWeekAnchor.getTime();
 
   return (
     <>
@@ -93,7 +95,13 @@ export default function CoursesShell({
               type="button"
               className="course-week-nav-btn"
               aria-label="Vorherige Woche"
-              onClick={() => setWeekAnchor((prev) => addWeeks(prev, -1))}
+              disabled={!canGoToPreviousWeek}
+              onClick={() =>
+                setWeekAnchor((prev) => {
+                  const next = addWeeks(prev, -1);
+                  return next.getTime() < earliestWeekAnchor.getTime() ? earliestWeekAnchor : next;
+                })
+              }
             >
               <ChevronLeft size={18} aria-hidden="true" />
             </button>

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import CourseList from "./CourseList";
+import CourseWeekView from "./CourseWeekView";
+import { User, Tenant, UserTenantMembership, DEFAULT_TENANT_ID } from "shared/types";
+import { addWeeks, formatWeekNavLabel, startOfWeekMonday } from "../lib/courseWeek";
+
+export type CourseViewMode = "week" | "courses";
+
+type Props = {
+  currentUser: User;
+  tenant?: Tenant;
+  membership?: UserTenantMembership;
+  forceParticipantView?: boolean;
+};
+
+export default function CoursesShell({
+  currentUser,
+  tenant,
+  membership,
+  forceParticipantView = false,
+}: Props) {
+  const effectiveMembership = useMemo(() => {
+    if (!forceParticipantView) return membership;
+    return {
+      tenantId: membership?.tenantId ?? tenant?.tenantId ?? DEFAULT_TENANT_ID,
+      role: "participant" as const,
+      userId: currentUser.nickname,
+    };
+  }, [membership, forceParticipantView, tenant?.tenantId, currentUser.nickname]);
+
+  const resolvedRole = effectiveMembership?.role ?? currentUser.role;
+  const canSeeCourseManagement = resolvedRole === "admin" || resolvedRole === "instructor";
+
+  const [viewMode, setViewMode] = useState<CourseViewMode>("week");
+  const [weekAnchor, setWeekAnchor] = useState(() => startOfWeekMonday(new Date()));
+
+  useEffect(() => {
+    if (!canSeeCourseManagement && viewMode === "courses") {
+      setViewMode("week");
+    }
+  }, [canSeeCourseManagement, viewMode]);
+
+  const weekLabel = formatWeekNavLabel(weekAnchor);
+
+  return (
+    <>
+      <div className="course-views-toolbar">
+        {canSeeCourseManagement && (
+          <div className="course-views-toggle" role="group" aria-label="Kursansicht">
+            <button
+              type="button"
+              className={`course-views-toggle-btn${viewMode === "week" ? " is-active" : ""}`}
+              aria-pressed={viewMode === "week"}
+              onClick={() => setViewMode("week")}
+            >
+              Wochenansicht
+            </button>
+            <button
+              type="button"
+              className={`course-views-toggle-btn${viewMode === "courses" ? " is-active" : ""}`}
+              aria-pressed={viewMode === "courses"}
+              onClick={() => setViewMode("courses")}
+            >
+              Kursübersicht
+            </button>
+          </div>
+        )}
+
+        {viewMode === "week" && (
+          <nav className="course-week-nav" aria-label="Kalenderwoche">
+            <button
+              type="button"
+              className="course-week-nav-btn"
+              aria-label="Vorherige Woche"
+              onClick={() => setWeekAnchor((prev) => addWeeks(prev, -1))}
+            >
+              <ChevronLeft size={18} aria-hidden="true" />
+            </button>
+            <span className="course-week-nav-label">{weekLabel}</span>
+            <button
+              type="button"
+              className="course-week-nav-btn"
+              aria-label="Nächste Woche"
+              onClick={() => setWeekAnchor((prev) => addWeeks(prev, 1))}
+            >
+              <ChevronRight size={18} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="course-week-nav-today"
+              onClick={() => setWeekAnchor(startOfWeekMonday(new Date()))}
+            >
+              Heute
+            </button>
+          </nav>
+        )}
+      </div>
+
+      {viewMode === "week" && (
+        <>
+          <p className="muted course-views-hint">
+            Klicke in deinen Kursen auf <em>„Termin absagen“</em> oder <em>„Tauschen anfragen“</em>.
+          </p>
+          <CourseWeekView weekAnchor={weekAnchor} onWeekAnchorChange={setWeekAnchor} />
+        </>
+      )}
+
+      {viewMode === "courses" && canSeeCourseManagement && (
+        <CourseList
+          currentUser={currentUser}
+          tenant={tenant}
+          membership={membership}
+          forceParticipantView={forceParticipantView}
+        />
+      )}
+    </>
+  );
+};

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -4,6 +4,7 @@ import CourseList from "./CourseList";
 import CourseWeekView from "./CourseWeekView";
 import { User, Tenant, UserTenantMembership, DEFAULT_TENANT_ID } from "shared/types";
 import { addWeeks, formatWeekNavLabel, startOfWeekMonday } from "../lib/courseWeek";
+import { useCoursesData } from "../hooks/useCoursesData";
 
 export type CourseViewMode = "week" | "courses";
 
@@ -34,6 +35,25 @@ export default function CoursesShell({
 
   const [viewMode, setViewMode] = useState<CourseViewMode>("week");
   const [weekAnchor, setWeekAnchor] = useState(() => startOfWeekMonday(new Date()));
+
+  const {
+    loading,
+    error,
+    courses,
+    weekCourseRows,
+    overrides,
+    swaps,
+    confirmSwap,
+    requestSwap,
+    cancelSwap,
+    onToggleAbsence,
+  } = useCoursesData({
+    currentUser,
+    tenant,
+    membership,
+    forceParticipantView,
+    weekAnchor,
+  });
 
   useEffect(() => {
     if (!canSeeCourseManagement && viewMode === "courses") {
@@ -102,7 +122,23 @@ export default function CoursesShell({
           <p className="muted course-views-hint">
             Klicke in deinen Kursen auf <em>„Termin absagen“</em> oder <em>„Tauschen anfragen“</em>.
           </p>
-          <CourseWeekView weekAnchor={weekAnchor} onWeekAnchorChange={setWeekAnchor} />
+          <CourseWeekView
+            weekAnchor={weekAnchor}
+            onWeekAnchorChange={setWeekAnchor}
+            loading={loading}
+            error={error}
+            rows={weekCourseRows}
+            courses={courses}
+            overrides={overrides}
+            swaps={swaps}
+            currentUser={currentUser}
+            canSeeCourseManagement={canSeeCourseManagement}
+            tenantSettings={tenant?.settings}
+            onToggleAbsence={onToggleAbsence}
+            confirmSwap={confirmSwap}
+            requestSwap={requestSwap}
+            cancelSwap={cancelSwap}
+          />
         </>
       )}
 

--- a/app/src/hooks/useCoursesData.ts
+++ b/app/src/hooks/useCoursesData.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Course,
+  CourseDateOverride,
+  Swap,
+  User,
+  Tenant,
+  UserTenantMembership,
+  DEFAULT_TENANT_ID,
+} from "shared/types";
+import { canSeeCourse, canShowParticipantCourseCard } from "shared/permissions";
+import { getCourses } from "../api/courses";
+import { getOverrides } from "../api/overrides";
+import { getSwaps, getSwapsByStatus } from "../api/swaps";
+import { getCourseDates } from "../lib/dates";
+import { collectWeekOccurrences, type WeekCourseRow } from "../lib/courseWeekOccurrences";
+import { useCourseSwaps } from "../components/useCourseSwaps";
+
+const WEEKDAY_ORDER: Record<string, number> = {
+  Mon: 1,
+  Monday: 1,
+  Tue: 2,
+  Tuesday: 2,
+  Wed: 3,
+  Wednesday: 3,
+  Thu: 4,
+  Thursday: 4,
+  Fri: 5,
+  Friday: 5,
+  Sat: 6,
+  Saturday: 6,
+  Sun: 7,
+  Sunday: 7,
+};
+
+function sortCoursesForDisplay(a: Course, b: Course): number {
+  const weekdayA = WEEKDAY_ORDER[a.weekday] ?? 99;
+  const weekdayB = WEEKDAY_ORDER[b.weekday] ?? 99;
+  if (weekdayA !== weekdayB) return weekdayA - weekdayB;
+  if (a.time !== b.time) return a.time.localeCompare(b.time);
+  return a.id - b.id;
+}
+
+function dedupeSwaps(values: Swap[]): Swap[] {
+  const seen = new Set<string>();
+  const result: Swap[] = [];
+  for (const swap of values) {
+    const key = `${swap.user}#${swap.fromCourseId}#${swap.fromDate}#${swap.toCourseId}#${swap.toDate}#${swap.status}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(swap);
+  }
+  return result;
+}
+
+type Options = {
+  currentUser: User;
+  tenant?: Tenant;
+  membership?: UserTenantMembership;
+  forceParticipantView?: boolean;
+  weekAnchor: Date;
+};
+
+export function useCoursesData({
+  currentUser,
+  tenant,
+  membership,
+  forceParticipantView = false,
+  weekAnchor,
+}: Options) {
+  const [swaps, setSwaps] = useState<Swap[]>([]);
+  const [overrides, setOverrides] = useState<CourseDateOverride[]>([]);
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveMembership = useMemo<UserTenantMembership | undefined>(() => {
+    if (!membership) return undefined;
+    if (!forceParticipantView) return membership;
+    return {
+      ...membership,
+      role: "participant",
+      userId: currentUser.nickname,
+    };
+  }, [membership, forceParticipantView, currentUser.nickname]);
+
+  const membershipForPermissions = useMemo<UserTenantMembership>(() => {
+    if (effectiveMembership) return effectiveMembership;
+    return {
+      userId: currentUser.nickname,
+      tenantId: tenant?.tenantId ?? DEFAULT_TENANT_ID,
+      role: currentUser.role,
+    };
+  }, [effectiveMembership, tenant?.tenantId, currentUser.nickname, currentUser.role]);
+
+  const resolvedRole = effectiveMembership?.role ?? currentUser.role;
+  const canSeeCourseManagement = resolvedRole === "admin" || resolvedRole === "instructor";
+
+  const courseContext = useCallback(
+    (course: Course) => ({
+      isTaughtByUser: (course.instructors ?? []).some(
+        (p) => p.toLowerCase() === currentUser.nickname.toLowerCase(),
+      ),
+      isBookedByUser: course.participants.some(
+        (p) => p.toLowerCase() === currentUser.nickname.toLowerCase(),
+      ),
+    }),
+    [currentUser.nickname],
+  );
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const swapsPromise = canSeeCourseManagement
+        ? Promise.all([getSwapsByStatus("pending"), getSwapsByStatus("active")]).then(([pending, active]) =>
+            dedupeSwaps([...pending, ...active]),
+          )
+        : getSwaps(currentUser.nickname);
+
+      const [courseData, overrideData, swapsData] = await Promise.all([
+        getCourses(),
+        getOverrides(),
+        swapsPromise,
+      ]);
+
+      setCourses(courseData.sort(sortCoursesForDisplay));
+      setOverrides(Array.isArray(overrideData) ? overrideData : []);
+      setSwaps(swapsData);
+      setError(null);
+    } catch (err) {
+      console.error("Error in useCoursesData:", err);
+      setError("Failed to load data");
+      setSwaps([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [canSeeCourseManagement, currentUser.nickname]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const swapHandlers = useCourseSwaps(
+    courses,
+    overrides,
+    setOverrides,
+    swaps,
+    setSwaps,
+    currentUser,
+    fetchData,
+    tenant?.settings,
+  );
+
+  const visibleCourses = useMemo(() => {
+    return courses.filter((course) =>
+      canSeeCourse(membershipForPermissions, tenant?.settings, course, courseContext(course)),
+    );
+  }, [courses, membershipForPermissions, tenant?.settings, courseContext]);
+
+  const weekCourseRows = useMemo((): WeekCourseRow[] => {
+    const rows: WeekCourseRow[] = [];
+    for (const course of visibleCourses) {
+      const occurrences = collectWeekOccurrences(course, weekAnchor);
+      if (occurrences.length === 0) continue;
+
+      if (!canSeeCourseManagement) {
+        const hasUpcoming = getCourseDates(course).length > 0;
+        const show = canShowParticipantCourseCard(membershipForPermissions, tenant?.settings, course, {
+          ...courseContext(course),
+          hasVisibleCourseDates: hasUpcoming || occurrences.length > 0,
+        });
+        if (!show) continue;
+      }
+
+      rows.push({ course, occurrences });
+    }
+    return rows.sort((a, b) => sortCoursesForDisplay(a.course, b.course));
+  }, [
+    visibleCourses,
+    weekAnchor,
+    canSeeCourseManagement,
+    membershipForPermissions,
+    tenant?.settings,
+    courseContext,
+  ]);
+
+  return {
+    loading,
+    error,
+    fetchData,
+    courses,
+    overrides: swapHandlers.overrides,
+    swaps,
+    visibleCourses,
+    weekCourseRows,
+    canSeeCourseManagement,
+    membershipForPermissions,
+    confirmSwap: swapHandlers.confirmSwap,
+    requestSwap: swapHandlers.requestSwap,
+    cancelSwap: swapHandlers.cancelSwap,
+    onToggleAbsence: swapHandlers.onToggleAbsence,
+  };
+}

--- a/app/src/hooks/useCoursesData.ts
+++ b/app/src/hooks/useCoursesData.ts
@@ -13,6 +13,7 @@ import { getCourses } from "../api/courses";
 import { getOverrides } from "../api/overrides";
 import { getSwaps, getSwapsByStatus } from "../api/swaps";
 import { getCourseDates } from "../lib/dates";
+import { canShowCourseInPastWeek, computeEarliestWeekAnchor } from "../lib/courseTermActions";
 import { collectWeekOccurrences, type WeekCourseRow } from "../lib/courseWeekOccurrences";
 import { useCourseSwaps } from "../components/useCourseSwaps";
 
@@ -163,6 +164,8 @@ export function useCoursesData({
       const occurrences = collectWeekOccurrences(course, weekAnchor);
       if (occurrences.length === 0) continue;
 
+      if (!canShowCourseInPastWeek(course, weekAnchor, tenant?.settings)) continue;
+
       if (!canSeeCourseManagement) {
         const hasUpcoming = getCourseDates(course).length > 0;
         const show = canShowParticipantCourseCard(membershipForPermissions, tenant?.settings, course, {
@@ -184,6 +187,11 @@ export function useCoursesData({
     courseContext,
   ]);
 
+  const earliestWeekAnchor = useMemo(
+    () => computeEarliestWeekAnchor(visibleCourses, tenant?.settings),
+    [visibleCourses, tenant?.settings],
+  );
+
   return {
     loading,
     error,
@@ -193,6 +201,7 @@ export function useCoursesData({
     swaps,
     visibleCourses,
     weekCourseRows,
+    earliestWeekAnchor,
     canSeeCourseManagement,
     membershipForPermissions,
     confirmSwap: swapHandlers.confirmSwap,

--- a/app/src/hooks/useCoursesData.ts
+++ b/app/src/hooks/useCoursesData.ts
@@ -158,13 +158,17 @@ export function useCoursesData({
     );
   }, [courses, membershipForPermissions, tenant?.settings, courseContext]);
 
-  const weekCourseRows = useMemo((): WeekCourseRow[] => {
+  const weekCourseRows = useMemo((): { rows: WeekCourseRow[]; hiddenPastCourses: number } => {
     const rows: WeekCourseRow[] = [];
+    let hiddenPastCourses = 0;
     for (const course of visibleCourses) {
       const occurrences = collectWeekOccurrences(course, weekAnchor);
       if (occurrences.length === 0) continue;
 
-      if (!canShowCourseInPastWeek(course, weekAnchor, tenant?.settings)) continue;
+      if (!canShowCourseInPastWeek(course, weekAnchor, tenant?.settings)) {
+        hiddenPastCourses += 1;
+        continue;
+      }
 
       if (!canSeeCourseManagement) {
         const hasUpcoming = getCourseDates(course).length > 0;
@@ -177,7 +181,10 @@ export function useCoursesData({
 
       rows.push({ course, occurrences });
     }
-    return rows.sort((a, b) => sortCoursesForDisplay(a.course, b.course));
+    return {
+      rows: rows.sort((a, b) => sortCoursesForDisplay(a.course, b.course)),
+      hiddenPastCourses,
+    };
   }, [
     visibleCourses,
     weekAnchor,
@@ -200,7 +207,8 @@ export function useCoursesData({
     overrides: swapHandlers.overrides,
     swaps,
     visibleCourses,
-    weekCourseRows,
+    weekCourseRows: weekCourseRows.rows,
+    hiddenPastCourseCount: weekCourseRows.hiddenPastCourses,
     earliestWeekAnchor,
     canSeeCourseManagement,
     membershipForPermissions,

--- a/app/src/lib/courseTermActions.test.ts
+++ b/app/src/lib/courseTermActions.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { Course, CourseDateOverride } from "shared/types";
+import {
+  canRequestSwapFromPastCancelledOrigin,
+  canShowCourseInPastWeek,
+  computeEarliestWeekAnchor,
+  isCourseInParticipantGrace,
+  isOccurrenceInPast,
+} from "./courseTermActions";
+import { startOfWeekMonday } from "./courseWeek";
+
+const endedCourse: Course = {
+  id: 1,
+  name: "Yoga",
+  weekday: "Mon",
+  time: "10:00",
+  capacity: 8,
+  participants: ["maya"],
+  dates: ["2026-05-18"],
+  seriesEndDate: "2026-05-18",
+  status: "active",
+};
+
+describe("isCourseInParticipantGrace", () => {
+  it("is true while within grace days after course end", () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    expect(isCourseInParticipantGrace(endedCourse, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      true,
+    );
+  });
+
+  it("is false after grace expired", () => {
+    const now = new Date(2026, 5, 10, 12, 0, 0);
+    expect(isCourseInParticipantGrace(endedCourse, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      false,
+    );
+  });
+
+  it("is false for active course with upcoming dates", () => {
+    const now = new Date(2026, 4, 10, 12, 0, 0);
+    const rolling: Course = {
+      ...endedCourse,
+      dates: ["2026-05-18", "2026-06-15"],
+      status: "active",
+    };
+    expect(isCourseInParticipantGrace(rolling, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      false,
+    );
+  });
+
+  it("is true for inactive course in grace even with stale future dates in list", () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const inactive: Course = {
+      ...endedCourse,
+      status: "inactive",
+      dates: ["2026-05-18", "2099-01-01"],
+    };
+    expect(isCourseInParticipantGrace(inactive, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      true,
+    );
+  });
+});
+
+describe("canShowCourseInPastWeek", () => {
+  it("hides course outside grace in a past week", () => {
+    const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
+    const now = new Date(2026, 5, 10, 12, 0, 0);
+    expect(canShowCourseInPastWeek(endedCourse, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      false,
+    );
+  });
+
+  it("shows course in grace in a past week", () => {
+    const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    expect(canShowCourseInPastWeek(endedCourse, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
+      true,
+    );
+  });
+
+  it("shows course in past week during calendar grace even with stale future dates", () => {
+    const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const withStaleFuture: Course = {
+      ...endedCourse,
+      status: "active",
+      dates: ["2026-05-18", "2099-01-01"],
+    };
+    expect(
+      isCourseInParticipantGrace(withStaleFuture, { inactiveGraceDaysAfterCourseEnd: 7 }, now),
+    ).toBe(false);
+    expect(
+      canShowCourseInPastWeek(withStaleFuture, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now),
+    ).toBe(true);
+  });
+});
+
+describe("computeEarliestWeekAnchor", () => {
+  it("uses the earlier of course-end week and grace lookback from today", () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const earliest = computeEarliestWeekAnchor(
+      [endedCourse],
+      { inactiveGraceDaysAfterCourseEnd: 7 },
+      now,
+    );
+    expect(earliest.getTime()).toBe(startOfWeekMonday(new Date(2026, 4, 12)).getTime());
+  });
+
+  it("allows one grace window step back at the start of the current week", () => {
+    const now = new Date(2026, 4, 19, 9, 0, 0);
+    const earliest = computeEarliestWeekAnchor(
+      [endedCourse],
+      { inactiveGraceDaysAfterCourseEnd: 7 },
+      now,
+    );
+    expect(earliest.getTime()).toBe(startOfWeekMonday(new Date(2026, 4, 12)).getTime());
+    expect(earliest.getTime()).toBeLessThan(startOfWeekMonday(now).getTime());
+  });
+
+  it("allows previous week when lookback falls in the same calendar week as today", () => {
+    const courseEndedMonday: Course = {
+      ...endedCourse,
+      dates: ["2026-05-26"],
+      seriesEndDate: "2026-05-26",
+    };
+    const now = new Date(2026, 4, 27, 12, 0, 0);
+    const todayWeek = startOfWeekMonday(now);
+    const earliest = computeEarliestWeekAnchor(
+      [courseEndedMonday],
+      { inactiveGraceDaysAfterCourseEnd: 3 },
+      now,
+    );
+    expect(earliest.getTime()).toBeLessThan(todayWeek.getTime());
+  });
+
+  it("enables back navigation for calendar grace even with stale future dates in dates", () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const withStaleFuture: Course = {
+      ...endedCourse,
+      status: "active",
+      dates: ["2026-05-18", "2099-01-01"],
+    };
+    const earliest = computeEarliestWeekAnchor(
+      [withStaleFuture],
+      { inactiveGraceDaysAfterCourseEnd: 7 },
+      now,
+    );
+    expect(earliest.getTime()).toBeLessThan(startOfWeekMonday(now).getTime());
+  });
+});
+
+describe("canRequestSwapFromPastCancelledOrigin", () => {
+  const override: CourseDateOverride = {
+    courseId: 1,
+    date: "2026-05-18",
+    participants: [],
+    swapped: [],
+    waitlist: [],
+  };
+
+  it("allows swap only for regular cancellation on past term", () => {
+    const now = new Date(2026, 4, 20, 12, 0, 0);
+    expect(
+      canRequestSwapFromPastCancelledOrigin({
+        isoDate: "2026-05-18",
+        courseTime: "10:00",
+        override,
+        userName: "maya",
+        participants: [],
+        originallyParticipant: true,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("denies swap on past term without cancellation", () => {
+    const now = new Date(2026, 4, 20, 12, 0, 0);
+    expect(
+      canRequestSwapFromPastCancelledOrigin({
+        isoDate: "2026-05-18",
+        courseTime: "10:00",
+        userName: "maya",
+        participants: ["maya"],
+        originallyParticipant: true,
+        now,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isOccurrenceInPast", () => {
+  it("detects past occurrence", () => {
+    expect(isOccurrenceInPast("2020-01-01", "10:00", new Date(2026, 0, 1))).toBe(true);
+  });
+});

--- a/app/src/lib/courseTermActions.test.ts
+++ b/app/src/lib/courseTermActions.test.ts
@@ -72,14 +72,19 @@ describe("canShowCourseInPastWeek", () => {
 
   it("shows course in grace in a past week", () => {
     const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
-    const now = new Date(2026, 4, 22, 12, 0, 0);
-    expect(canShowCourseInPastWeek(endedCourse, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now)).toBe(
-      true,
-    );
+    const now = new Date(2026, 4, 18, 12, 0, 0);
+    const courseInWeek: Course = {
+      ...endedCourse,
+      dates: ["2026-05-12"],
+      seriesEndDate: "2026-05-12",
+    };
+    expect(
+      canShowCourseInPastWeek(courseInWeek, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now),
+    ).toBe(true);
   });
 
   it("shows course in past week during calendar grace even with stale future dates", () => {
-    const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
+    const pastWeek = startOfWeekMonday(new Date(2026, 4, 18));
     const now = new Date(2026, 4, 22, 12, 0, 0);
     const withStaleFuture: Course = {
       ...endedCourse,
@@ -92,6 +97,34 @@ describe("canShowCourseInPastWeek", () => {
     expect(
       canShowCourseInPastWeek(withStaleFuture, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now),
     ).toBe(true);
+  });
+
+  it("hides past week when the occurrence is older than grace for ongoing course", () => {
+    const pastWeek = startOfWeekMonday(new Date(2026, 4, 11));
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const notEndedYet: Course = {
+      ...endedCourse,
+      dates: ["2026-05-12", "2026-06-15"],
+      seriesEndDate: "2026-06-30",
+      status: "active",
+    };
+    expect(
+      canShowCourseInPastWeek(notEndedYet, pastWeek, { inactiveGraceDaysAfterCourseEnd: 7 }, now),
+    ).toBe(false);
+  });
+
+  it("hides week occurrence that is older than grace window", () => {
+    const oldWeek = startOfWeekMonday(new Date(2026, 4, 4));
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const oldCourse: Course = {
+      ...endedCourse,
+      dates: ["2026-05-05"],
+      seriesEndDate: "2026-05-05",
+      status: "inactive",
+    };
+    expect(canShowCourseInPastWeek(oldCourse, oldWeek, { inactiveGraceDaysAfterCourseEnd: 5 }, now)).toBe(
+      false,
+    );
   });
 });
 
@@ -147,6 +180,22 @@ describe("computeEarliestWeekAnchor", () => {
     );
     expect(earliest.getTime()).toBeLessThan(startOfWeekMonday(now).getTime());
   });
+
+  it("keeps previous-week navigation available for ongoing weekly courses", () => {
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const ongoing: Course = {
+      ...endedCourse,
+      dates: ["2026-05-20", "2026-05-27"],
+      seriesEndDate: "2026-06-30",
+      status: "active",
+    };
+    const earliest = computeEarliestWeekAnchor(
+      [ongoing],
+      { inactiveGraceDaysAfterCourseEnd: 7 },
+      now,
+    );
+    expect(earliest.getTime()).toBeLessThan(startOfWeekMonday(now).getTime());
+  });
 });
 
 describe("canRequestSwapFromPastCancelledOrigin", () => {
@@ -181,6 +230,22 @@ describe("canRequestSwapFromPastCancelledOrigin", () => {
         courseTime: "10:00",
         userName: "maya",
         participants: ["maya"],
+        originallyParticipant: true,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("denies swap when past term is outside grace window", () => {
+    const now = new Date(2026, 4, 25, 12, 0, 0);
+    expect(
+      canRequestSwapFromPastCancelledOrigin({
+        isoDate: "2026-05-18",
+        courseTime: "10:00",
+        tenantSettings: { inactiveGraceDaysAfterCourseEnd: 5 },
+        override,
+        userName: "maya",
+        participants: [],
         originallyParticipant: true,
         now,
       }),

--- a/app/src/lib/courseTermActions.ts
+++ b/app/src/lib/courseTermActions.ts
@@ -12,7 +12,7 @@ import {
 } from "shared/courseStatus";
 import type { Course, CourseDateOverride, TenantSettings } from "shared/types";
 import { addWeeks, startOfWeekMonday } from "./courseWeek";
-import { isWeekEntirelyInPast } from "./courseWeekOccurrences";
+import { isWeekEntirelyInPast, weekRangeKeys } from "./courseWeekOccurrences";
 
 function resolveGraceDays(settings?: TenantSettings): number {
   const value = settings?.inactiveGraceDaysAfterCourseEnd;
@@ -27,8 +27,17 @@ export function isWithinParticipantGraceCalendar(
 ): boolean {
   const endIso = courseEndDateIso(course);
   if (!endIso) return false;
+  const todayIso = toIsoDateUtc(now);
+  if (todayIso < endIso) return false;
   const lastGraceInclusiveIso = addCalendarDaysIsoUtc(endIso, resolveGraceDays(settings));
-  return toIsoDateUtc(now) <= lastGraceInclusiveIso;
+  return todayIso <= lastGraceInclusiveIso;
+}
+
+function isIsoWithinGraceWindow(isoDate: string, settings: TenantSettings | undefined, now: Date): boolean {
+  const todayIso = toIsoDateUtc(now);
+  if (isoDate > todayIso) return false;
+  const lastGraceInclusiveIso = addCalendarDaysIsoUtc(isoDate, resolveGraceDays(settings));
+  return todayIso <= lastGraceInclusiveIso;
 }
 
 /**
@@ -52,6 +61,9 @@ export function isCourseInNavigationGrace(
   settings?: TenantSettings,
   now: Date = new Date(),
 ): boolean {
+  const todayIso = toIsoDateUtc(now);
+  const validPastDates = (course.dates ?? []).filter((iso) => iso <= todayIso);
+  if (validPastDates.some((iso) => isIsoWithinGraceWindow(iso, settings, now))) return true;
   return isWithinParticipantGraceCalendar(course, settings, now);
 }
 
@@ -63,7 +75,10 @@ export function canShowCourseInPastWeek(
   now: Date = new Date(),
 ): boolean {
   if (!isWeekEntirelyInPast(weekStart, now)) return true;
-  return isCourseInNavigationGrace(course, settings, now);
+  const { start, end } = weekRangeKeys(weekStart);
+  const weekDates = (course.dates ?? []).filter((iso) => iso >= start && iso <= end);
+  if (weekDates.length === 0) return false;
+  return weekDates.some((iso) => isIsoWithinGraceWindow(iso, settings, now));
 }
 
 /**
@@ -91,11 +106,22 @@ export function computeEarliestWeekAnchor(
   for (const course of courses) {
     if (!isCourseInNavigationGrace(course, settings, now)) continue;
     hasNavigationGrace = true;
+    const candidateIsos = (course.dates ?? []).filter((iso) => isIsoWithinGraceWindow(iso, settings, now));
+    if (candidateIsos.length > 0) {
+      for (const iso of candidateIsos) {
+        const isoWeek = startOfWeekMonday(new Date(`${iso}T12:00:00.000Z`));
+        if (!earliest || isoWeek.getTime() < earliest.getTime()) {
+          earliest = isoWeek;
+        }
+      }
+      continue;
+    }
     const endIso = courseEndDateIso(course);
-    if (!endIso) continue;
-    const endWeek = startOfWeekMonday(new Date(`${endIso}T12:00:00.000Z`));
-    if (!earliest || endWeek.getTime() < earliest.getTime()) {
-      earliest = endWeek;
+    if (endIso) {
+      const endWeek = startOfWeekMonday(new Date(`${endIso}T12:00:00.000Z`));
+      if (!earliest || endWeek.getTime() < earliest.getTime()) {
+        earliest = endWeek;
+      }
     }
   }
 
@@ -148,6 +174,12 @@ export function canRequestSwapFromPastCancelledOrigin(input: {
 }): boolean {
   const now = input.now ?? new Date();
   if (!isOccurrenceInPast(input.isoDate, input.courseTime, now)) return false;
+  const todayIso = toIsoDateUtc(now);
+  const lastGraceInclusiveIso = addCalendarDaysIsoUtc(
+    input.isoDate,
+    resolveGraceDays(input.tenantSettings),
+  );
+  if (todayIso > lastGraceInclusiveIso) return false;
   if (
     !isRegularCancellation(
       input.originallyParticipant,

--- a/app/src/lib/courseTermActions.ts
+++ b/app/src/lib/courseTermActions.ts
@@ -1,0 +1,171 @@
+import {
+  canCreateSwapFromOrigin,
+  isRegularCancellation,
+} from "shared/cancellationSwapCutoff";
+import {
+  addCalendarDaysIsoUtc,
+  buildCourseOccurrenceLocal,
+  courseEndDateIso,
+  DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END,
+  isWithinPostCourseEndGrace,
+  toIsoDateUtc,
+} from "shared/courseStatus";
+import type { Course, CourseDateOverride, TenantSettings } from "shared/types";
+import { addWeeks, startOfWeekMonday } from "./courseWeek";
+import { isWeekEntirelyInPast } from "./courseWeekOccurrences";
+
+function resolveGraceDays(settings?: TenantSettings): number {
+  const value = settings?.inactiveGraceDaysAfterCourseEnd;
+  return typeof value === "number" && value > 0 ? value : DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+}
+
+/** Kalendertage nach Kursende — gleiche Basis wie `canSeeCourse` für inaktive Kurse (#149). */
+export function isWithinParticipantGraceCalendar(
+  course: Pick<Course, "dates" | "time" | "seriesEndDate" | "visibleUntil" | "status" | "plannedEndDate">,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  const endIso = courseEndDateIso(course);
+  if (!endIso) return false;
+  const lastGraceInclusiveIso = addCalendarDaysIsoUtc(endIso, resolveGraceDays(settings));
+  return toIsoDateUtc(now) <= lastGraceInclusiveIso;
+}
+
+/**
+ * Kurs gilt als „im Nachlauf“ für Wochenrückblick: innerhalb Grace-Tage nach Ende,
+ * ohne weitere Zukunftstermine (außer `inactive` — dort reicht Kalender-Nachlauf).
+ */
+export function isCourseInParticipantGrace(
+  course: Course,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  if (!isWithinParticipantGraceCalendar(course, settings, now)) return false;
+  const status = course.status ?? "active";
+  if (status === "inactive") return true;
+  return isWithinPostCourseEndGrace(course, settings, now);
+}
+
+/** Kalender-Nachlauf für ‹-Navigation und Sichtbarkeit vergangener KWs (vgl. #149). */
+export function isCourseInNavigationGrace(
+  course: Course,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  return isWithinParticipantGraceCalendar(course, settings, now);
+}
+
+/** Vergangene KW: Kurs nur im Nachlauf anzeigen (alle Rollen in der Wochenansicht). */
+export function canShowCourseInPastWeek(
+  course: Course,
+  weekStart: Date,
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): boolean {
+  if (!isWeekEntirelyInPast(weekStart, now)) return true;
+  return isCourseInNavigationGrace(course, settings, now);
+}
+
+/**
+ * Früheste navigierbare KW für ‹ :
+ * - pro Kurs im Nachlauf: Woche des Kursendes
+ * - zusätzlich: bis zu `inactiveGraceDaysAfterCourseEnd` Kalendertage zurück ab heute,
+ *   damit man zu Wochenanfang noch in die vorige KW wechseln kann, solange Nachlauf läuft
+ */
+export function computeEarliestWeekAnchor(
+  courses: Course[],
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): Date {
+  const todayWeek = startOfWeekMonday(now);
+  const previousWeek = addWeeks(todayWeek, -1);
+  const graceDays = resolveGraceDays(settings);
+
+  const lookback = new Date(now);
+  lookback.setDate(lookback.getDate() - graceDays);
+  const lookbackWeek = startOfWeekMonday(lookback);
+
+  let earliest: Date | null = null;
+  let hasNavigationGrace = false;
+
+  for (const course of courses) {
+    if (!isCourseInNavigationGrace(course, settings, now)) continue;
+    hasNavigationGrace = true;
+    const endIso = courseEndDateIso(course);
+    if (!endIso) continue;
+    const endWeek = startOfWeekMonday(new Date(`${endIso}T12:00:00.000Z`));
+    if (!earliest || endWeek.getTime() < earliest.getTime()) {
+      earliest = endWeek;
+    }
+  }
+
+  if (!hasNavigationGrace) {
+    return todayWeek;
+  }
+
+  if (!earliest) {
+    return previousWeek;
+  }
+
+  let result = earliest;
+  if (lookbackWeek.getTime() < result.getTime()) {
+    result = lookbackWeek;
+  }
+  // Kursende in dieser KW: lookback kann noch dieselbe KW sein — mindestens eine Woche zurück
+  if (previousWeek.getTime() < result.getTime()) {
+    result = previousWeek;
+  }
+  return result;
+}
+
+export function earliestAllowedWeekStart(
+  courses: Course[],
+  settings?: TenantSettings,
+  now: Date = new Date(),
+): Date {
+  return computeEarliestWeekAnchor(courses, settings, now);
+}
+
+export function isOccurrenceInPast(
+  isoDate: string,
+  courseTime: string,
+  now: Date = new Date(),
+): boolean {
+  const occurrence = buildCourseOccurrenceLocal(isoDate, courseTime);
+  return occurrence != null && occurrence < now;
+}
+
+/** Vergangener Termin: nur Tausch aus rechtzeitiger Absage (RC), nicht Kurzfrist. */
+export function canRequestSwapFromPastCancelledOrigin(input: {
+  isoDate: string;
+  courseTime: string;
+  tenantSettings?: TenantSettings;
+  override?: CourseDateOverride;
+  userName: string;
+  participants: string[];
+  originallyParticipant: boolean;
+  now?: Date;
+}): boolean {
+  const now = input.now ?? new Date();
+  if (!isOccurrenceInPast(input.isoDate, input.courseTime, now)) return false;
+  if (
+    !isRegularCancellation(
+      input.originallyParticipant,
+      input.override,
+      input.participants,
+      input.userName,
+    )
+  ) {
+    return false;
+  }
+  return canCreateSwapFromOrigin({
+    isoDate: input.isoDate,
+    courseTime: input.courseTime,
+    tenantSettings: input.tenantSettings,
+    override: input.override,
+    userName: input.userName,
+    participants: input.participants,
+    originallyParticipant: input.originallyParticipant,
+    now,
+  });
+}

--- a/app/src/lib/courseWeek.test.ts
+++ b/app/src/lib/courseWeek.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  addWeeks,
+  formatWeekNavLabel,
+  getIsoWeekNumber,
+  isSameCalendarWeek,
+  startOfWeekMonday,
+  weekAnchorForOccurrence,
+} from "./courseWeek";
+
+describe("startOfWeekMonday", () => {
+  it("returns Monday for a Wednesday", () => {
+    const wed = new Date(2026, 4, 27, 15, 0, 0);
+    const mon = startOfWeekMonday(wed);
+    expect(mon.getDay()).toBe(1);
+    expect(mon.getDate()).toBe(25);
+    expect(mon.getMonth()).toBe(4);
+  });
+
+  it("returns Monday of the same week for Sunday", () => {
+    const sun = new Date(2026, 5, 7);
+    expect(sun.getDay()).toBe(0);
+    const mon = startOfWeekMonday(sun);
+    expect(mon.getDate()).toBe(1);
+    expect(mon.getMonth()).toBe(5);
+  });
+});
+
+describe("weekAnchorForOccurrence", () => {
+  it("keeps anchor when occurrence is in the same week", () => {
+    const anchor = startOfWeekMonday(new Date(2026, 4, 26));
+    const occurrence = new Date(2026, 4, 28);
+    expect(weekAnchorForOccurrence(occurrence, anchor)).toBe(anchor);
+  });
+
+  it("jumps to occurrence week when outside current week", () => {
+    const anchor = startOfWeekMonday(new Date(2026, 4, 26));
+    const occurrence = new Date(2026, 5, 10);
+    const next = weekAnchorForOccurrence(occurrence, anchor);
+    expect(isSameCalendarWeek(next, occurrence)).toBe(true);
+    expect(isSameCalendarWeek(next, anchor)).toBe(false);
+  });
+});
+
+describe("formatWeekNavLabel", () => {
+  it("includes KW and date range", () => {
+    const label = formatWeekNavLabel(startOfWeekMonday(new Date(2026, 4, 26)));
+    expect(label).toMatch(/^KW \d+ · /);
+    expect(label).toContain("–");
+  });
+});
+
+describe("getIsoWeekNumber", () => {
+  it("matches late May 2026 sample week", () => {
+    const weekStart = startOfWeekMonday(new Date(2026, 4, 26));
+    expect(getIsoWeekNumber(weekStart)).toBeGreaterThan(0);
+  });
+});
+
+describe("addWeeks", () => {
+  it("adds seven days per week", () => {
+    const start = startOfWeekMonday(new Date(2026, 4, 26));
+    const next = addWeeks(start, 1);
+    expect(next.getTime() - start.getTime()).toBe(7 * 86_400_000);
+  });
+});

--- a/app/src/lib/courseWeek.ts
+++ b/app/src/lib/courseWeek.ts
@@ -1,0 +1,46 @@
+/** Montag 00:00 (lokal) als Wochenstart — Studio-Alltag / ISO-Woche. */
+export function startOfWeekMonday(date: Date): Date {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function addWeeks(weekStart: Date, weeks: number): Date {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + weeks * 7);
+  return d;
+}
+
+export function isSameCalendarWeek(a: Date, b: Date): boolean {
+  return startOfWeekMonday(a).getTime() === startOfWeekMonday(b).getTime();
+}
+
+/** ISO-Kalenderwoche (Mo–So). */
+export function getIsoWeekNumber(weekStart: Date): number {
+  const thursday = new Date(weekStart);
+  thursday.setDate(thursday.getDate() + 3);
+  const yearStart = new Date(thursday.getFullYear(), 0, 1);
+  return Math.ceil(((thursday.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+}
+
+export function formatWeekNavLabel(weekStart: Date): string {
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekEnd.getDate() + 6);
+  const kw = getIsoWeekNumber(weekStart);
+  const fmt: Intl.DateTimeFormatOptions = { day: "numeric", month: "short", year: "numeric" };
+  const start = weekStart.toLocaleDateString("de-DE", fmt);
+  const end = weekEnd.toLocaleDateString("de-DE", fmt);
+  const year = weekStart.getFullYear() !== weekEnd.getFullYear() ? ` ${weekEnd.getFullYear()}` : "";
+  return `KW ${kw} · ${start} – ${end}${year}`;
+}
+
+/** Wenn occurrence außerhalb von weekStart-Woche liegt → neuer weekAnchor. */
+export function weekAnchorForOccurrence(occurrence: Date, currentWeekStart: Date): Date {
+  if (isSameCalendarWeek(occurrence, currentWeekStart)) {
+    return currentWeekStart;
+  }
+  return startOfWeekMonday(occurrence);
+}

--- a/app/src/lib/courseWeekOccurrences.test.ts
+++ b/app/src/lib/courseWeekOccurrences.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { Course } from "shared/types";
+import {
+  collectWeekOccurrences,
+  getWeekViewCardDates,
+  groupWeekRowsByDay,
+  isIsoDateInWeek,
+  isWeekEntirelyInPast,
+  preferredWeekCardDate,
+  weekRangeKeys,
+} from "./courseWeekOccurrences";
+
+const baseCourse: Pick<Course, "dates" | "excludedDates"> = {
+  dates: ["2026-05-25", "2026-06-01"],
+  excludedDates: ["2026-05-26"],
+};
+
+describe("collectWeekOccurrences", () => {
+  const weekStart = new Date(2026, 4, 25);
+
+  it("includes visible and excluded dates in the week", () => {
+    const occ = collectWeekOccurrences(baseCourse, weekStart);
+    expect(occ.map((o) => o.dateIso)).toEqual(["2026-05-25", "2026-05-26"]);
+    expect(occ.find((o) => o.dateIso === "2026-05-26")?.kind).toBe("excluded");
+    expect(occ.find((o) => o.dateIso === "2026-05-25")?.kind).toBe("scheduled");
+  });
+
+  it("ignores dates outside the week", () => {
+    expect(collectWeekOccurrences(baseCourse, weekStart).some((o) => o.dateIso === "2026-06-01")).toBe(
+      false,
+    );
+  });
+});
+
+describe("weekRangeKeys", () => {
+  it("spans Monday through Sunday locally", () => {
+    const keys = weekRangeKeys(new Date(2026, 4, 25));
+    expect(keys.start).toBe("2026-05-25");
+    expect(keys.end).toBe("2026-05-31");
+    expect(isIsoDateInWeek("2026-05-31", keys.start, keys.end)).toBe(true);
+    expect(isIsoDateInWeek("2026-06-01", keys.start, keys.end)).toBe(false);
+  });
+});
+
+describe("preferredWeekCardDate", () => {
+  const course: Course = {
+    id: 1,
+    name: "Test",
+    weekday: "Mon",
+    time: "10:00",
+    capacity: 8,
+    participants: [],
+    dates: ["2026-05-25", "2026-05-26", "2026-06-08"],
+    excludedDates: [],
+  };
+
+  it("prefers a future date inside the current week", () => {
+    const now = new Date(2026, 4, 20, 12, 0, 0);
+    const weekStart = new Date(2026, 4, 25);
+    const picked = preferredWeekCardDate(course, weekStart, now);
+    expect(picked && toLocalDateIso(picked)).toBe("2026-05-25");
+  });
+
+  it("uses the last occurrence when the week is entirely in the past", () => {
+    const now = new Date(2026, 5, 10, 12, 0, 0);
+    const weekStart = new Date(2026, 4, 25);
+    expect(isWeekEntirelyInPast(weekStart, now)).toBe(true);
+    const picked = preferredWeekCardDate(course, weekStart, now);
+    expect(picked && toLocalDateIso(picked)).toBe("2026-05-26");
+  });
+});
+
+describe("getWeekViewCardDates", () => {
+  it("includes past dates from the displayed week", () => {
+    const course: Course = {
+      id: 1,
+      name: "Test",
+      weekday: "Mon",
+      time: "10:00",
+      capacity: 8,
+      participants: [],
+      dates: ["2026-05-26", "2026-06-15"],
+      excludedDates: [],
+    };
+    const now = new Date(2026, 5, 10, 12, 0, 0);
+    const weekStart = new Date(2026, 4, 25);
+    const keys = getWeekViewCardDates(course, weekStart, now).map((d) => toLocalDateIso(d));
+    expect(keys).toContain("2026-05-26");
+    expect(keys).toContain("2026-06-15");
+  });
+});
+
+function toLocalDateIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+describe("groupWeekRowsByDay", () => {
+  it("groups and sorts by time then name", () => {
+    const groups = groupWeekRowsByDay([
+      {
+        course: { ...baseCourse, id: 1, name: "Zebra", time: "18:00" } as Course,
+        occurrences: [{ dateIso: "2026-05-25", kind: "scheduled" }],
+      },
+      {
+        course: { ...baseCourse, id: 2, name: "Alpha", time: "10:00" } as Course,
+        occurrences: [{ dateIso: "2026-05-25", kind: "scheduled" }],
+      },
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map((i) => i.course.name)).toEqual(["Alpha", "Zebra"]);
+  });
+});

--- a/app/src/lib/courseWeekOccurrences.test.ts
+++ b/app/src/lib/courseWeekOccurrences.test.ts
@@ -84,8 +84,31 @@ describe("getWeekViewCardDates", () => {
     };
     const now = new Date(2026, 5, 10, 12, 0, 0);
     const weekStart = new Date(2026, 4, 25);
-    const keys = getWeekViewCardDates(course, weekStart, now).map((d) => toLocalDateIso(d));
+    const keys = getWeekViewCardDates(course, weekStart, undefined, now).map((d) => toLocalDateIso(d));
     expect(keys).toContain("2026-05-26");
+    expect(keys).toContain("2026-06-15");
+  });
+
+  it("includes past grace dates from previous week for term jump", () => {
+    const course: Course = {
+      id: 1,
+      name: "Test",
+      weekday: "Mon",
+      time: "10:00",
+      capacity: 8,
+      participants: [],
+      dates: ["2026-05-18", "2026-06-15"],
+      excludedDates: [],
+    };
+    const now = new Date(2026, 4, 22, 12, 0, 0);
+    const weekStart = new Date(2026, 4, 25);
+    const keys = getWeekViewCardDates(
+      course,
+      weekStart,
+      { inactiveGraceDaysAfterCourseEnd: 7 },
+      now,
+    ).map((d) => toLocalDateIso(d));
+    expect(keys).toContain("2026-05-18");
     expect(keys).toContain("2026-06-15");
   });
 });

--- a/app/src/lib/courseWeekOccurrences.test.ts
+++ b/app/src/lib/courseWeekOccurrences.test.ts
@@ -61,6 +61,18 @@ describe("preferredWeekCardDate", () => {
     expect(picked && toLocalDateIso(picked)).toBe("2026-05-25");
   });
 
+  it("skips excluded dates when picking the default term in a week", () => {
+    const courseWithExcluded: Course = {
+      ...course,
+      dates: ["2026-05-25", "2026-05-26", "2026-06-08"],
+      excludedDates: ["2026-05-26"],
+    };
+    const now = new Date(2026, 4, 20, 12, 0, 0);
+    const weekStart = new Date(2026, 4, 25);
+    const picked = preferredWeekCardDate(courseWithExcluded, weekStart, now);
+    expect(picked && toLocalDateIso(picked)).toBe("2026-05-25");
+  });
+
   it("uses the last occurrence when the week is entirely in the past", () => {
     const now = new Date(2026, 5, 10, 12, 0, 0);
     const weekStart = new Date(2026, 4, 25);

--- a/app/src/lib/courseWeekOccurrences.ts
+++ b/app/src/lib/courseWeekOccurrences.ts
@@ -1,0 +1,131 @@
+import { buildCourseOccurrenceLocal } from "shared/courseStatus";
+import type { Course } from "shared/types";
+import { getCourseDates } from "./dates";
+
+export type WeekOccurrenceKind = "scheduled" | "excluded";
+
+export type WeekOccurrence = {
+  dateIso: string;
+  kind: WeekOccurrenceKind;
+};
+
+export function toLocalDateIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function weekRangeKeys(weekStart: Date): { start: string; end: string } {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 6);
+  return { start: toLocalDateIso(weekStart), end: toLocalDateIso(end) };
+}
+
+export function isIsoDateInWeek(iso: string, start: string, end: string): boolean {
+  return iso >= start && iso <= end;
+}
+
+/** Sichtbare und ausgeschlossene Termine der Kalenderwoche (lokales Mo–So). */
+export function collectWeekOccurrences(
+  course: Pick<Course, "dates" | "excludedDates">,
+  weekStart: Date,
+): WeekOccurrence[] {
+  const { start, end } = weekRangeKeys(weekStart);
+  const excluded = new Set(course.excludedDates ?? []);
+  const dateSet = new Set<string>();
+
+  for (const iso of course.dates ?? []) {
+    if (isIsoDateInWeek(iso, start, end)) dateSet.add(iso);
+  }
+  for (const iso of course.excludedDates ?? []) {
+    if (isIsoDateInWeek(iso, start, end)) dateSet.add(iso);
+  }
+
+  return Array.from(dateSet)
+    .sort((a, b) => a.localeCompare(b))
+    .map((dateIso) => ({
+      dateIso,
+      kind: excluded.has(dateIso) ? "excluded" : "scheduled",
+    }));
+}
+
+export type WeekCourseRow = {
+  course: Course;
+  occurrences: WeekOccurrence[];
+};
+
+export type WeekDayGroup = {
+  dateIso: string;
+  items: Array<{ course: Course; occurrence: WeekOccurrence }>;
+};
+
+/** Termine der Kalenderwoche als lokale Date-Objekte (inkl. ausgeschlossener). */
+export function weekOccurrenceDates(course: Course, weekStart: Date): Date[] {
+  return collectWeekOccurrences(course, weekStart)
+    .map((o) => buildCourseOccurrenceLocal(o.dateIso, course.time))
+    .filter((d): d is Date => d !== null)
+    .sort((a, b) => a.getTime() - b.getTime());
+}
+
+export function isWeekEntirelyInPast(weekStart: Date, now: Date = new Date()): boolean {
+  const { end } = weekRangeKeys(weekStart);
+  return end < toLocalDateIso(now);
+}
+
+/** Termine für Kachel-Dropdown: künftige plus alle Termine der angezeigten Kalenderwoche. */
+export function getWeekViewCardDates(
+  course: Course,
+  weekStart: Date,
+  now: Date = new Date(),
+): Date[] {
+  const future = getCourseDates(course, now);
+  const inWeek = weekOccurrenceDates(course, weekStart);
+  const merged = new Map<string, Date>();
+  for (const d of [...future, ...inWeek]) {
+    merged.set(toLocalDateIso(d), d);
+  }
+  return Array.from(merged.values()).sort((a, b) => a.getTime() - b.getTime());
+}
+
+/**
+ * Vorauswahl passend zur angezeigten KW: bei vergangener Woche letzter Termin dort,
+ * sonst erster künftiger Termin in der Woche, sonst erster Termin in der Woche.
+ */
+export function preferredWeekCardDate(
+  course: Course,
+  weekStart: Date,
+  now: Date = new Date(),
+): Date | undefined {
+  const inWeek = weekOccurrenceDates(course, weekStart);
+  if (inWeek.length > 0) {
+    if (isWeekEntirelyInPast(weekStart, now)) {
+      return inWeek[inWeek.length - 1];
+    }
+    const futureInWeek = inWeek.filter((d) => d >= now);
+    return futureInWeek[0] ?? inWeek[0];
+  }
+  return getCourseDates(course, now)[0];
+}
+
+export function groupWeekRowsByDay(rows: WeekCourseRow[]): WeekDayGroup[] {
+  const byDate = new Map<string, WeekDayGroup["items"]>();
+
+  for (const { course, occurrences } of rows) {
+    for (const occurrence of occurrences) {
+      const list = byDate.get(occurrence.dateIso) ?? [];
+      list.push({ course, occurrence });
+      byDate.set(occurrence.dateIso, list);
+    }
+  }
+
+  return Array.from(byDate.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([dateIso, items]) => ({
+      dateIso,
+      items: items.sort((a, b) => {
+        if (a.course.time !== b.course.time) return a.course.time.localeCompare(b.course.time);
+        return a.course.name.localeCompare(b.course.name, "de");
+      }),
+    }));
+}

--- a/app/src/lib/courseWeekOccurrences.ts
+++ b/app/src/lib/courseWeekOccurrences.ts
@@ -30,6 +30,13 @@ export function isIsoDateInWeek(iso: string, start: string, end: string): boolea
   return iso >= start && iso <= end;
 }
 
+export function isExcludedCourseDate(
+  course: Pick<Course, "excludedDates">,
+  dateIso: string,
+): boolean {
+  return (course.excludedDates ?? []).includes(dateIso);
+}
+
 /** Sichtbare und ausgeschlossene Termine der Kalenderwoche (lokales Mo–So). */
 export function collectWeekOccurrences(
   course: Pick<Course, "dates" | "excludedDates">,
@@ -107,18 +114,55 @@ export function getWeekViewCardDates(
  * Vorauswahl passend zur angezeigten KW: bei vergangener Woche letzter Termin dort,
  * sonst erster künftiger Termin in der Woche, sonst erster Termin in der Woche.
  */
+function occurrenceDatesSorted(
+  occurrences: WeekOccurrence[],
+  course: Course,
+): Date[] {
+  return occurrences
+    .map((o) => buildCourseOccurrenceLocal(o.dateIso, course.time))
+    .filter((d): d is Date => d !== null)
+    .sort((a, b) => a.getTime() - b.getTime());
+}
+
+function pickPreferredFromWeekDates(
+  dates: Date[],
+  occurrences: WeekOccurrence[],
+  weekStart: Date,
+  now: Date,
+): Date | undefined {
+  if (dates.length === 0) return undefined;
+  const excludedSet = new Set(
+    occurrences.filter((o) => o.kind === "excluded").map((o) => o.dateIso),
+  );
+  const isScheduled = (d: Date) => !excludedSet.has(toLocalDateIso(d));
+  const scheduled = dates.filter(isScheduled);
+
+  if (isWeekEntirelyInPast(weekStart, now)) {
+    const pool = scheduled.length > 0 ? scheduled : dates;
+    return pool[pool.length - 1];
+  }
+
+  const future = dates.filter((d) => d >= now);
+  const futureScheduled = future.filter(isScheduled);
+  if (futureScheduled.length > 0) return futureScheduled[0];
+  if (future.length > 0) return future[0];
+  if (scheduled.length > 0) return scheduled[0];
+  return dates[0];
+}
+
 export function preferredWeekCardDate(
   course: Course,
   weekStart: Date,
   now: Date = new Date(),
 ): Date | undefined {
-  const inWeek = weekOccurrenceDates(course, weekStart);
-  if (inWeek.length > 0) {
-    if (isWeekEntirelyInPast(weekStart, now)) {
-      return inWeek[inWeek.length - 1];
-    }
-    const futureInWeek = inWeek.filter((d) => d >= now);
-    return futureInWeek[0] ?? inWeek[0];
+  const occurrences = collectWeekOccurrences(course, weekStart);
+  if (occurrences.length > 0) {
+    return pickPreferredFromWeekDates(
+      occurrenceDatesSorted(occurrences, course),
+      occurrences,
+      weekStart,
+      now,
+    );
   }
   return getCourseDates(course, now)[0];
 }

--- a/app/src/lib/courseWeekOccurrences.ts
+++ b/app/src/lib/courseWeekOccurrences.ts
@@ -1,5 +1,9 @@
-import { buildCourseOccurrenceLocal } from "shared/courseStatus";
-import type { Course } from "shared/types";
+import {
+  addCalendarDaysIsoUtc,
+  buildCourseOccurrenceLocal,
+  DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END,
+} from "shared/courseStatus";
+import type { Course, TenantSettings } from "shared/types";
 import { getCourseDates } from "./dates";
 
 export type WeekOccurrenceKind = "scheduled" | "excluded";
@@ -77,12 +81,23 @@ export function isWeekEntirelyInPast(weekStart: Date, now: Date = new Date()): b
 export function getWeekViewCardDates(
   course: Course,
   weekStart: Date,
+  settings?: TenantSettings,
   now: Date = new Date(),
 ): Date[] {
   const future = getCourseDates(course, now);
   const inWeek = weekOccurrenceDates(course, weekStart);
+  const todayIso = toLocalDateIso(now);
+  const graceDays =
+    typeof settings?.inactiveGraceDaysAfterCourseEnd === "number" &&
+    settings.inactiveGraceDaysAfterCourseEnd > 0
+      ? settings.inactiveGraceDaysAfterCourseEnd
+      : DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END;
+  const pastGrace = (course.dates ?? [])
+    .filter((iso) => iso < todayIso && todayIso <= addCalendarDaysIsoUtc(iso, graceDays))
+    .map((iso) => buildCourseOccurrenceLocal(iso, course.time))
+    .filter((d): d is Date => d !== null);
   const merged = new Map<string, Date>();
-  for (const d of [...future, ...inWeek]) {
+  for (const d of [...future, ...inWeek, ...pastGrace]) {
     merged.set(toLocalDateIso(d), d);
   }
   return Array.from(merged.values()).sort((a, b) => a.getTime() - b.getTime());

--- a/app/src/shared/permissions.test.ts
+++ b/app/src/shared/permissions.test.ts
@@ -302,16 +302,19 @@ describe("permissions", () => {
 
     it("zeigt aktiven Kurs nur mit sichtbaren Terminen", () => {
       const withDate = { ...dummyCourse, dates: ["2026-06-01"] };
+      const now = new Date(Date.UTC(2026, 4, 15, 12, 0, 0));
       expect(
         canShowParticipantCourseCard(participantMembership, defaultSettings, withDate, {
           ...baseCtx,
           hasVisibleCourseDates: true,
+          now,
         }),
       ).toBe(true);
       expect(
         canShowParticipantCourseCard(participantMembership, defaultSettings, withDate, {
           ...baseCtx,
           hasVisibleCourseDates: false,
+          now,
         }),
       ).toBe(false);
     });

--- a/docs/course-views.md
+++ b/docs/course-views.md
@@ -79,6 +79,20 @@ Gemeinsame Leiste über dem Kursbereich (`App` oder `CoursesShell`):
 
 Hinweis-Text unter dem Header („Termin absagen“ / „Tauschen“) ggf. nur in der Wochenansicht oder ansichtsspezifisch.
 
+### Vergangenheit (Nachlauf)
+
+Gilt einheitlich in der **Wochenansicht** für alle Rollen (Verwaltung über **Kursübersicht**):
+
+| Regel | Verhalten |
+|--------|-----------|
+| **Sichtbarkeit** | Vergangene Kalenderwoche: nur Kurse noch im Kalender-Nachlauf (`inactiveGraceDaysAfterCourseEnd`, vgl. #149), mit Termin in dieser KW. |
+| **Navigation ‹** | Solange mindestens ein Kurs im Kalender-Nachlauf liegt: frühestens bis zur KW des Kursendes, `inactiveGraceDaysAfterCourseEnd` Tage zurück ab heute und mindestens die **vorige** KW (`computeEarliestWeekAnchor`). ‹ deaktiviert, wenn kein Kurs mehr im Nachlauf liegt. |
+| **Vergangener Termin** | Keine Absage, kein neuer Tausch — Hinweis „keine Änderungen mehr möglich“. |
+| **Rechtzeitig abgesagt (RC)** | Nur dann weiter „Anderen Termin wählen“ / offene Tauschanfragen verwalten. |
+| **Bestehende Swaps** | Abbrechen/verwalten am vergangenen Termin weiter möglich. |
+
+Code: `app/src/lib/courseTermActions.ts`, Filter in `useCoursesData`, `CourseCard` (`canUseFullTermActions` vs. `canSwapFromPastCancelled`).
+
 ---
 
 ## Abgrenzung

--- a/docs/course-views.md
+++ b/docs/course-views.md
@@ -90,7 +90,7 @@ Aggregierter Hinweis, wenn Kurse in der KW wegen abgelaufenem Nachlauf ausgeblen
 
 - Default **Wochenansicht** für alle Rollen mit Kurszugang.
 - Hinweis unter der Toolbar in der Wochenansicht (Absagen/Tauschen).
-- **Noch nicht:** URL-Parameter, `localStorage` für letzte Ansicht, globales `selectedOccurrence` im Shell-State.
+- **Noch nicht:** Persistenz der KW beim Reload ([#187](https://github.com/CurlyKarin/yogaswap/issues/187): `sessionStorage` in der Tab-Session, Vertretung in gleicher KW), URL-Parameter, globales `selectedOccurrence` im Shell-State.
 
 ### Vergangenheit (Nachlauf)
 
@@ -137,7 +137,8 @@ Aggregierter Hinweis, wenn Kurse in der KW wegen abgelaufenem Nachlauf ausgeblen
 - [ ] Layout-Polish Kacheln [#182](https://github.com/CurlyKarin/yogaswap/issues/182)
 - [ ] Meilenstein Post-rollout: Kachel Status/Tausch-Ursprung [#185](https://github.com/CurlyKarin/yogaswap/issues/185)
 - [ ] Meilenstein Post-rollout: Übersicht „Meine Termine“ [#186](https://github.com/CurlyKarin/yogaswap/issues/186) (`groupWeekRowsByDay` vorbereitet, UI noch nicht)
-- [ ] Optional: URL-Parameter, `localStorage`, Tagesgruppierung in der Wochenansicht
+- [ ] KW in Tab-Session behalten + Vertretung ([#187](https://github.com/CurlyKarin/yogaswap/issues/187))
+- [ ] Optional: URL-Parameter, Tagesgruppierung in der Wochenansicht
 
 ---
 
@@ -148,3 +149,4 @@ Aggregierter Hinweis, wenn Kurse in der KW wegen abgelaufenem Nachlauf ausgeblen
 - [#182](https://github.com/CurlyKarin/yogaswap/issues/182) — Layout Kurskacheln
 - [#185](https://github.com/CurlyKarin/yogaswap/issues/185) — Tausch-Ursprung / eigene Absagen in der Kachel
 - [#186](https://github.com/CurlyKarin/yogaswap/issues/186) — Terminübersicht nach Woche
+- [#187](https://github.com/CurlyKarin/yogaswap/issues/187) — `weekAnchor` in Session, Vertretung in gleicher KW

--- a/docs/course-views.md
+++ b/docs/course-views.md
@@ -1,0 +1,107 @@
+# Kursübersicht und Wochenansicht (Issue #164)
+
+Produkt- und UI-Abstimmung für zwei getrennte Ansichten der Kurse/Termine. Ergänzt [#164](https://github.com/CurlyKarin/yogaswap/issues/164); Sichtbarkeit nach Kursstatus bleibt in [#149](https://github.com/CurlyKarin/yogaswap/issues/149) (`docs/course-status-visibility.md`).
+
+## Kurzfassung
+
+| Ansicht | Primär für | Job |
+|--------|------------|-----|
+| **Kursübersicht** | Admin, Kursleitung | Planen & verwalten (Status, Kapazität, Mitglieder, Termine, Überplanung) |
+| **Wochenansicht** | Teilnehmer:innen, Kursleitung im Alltag | Orientierung in der Zeit; Absagen/Ausschlüsse erkennbar; Tausch-Kontext |
+
+Heute existiert nur die **kurszentrierte Kurskarten-Liste** (`CourseList` + `CourseCard`) — für alle Rollen. #164 führt die **Wochenansicht** ein und benennt die bestehende Liste als **Kursübersicht** (Planungsfokus).
+
+---
+
+## Kursübersicht (Ist → Ziel)
+
+**Mental Model:** Nach **Kurs** sortiert; pro Kurs die **anstehenden, planungsseitig sichtbaren** Termine (`visibleDates` / `getCourseDates`: Datum + Uhrzeit ≥ jetzt); pro gewähltem Termin der **effektive** Zustand (Serie + Override).
+
+**Nicht:** vollständiger Kalender, keine Terminhistorie, ausgeschlossene Tage erscheinen nicht in der Datumsauswahl (sie sind aus `visibleDates`).
+
+**Ziel-Rollen:** Admin und Kursleitung (Verwaltung). Teilnehmer:innen nutzen künftig primär die **Wochenansicht**. Vertretung (`forceParticipantView`) gehört zur Wochenansicht, nicht zur Kursübersicht.
+
+**Code (aktuell):** `app/src/components/CourseList.tsx`, `CourseCard.tsx`, Toolbar „Kurse verwalten“.
+
+---
+
+## Wochenansicht (#164)
+
+**Mental Model:** Nach **Kalenderwoche** sortiert; mehrere Kurse im gleichen Zeitfenster; Sonderzustände pro Termin sichtbar.
+
+### Anforderungen (aus #164 / #149)
+
+- **Abgesagte** und **ausgeschlossene** Termine in irgendeiner Form sichtbar (eigene Darstellung), nicht nur über reduzierte `visibleDates`.
+- **Swap-Tausch-UI:** begrenzt in die **Vergangenheit** blicken (Referenz/Ursprung); **Zieltermine in der Vergangenheit** weiterhin fachlich nicht erlaubt (bestehende Regeln, `SwapSettings`).
+- Datenquellen: `excludedDates`, Overrides, Swaps, ggf. Abwesenheiten — konsistent mit #149 und `TenantSettings`.
+
+### Gemeinsame Kalenderwoche
+
+Eine zentrale **`weekAnchor`** (Start der angezeigten Woche, z. B. Montag 00:00 in Studio-/Lokalzeit):
+
+- Alle Kurse in der Wochenansicht zeigen Termine **dieser Woche**.
+- Wählt jemand an einem Kurs ein Datum außerhalb der aktuellen Woche → **`weekAnchor` wechselt** → alle anderen Kurse „springen“ in dieselbe Woche.
+- Klick innerhalb der aktuellen Woche → nur Fokus/Highlight wechseln, `weekAnchor` unverändert.
+
+Vorgeschlagener App-State (eine Ebene über den Kurskomponenten, z. B. `CoursesShell`):
+
+```text
+viewMode: 'week' | 'courses'
+weekAnchor: Date
+selectedOccurrence?: { courseId, dateIso }
+```
+
+---
+
+## Navigation (UI)
+
+Gemeinsame Leiste über dem Kursbereich (`App` oder `CoursesShell`):
+
+```text
+[ Wochenansicht | Kursübersicht ]     ← Kursübersicht nur bei Berechtigung (Admin/Kursleitung)
+
+[ ‹ ]  KW 22 · 26. Mai – 1. Juni 2026  [ › ]  [ Heute ]   ← nur in Wochenansicht
+```
+
+- **Ansichts-Toggle:** Segmented Control oder zwei Buttons (`aria-pressed` / aktive Klasse).
+- **Wochensteuerung:** nur in der Wochenansicht sichtbar.
+- Optional später: URL-Parameter (`?view=week&week=2026-W22`) für Reload/Bookmark — nicht zwingend in v1.
+
+### Defaults & Wechsel
+
+| Situation | Vorschlag |
+|-----------|-----------|
+| Teilnehmer:in | Default **Wochenansicht** |
+| Admin / Kursleitung | Default **Wochenansicht**; Umschalter zur **Kursübersicht** |
+| Woche → Kursübersicht | `weekAnchor` merken |
+| Kursübersicht → Woche | Woche von „heute“ oder letztem `weekAnchor` |
+| Letzte Ansicht | optional `localStorage` |
+
+Hinweis-Text unter dem Header („Termin absagen“ / „Tauschen“) ggf. nur in der Wochenansicht oder ansichtsspezifisch.
+
+---
+
+## Abgrenzung
+
+| Thema | Issue / Doku |
+|--------|----------------|
+| Kursstatus, `visibleDates`, Nachlauf | #149, `course-status-visibility.md` |
+| Kalender-/Swap-Zeitachse, Sondertermine | #164 (dieses Dokument) |
+| Kontrollierte Überplanung | #153, `course-overbooking.md` |
+
+---
+
+## Umsetzung (technisch, grob)
+
+1. `CoursesShell`: State `viewMode`, `weekAnchor`, Toggle + Wochennav.
+2. `CourseList` → Kursübersicht (Benennung, ggf. nur mit `canSeeCourseManagement`).
+3. Neue `WeekView` (oder ähnlich): Termine pro Woche, inkl. abgesagt/ausgeschlossen.
+4. Swap-Modals: geteilte Woche / begrenzte Vergangenheit (#164).
+5. Tests + Accessibility (Toggle, Wochenbuttons).
+
+---
+
+## Verknüpfung
+
+- [#164](https://github.com/CurlyKarin/yogaswap/issues/164) — Wochenansicht (Termine, Absagen, Ausschlüsse, Swap-Kontext)
+- [#149](https://github.com/CurlyKarin/yogaswap/issues/149) — Kursstatus-Sichtbarkeit

--- a/docs/course-views.md
+++ b/docs/course-views.md
@@ -9,89 +9,98 @@ Produkt- und UI-Abstimmung für zwei getrennte Ansichten der Kurse/Termine. Erg�
 | **Kursübersicht** | Admin, Kursleitung | Planen & verwalten (Status, Kapazität, Mitglieder, Termine, Überplanung) |
 | **Wochenansicht** | Teilnehmer:innen, Kursleitung im Alltag | Orientierung in der Zeit; Absagen/Ausschlüsse erkennbar; Tausch-Kontext |
 
-Heute existiert nur die **kurszentrierte Kurskarten-Liste** (`CourseList` + `CourseCard`) — für alle Rollen. #164 führt die **Wochenansicht** ein und benennt die bestehende Liste als **Kursübersicht** (Planungsfokus).
+Beide Ansichten sind umgesetzt. `CoursesShell` schaltet zwischen ihnen; die Wochenansicht nutzt ein gemeinsames **`weekAnchor`** und Kurskacheln (`CourseWeekView` + `CourseCard`).
 
 ---
 
-## Kursübersicht (Ist → Ziel)
+## Architektur (App)
+
+```text
+CoursesShell
+  viewMode: 'week' | 'courses'     (Default: week)
+  weekAnchor: Date                 (Montag 00:00, Lokalzeit)
+
+  week  → CourseWeekView → CourseCard (pro sichtbarem Kurs)
+  courses → CourseList → CourseCard   (nur canSeeCourseManagement)
+```
+
+Daten: `useCoursesData` (Kurse, Overrides, Swaps, `weekCourseRows`, `earliestWeekAnchor`, `hiddenPastCourseCount`).
+
+Vertretung (`forceParticipantView` in `App`): Teilnehmer-Perspektive in der **Wochenansicht**; Kursübersicht bleibt für Admin/Kursleitung reserviert.
+
+---
+
+## Kursübersicht
 
 **Mental Model:** Nach **Kurs** sortiert; pro Kurs die **anstehenden, planungsseitig sichtbaren** Termine (`visibleDates` / `getCourseDates`: Datum + Uhrzeit ≥ jetzt); pro gewähltem Termin der **effektive** Zustand (Serie + Override).
 
-**Nicht:** vollständiger Kalender, keine Terminhistorie, ausgeschlossene Tage erscheinen nicht in der Datumsauswahl (sie sind aus `visibleDates`).
+**Nicht:** vollständiger Kalender, keine Terminhistorie; **ausgeschlossene** Serientage (`excludedDates`) erscheinen nicht in der Datumsauswahl (nicht in `visibleDates`).
 
-**Ziel-Rollen:** Admin und Kursleitung (Verwaltung). Teilnehmer:innen nutzen künftig primär die **Wochenansicht**. Vertretung (`forceParticipantView`) gehört zur Wochenansicht, nicht zur Kursübersicht.
+**Rollen:** Nur mit `canSeeCourseManagement` (Admin/Kursleitung). Toolbar „Kurse verwalten“.
 
-**Code (aktuell):** `app/src/components/CourseList.tsx`, `CourseCard.tsx`, Toolbar „Kurse verwalten“.
+**Code:** `app/src/components/CourseList.tsx`, `CourseCard.tsx` (ohne `includePastTermsInSelect`).
 
 ---
 
-## Wochenansicht (#164)
+## Wochenansicht
 
-**Mental Model:** Nach **Kalenderwoche** sortiert; mehrere Kurse im gleichen Zeitfenster; Sonderzustände pro Termin sichtbar.
-
-### Anforderungen (aus #164 / #149)
-
-- **Abgesagte** und **ausgeschlossene** Termine in irgendeiner Form sichtbar (eigene Darstellung), nicht nur über reduzierte `visibleDates`.
-- **Swap-Tausch-UI:** begrenzt in die **Vergangenheit** blicken (Referenz/Ursprung); **Zieltermine in der Vergangenheit** weiterhin fachlich nicht erlaubt (bestehende Regeln, `SwapSettings`).
-- Datenquellen: `excludedDates`, Overrides, Swaps, ggf. Abwesenheiten — konsistent mit #149 und `TenantSettings`.
+**Mental Model:** Eine **Kalenderwoche** (`weekAnchor`); alle sichtbaren Kurse als Kacheln im Grid. Pro Kurs Termine dieser Woche (und Nachlauf-Sprünge) über die Terminauswahl in der Kachel.
 
 ### Gemeinsame Kalenderwoche
 
-Eine zentrale **`weekAnchor`** (Start der angezeigten Woche, z. B. Montag 00:00 in Studio-/Lokalzeit):
+- Alle Kacheln beziehen sich auf dieselbe KW (`weekAnchor`).
+- Terminwahl in einer Kachel **außerhalb** der aktuellen KW → `weekAnchor` wechselt (`onDateChange` / `weekAnchorForOccurrence`).
+- Terminwahl **innerhalb** der KW → nur Fokus in der Kachel, `weekAnchor` unverändert.
 
-- Alle Kurse in der Wochenansicht zeigen Termine **dieser Woche**.
-- Wählt jemand an einem Kurs ein Datum außerhalb der aktuellen Woche → **`weekAnchor` wechselt** → alle anderen Kurse „springen“ in dieselbe Woche.
-- Klick innerhalb der aktuellen Woche → nur Fokus/Highlight wechseln, `weekAnchor` unverändert.
+**Vorauswahl:** `preferredWeekCardDate` — bevorzugt geplante, künftige Termine in der KW; **überspringt** `excludedDates`; in vergangener KW der letzte Termin dort.
 
-Vorgeschlagener App-State (eine Ebene über den Kurskomponenten, z. B. `CoursesShell`):
+**Terminliste in der Kachel:** `getWeekViewCardDates` — künftige Termine plus alle Termine der angezeigten KW (inkl. Vergangenheit in der KW und Nachlauf-Termine außerhalb der KW zum Springen).
 
-```text
-viewMode: 'week' | 'courses'
-weekAnchor: Date
-selectedOccurrence?: { courseId, dateIso }
-```
+### Sondertermine in der Kachel
+
+| Zustand | Erkennbar wie | Aktionen (Teilnehmer) |
+|--------|----------------|------------------------|
+| **Studio-Entfall** (`excludedDates`) | Marker `CalendarX` (rot), Dropdown `(entfällt)`, Hinweis „Termin entfällt“ | Keine Absage/Tausch; Swap ggf. nur abbrechen |
+| **Vergangen** (Nachlauf) | Marker `History` | Keine neuen Aktionen; RC-Absage → Tausch verwalten; bestehende Swaps abbrechen |
+| **Cutoff** (kurz vor Start) | Marker `Clock3` | Kein neuer Tausch; SN/RC-Regeln (#167) |
+| **Eigene RC/SN** | Chips (eigenes Chip grün; SN: du kräftig rot, andere blass) | Absage/Tausch wie in Kursübersicht |
+| **Aktiver Tausch vom Ursprung** | Oft nicht in Teilnehmer-Chips; Status-Text unten („Getauscht mit …“) | Follow-up [#185](https://github.com/CurlyKarin/yogaswap/issues/185) |
+
+Daten: `collectWeekOccurrences` / `isExcludedCourseDate` in `app/src/lib/courseWeekOccurrences.ts`; Filter Nachlauf in `useCoursesData` / `canShowCourseInPastWeek`.
+
+Aggregierter Hinweis, wenn Kurse in der KW wegen abgelaufenem Nachlauf ausgeblendet werden: `hiddenPastCourseCount`.
+
+### Tausch-UI
+
+- Zieltermine: `getAvailableDates` / `getWaitlistDates` (weiterhin keine Ziele in der Vergangenheit; Swap-Fenster `SwapSettings`).
+- Modal mit Hilfe-Texten zu freien Terminen und Warteliste.
+- Bekannte Bugs: [#183](https://github.com/CurlyKarin/yogaswap/issues/183) (Überplanung + Cutoff-Ziel), [#184](https://github.com/CurlyKarin/yogaswap/issues/184) (SN-Persistenz im Cutoff).
+
+**Code:** `app/src/components/CourseWeekView.tsx`, `CourseCard.tsx` (`includePastTermsInSelect`), `app/src/lib/courseTermActions.ts`.
 
 ---
 
 ## Navigation (UI)
 
-Gemeinsame Leiste über dem Kursbereich (`App` oder `CoursesShell`):
-
 ```text
-[ Wochenansicht | Kursübersicht ]     ← Kursübersicht nur bei Berechtigung (Admin/Kursleitung)
+[ Wochenansicht | Kursübersicht ]     ← nur Admin/Kursleitung
 
-[ ‹ ]  KW 22 · 26. Mai – 1. Juni 2026  [ › ]  [ Heute ]   ← nur in Wochenansicht
+[ ‹ ]  KW 22 · 26. Mai – 1. Juni 2026  [ › ]  [ Heute ]   ← nur Wochenansicht
 ```
 
-- **Ansichts-Toggle:** Segmented Control oder zwei Buttons (`aria-pressed` / aktive Klasse).
-- **Wochensteuerung:** nur in der Wochenansicht sichtbar.
-- Optional später: URL-Parameter (`?view=week&week=2026-W22`) für Reload/Bookmark — nicht zwingend in v1.
-
-### Defaults & Wechsel
-
-| Situation | Vorschlag |
-|-----------|-----------|
-| Teilnehmer:in | Default **Wochenansicht** |
-| Admin / Kursleitung | Default **Wochenansicht**; Umschalter zur **Kursübersicht** |
-| Woche → Kursübersicht | `weekAnchor` merken |
-| Kursübersicht → Woche | Woche von „heute“ oder letztem `weekAnchor` |
-| Letzte Ansicht | optional `localStorage` |
-
-Hinweis-Text unter dem Header („Termin absagen“ / „Tauschen“) ggf. nur in der Wochenansicht oder ansichtsspezifisch.
+- Default **Wochenansicht** für alle Rollen mit Kurszugang.
+- Hinweis unter der Toolbar in der Wochenansicht (Absagen/Tauschen).
+- **Noch nicht:** URL-Parameter, `localStorage` für letzte Ansicht, globales `selectedOccurrence` im Shell-State.
 
 ### Vergangenheit (Nachlauf)
 
-Gilt einheitlich in der **Wochenansicht** für alle Rollen (Verwaltung über **Kursübersicht**):
-
 | Regel | Verhalten |
 |--------|-----------|
-| **Sichtbarkeit** | Vergangene Kalenderwoche: nur Kurse noch im Kalender-Nachlauf (`inactiveGraceDaysAfterCourseEnd`, vgl. #149), mit Termin in dieser KW. |
-| **Navigation ‹** | Solange mindestens ein Kurs im Kalender-Nachlauf liegt: frühestens bis zur KW des Kursendes, `inactiveGraceDaysAfterCourseEnd` Tage zurück ab heute und mindestens die **vorige** KW (`computeEarliestWeekAnchor`). ‹ deaktiviert, wenn kein Kurs mehr im Nachlauf liegt. |
-| **Vergangener Termin** | Keine Absage, kein neuer Tausch — Hinweis „keine Änderungen mehr möglich“. |
-| **Rechtzeitig abgesagt (RC)** | Nur dann weiter „Anderen Termin wählen“ / offene Tauschanfragen verwalten. |
-| **Bestehende Swaps** | Abbrechen/verwalten am vergangenen Termin weiter möglich. |
-
-Code: `app/src/lib/courseTermActions.ts`, Filter in `useCoursesData`, `CourseCard` (`canUseFullTermActions` vs. `canSwapFromPastCancelled`).
+| **Sichtbarkeit** | Vergangene KW: nur Kurse im Kalender-Nachlauf mit Termin in dieser KW. |
+| **Navigation ‹** | `computeEarliestWeekAnchor`; ‹ deaktiviert am unteren Limit. |
+| **Vergangener Termin** | Keine Absage, kein neuer Tausch. |
+| **RC abgesagt** | „Anderen Termin wählen“ / offene Tauschanfragen. |
+| **Bestehende Swaps** | Abbrechen/verwalten weiter möglich. |
 
 ---
 
@@ -102,20 +111,40 @@ Code: `app/src/lib/courseTermActions.ts`, Filter in `useCoursesData`, `CourseCar
 | Kursstatus, `visibleDates`, Nachlauf | #149, `course-status-visibility.md` |
 | Kalender-/Swap-Zeitachse, Sondertermine | #164 (dieses Dokument) |
 | Kontrollierte Überplanung | #153, `course-overbooking.md` |
+| Kurzfristige Absage (SN/RC, Cutoff) | #167, `short-notice-cancellation.md` |
 
 ---
 
-## Umsetzung (technisch, grob)
+## Umsetzungsstand
 
-1. `CoursesShell`: State `viewMode`, `weekAnchor`, Toggle + Wochennav.
-2. `CourseList` → Kursübersicht (Benennung, ggf. nur mit `canSeeCourseManagement`).
-3. Neue `WeekView` (oder ähnlich): Termine pro Woche, inkl. abgesagt/ausgeschlossen.
-4. Swap-Modals: geteilte Woche / begrenzte Vergangenheit (#164).
-5. Tests + Accessibility (Toggle, Wochenbuttons).
+### Erledigt (Branch `feature/164-week-view`)
+
+- [x] `CoursesShell`: `viewMode`, `weekAnchor`, Toggle, Wochennavigation
+- [x] `CourseWeekView` mit Kurskarten-Grid
+- [x] `CourseList` als Kursübersicht (nur Verwaltung)
+- [x] Nachlauf, früheste KW, ausgeblendete Kurse-Hinweis
+- [x] Termin-Dropdown inkl. KW, Vergangenheit, Nachlauf-Sprung
+- [x] Studio-Entfall (`excludedDates`) sichtbar + Marker
+- [x] Termin-Marker Nachlauf / Cutoff / entfällt (ohne Text-Legende)
+- [x] Swap-Modal mit Kontext-Hilfen
+- [x] Chip-Hervorhebung: eigener Teilnehmer/Warteliste; SN/Tausch-Farben
+- [x] Tests (`CoursesShell`, `CourseWeekView`, `courseWeekOccurrences`, `CourseCard`, …)
+
+### Offen / Follow-up
+
+- [ ] [#164](https://github.com/CurlyKarin/yogaswap/issues/164) schließen nach QA + Merge
+- [ ] Bugs [#183](https://github.com/CurlyKarin/yogaswap/issues/183), [#184](https://github.com/CurlyKarin/yogaswap/issues/184)
+- [ ] Layout-Polish Kacheln [#182](https://github.com/CurlyKarin/yogaswap/issues/182)
+- [ ] Meilenstein Post-rollout: Kachel Status/Tausch-Ursprung [#185](https://github.com/CurlyKarin/yogaswap/issues/185)
+- [ ] Meilenstein Post-rollout: Übersicht „Meine Termine“ [#186](https://github.com/CurlyKarin/yogaswap/issues/186) (`groupWeekRowsByDay` vorbereitet, UI noch nicht)
+- [ ] Optional: URL-Parameter, `localStorage`, Tagesgruppierung in der Wochenansicht
 
 ---
 
 ## Verknüpfung
 
-- [#164](https://github.com/CurlyKarin/yogaswap/issues/164) — Wochenansicht (Termine, Absagen, Ausschlüsse, Swap-Kontext)
+- [#164](https://github.com/CurlyKarin/yogaswap/issues/164) — Wochenansicht
 - [#149](https://github.com/CurlyKarin/yogaswap/issues/149) — Kursstatus-Sichtbarkeit
+- [#182](https://github.com/CurlyKarin/yogaswap/issues/182) — Layout Kurskacheln
+- [#185](https://github.com/CurlyKarin/yogaswap/issues/185) — Tausch-Ursprung / eigene Absagen in der Kachel
+- [#186](https://github.com/CurlyKarin/yogaswap/issues/186) — Terminübersicht nach Woche


### PR DESCRIPTION
## Summary

- Einführung von **CoursesShell** mit **Wochenansicht** (Default) und **Kursübersicht** (nur Admin/Kursleitung): gemeinsames `weekAnchor`, KW-Navigation inkl. Nachlauf.
- **CourseWeekView** zeigt Kurse der aktuellen Kalenderwoche als Kacheln; Terminwahl inkl. Vergangenheit in der KW, Nachlauf-Sprung und Studio-Entfall (`excludedDates`) mit Marker und gesperrten Teilnehmer-Aktionen.
- **CourseCard** erweitert: Termin-Marker (Nachlauf, Cutoff, entfällt), Hilfe im Tauschdialog, Hervorhebung des eigenen Chips in Teilnehmer-/Warteliste, SN/Tausch-Farben für andere dezent.
- Neue Libs/Hooks: `courseTermActions`, `courseWeekOccurrences`, `useCoursesData`; Doku `docs/course-views.md`.

Closes #164

## Testplan

- [ ] Als **Teilnehmer:in**: Default Wochenansicht, ‹/›/Heute, Termin in anderer KW springt alle Kacheln mit
- [ ] **Absage / Tausch** am aktuellen Termin; nach RC „Anderen Termin wählen“ (Modal-Titel)
- [ ] **Vergangene KW** im Nachlauf: nur erlaubte Kurse, Hinweis bei ausgeblendeten Kursen
- [ ] **Studio-Entfall** in KW: Marker, `(entfällt)`, kein Absagen/Tausch
- [ ] Als **Admin/Kursleitung**: Toggle **Kursübersicht**, Verwaltung unverändert nutzbar
- [ ] **Vertretung**: Wochenansicht aus Teilnehmer-Perspektive
- [ ] `npm test -- --run` in `app/` (294 Tests)

## Follow-ups (nicht in diesem PR)

- Bugs: #183 (Überplanung + Cutoff-Ziel), #184 (SN-Persistenz Cutoff)
- Post-rollout: #182, #185, #186, #187, Refactor #188


Made with [Cursor](https://cursor.com)