### PR TITLE
Fix short-notice cutoff persist and validation (#184)

### DIFF
--- a/app/src/api/overrides.test.ts
+++ b/app/src/api/overrides.test.ts
@@ -79,6 +79,14 @@ describe("updateOverride", () => {
       { headers: { "x-acting-for-user-id": "maya" } },
     );
   });
+
+  it("wirft bei API-Fehler", async () => {
+    vi.mocked(axios.put).mockRejectedValueOnce(new Error("Network error"));
+
+    await expect(
+      updateOverride(1, "2025-06-16", { participants: ["alice"] }),
+    ).rejects.toThrow("Network error");
+  });
 });
 
 describe("deleteOverride", () => {
@@ -141,5 +149,17 @@ describe("createOverride", () => {
     expect(axios.post).toHaveBeenCalledWith("/course-overrides", newOverride, {
       headers: { "x-acting-for-user-id": "maya" },
     });
+  });
+
+  it("wirft bei API-Fehler", async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce(new Error("Network error"));
+    const newOverride: CourseDateOverride = {
+      courseId: 1,
+      date: "2025-06-16",
+      participants: ["alice"],
+      waitlist: [],
+    };
+
+    await expect(createOverride(newOverride)).rejects.toThrow("Network error");
   });
 });

--- a/app/src/api/overrides.ts
+++ b/app/src/api/overrides.ts
@@ -31,6 +31,7 @@ export async function updateOverride(
     console.log('API Overrides Response (updates):', updates);
   } catch (error) {
     console.error('Fehler beim Updaten des Overrides', error);
+    throw error;
   }
 }
 
@@ -61,5 +62,6 @@ export async function createOverride(newOverride: CourseDateOverride): Promise<v
     console.log('API Overrides Response (newOverride):', newOverride);
   } catch (error) {
     console.error('Fehler beim Anlegen des Overrides', error);
+    throw error;
   }
 }

--- a/app/src/components/useCourseSwaps.test.ts
+++ b/app/src/components/useCourseSwaps.test.ts
@@ -19,7 +19,7 @@ vi.mock("../lib/waitlist", () => ({
 }));
 
 const { createSwap, deleteSwap, processPromotions } = await import("../api/swaps");
-const { updateOverride } = await import("../api/overrides");
+const { createOverride, updateOverride } = await import("../api/overrides");
 
 const baseUser: User = {
   nickname: "alice",
@@ -58,6 +58,53 @@ const pendingSwap: Swap = {
 describe("useCourseSwaps", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (updateOverride as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (createOverride as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("onToggleAbsence persistiert kurzfristige Absage im Cutoff vor processPromotions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2099, 5, 16, 9, 30));
+
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) =>
+      updater([baseOverride]),
+    );
+    const setSwaps = vi.fn();
+    (updateOverride as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (processPromotions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      swaps: [],
+      overrides: [{ ...baseOverride, shortNoticeCancellations: [] }],
+    });
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course],
+        [baseOverride],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.onToggleAbsence(course, "2099-06-16", baseUser.nickname);
+    });
+
+    expect(updateOverride).toHaveBeenCalledWith(1, "2099-06-16", {
+      participants: ["alice"],
+      shortNoticeCancellations: ["alice"],
+    });
+    expect(processPromotions).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it("onToggleAbsence aktualisiert Overrides und ruft processPromotions auf", async () => {

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
 import { getEffectiveWaitlist } from "../lib/waitlist";
-import { sameDayUTC } from "../lib/dates";
 import { overrideCourseUidFields, swapCourseUidFields } from "../lib/courseUid";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -15,6 +14,46 @@ import {
 import { hasBookingCapacity, resolveMaxCapacity } from "shared/courseCapacity";
 import { createSwap, deleteSwap, processPromotions } from "../api/swaps";
 import { createOverride, updateOverride } from "../api/overrides";
+
+function findOverrideIndex(
+  list: CourseDateOverride[],
+  courseId: number,
+  dateIso: string,
+): number {
+  return list.findIndex((o) => o.courseId === courseId && o.date === dateIso);
+}
+
+function upsertCourseDateOverride(
+  prev: CourseDateOverride[],
+  next: CourseDateOverride,
+  courseId: number,
+  dateIso: string,
+): CourseDateOverride[] {
+  const idx = findOverrideIndex(prev, courseId, dateIso);
+  if (idx >= 0) {
+    const updated = [...prev];
+    updated[idx] = next;
+    return updated;
+  }
+  return [...prev, next];
+}
+
+async function persistCourseDateOverride(
+  courseId: number,
+  dateIso: string,
+  next: CourseDateOverride,
+  exists: boolean,
+): Promise<void> {
+  const payload = {
+    participants: next.participants,
+    shortNoticeCancellations: next.shortNoticeCancellations ?? [],
+  };
+  if (exists) {
+    await updateOverride(courseId, dateIso, payload);
+  } else {
+    await createOverride({ ...next, courseId, date: dateIso });
+  }
+}
 
 /** Behält shortNotice, falls API-Antwort das Feld (noch) nicht liefert. */
 function mergeOverridesPreservingShortNotice(
@@ -245,73 +284,46 @@ export function useCourseSwaps(
         }
       }
 
-      const persistOverride = (
-        courseId: number,
-        dateKey: string,
-        nextOverride: CourseDateOverride,
-        idx: number,
-        prev: CourseDateOverride[],
-      ) => {
-        const updated = [...prev];
-        const payload = {
-          participants: nextOverride.participants,
-          shortNoticeCancellations: nextOverride.shortNoticeCancellations ?? [],
-        };
-        if (idx >= 0) {
-          updated[idx] = nextOverride;
-          updateOverride(courseId, dateKey, payload);
-        } else {
-          updated.push(nextOverride);
-          createOverride(nextOverride);
+      const existingIndex = findOverrideIndex(filteredOverrides, course.id, dateIso);
+      const baseOverride: CourseDateOverride =
+        existingIndex >= 0
+          ? { ...filteredOverrides[existingIndex] }
+          : {
+              courseId: course.id,
+              date: dateIso,
+              participants: [...course.participants],
+              swapped: [],
+              waitlist: [],
+              shortNoticeCancellations: [],
+              ...overrideCourseUidFields(course),
+            };
+
+      const maxCapacity = resolveMaxCapacity(course);
+      let nextParticipants = [...baseOverride.participants];
+      let nextShortNotice = [...(baseOverride.shortNoticeCancellations ?? [])];
+
+      if (isSn) {
+        nextShortNotice = removeUserCaseInsensitive(nextShortNotice, userName);
+      } else if (isIn && inCutoff) {
+        nextShortNotice = addUserUniqueCaseInsensitive(nextShortNotice, userName);
+      } else if (isIn) {
+        nextParticipants = removeUserCaseInsensitive(nextParticipants, userName);
+      } else {
+        if (nextParticipants.length >= maxCapacity) {
+          alert("Dieser Termin ist inzwischen voll – Rücknahme nicht möglich.");
+          return;
         }
-        return updated;
+        nextParticipants = addUserUniqueCaseInsensitive(nextParticipants, userName);
+      }
+
+      const nextOverride: CourseDateOverride = {
+        ...baseOverride,
+        participants: nextParticipants,
+        shortNoticeCancellations: nextShortNotice,
       };
 
-      setOverrides((prev: CourseDateOverride[]) => {
-        const date = new Date(dateIso);
-        const idx = prev.findIndex(
-          (o: CourseDateOverride) => o.courseId === course.id && sameDayUTC(new Date(o.date), date),
-        );
-
-        const baseOverride: CourseDateOverride =
-          idx >= 0
-            ? { ...prev[idx] }
-            : {
-                courseId: course.id,
-                date: dateIso,
-                participants: [...course.participants],
-                swapped: [],
-                waitlist: [],
-                shortNoticeCancellations: [],
-                ...overrideCourseUidFields(course),
-              };
-
-        const maxCapacity = resolveMaxCapacity(course);
-        let nextParticipants = [...baseOverride.participants];
-        let nextShortNotice = [...(baseOverride.shortNoticeCancellations ?? [])];
-
-        if (isSn) {
-          nextShortNotice = removeUserCaseInsensitive(nextShortNotice, userName);
-        } else if (isIn && inCutoff) {
-          nextShortNotice = addUserUniqueCaseInsensitive(nextShortNotice, userName);
-        } else if (isIn) {
-          nextParticipants = removeUserCaseInsensitive(nextParticipants, userName);
-        } else {
-          if (nextParticipants.length >= maxCapacity) {
-            alert("Dieser Termin ist inzwischen voll – Rücknahme nicht möglich.");
-            return prev;
-          }
-          nextParticipants = addUserUniqueCaseInsensitive(nextParticipants, userName);
-        }
-
-        const nextOverride: CourseDateOverride = {
-          ...baseOverride,
-          participants: nextParticipants,
-          shortNoticeCancellations: nextShortNotice,
-        };
-
-        return persistOverride(course.id, dateIso, nextOverride, idx, prev);
-      });
+      await persistCourseDateOverride(course.id, dateIso, nextOverride, existingIndex >= 0);
+      setOverrides((prev) => upsertCourseDateOverride(prev, nextOverride, course.id, dateIso));
 
       if (isIn && !isSn && inCutoff) {
         await cleanupPendingSwapsFromOrigin(course.id, dateIso, userName);
@@ -331,6 +343,8 @@ export function useCourseSwaps(
 
     } catch (err) {
         console.error('Error in onToggleAbsence:', err);
+        alert("Fehler beim Speichern der Absage. Bitte erneut versuchen.");
+        await fetchData();
       }
     },
     // courses, currentUser.nickname kept so callback updates when they change
@@ -604,27 +618,31 @@ export function useCourseSwaps(
           const nextShortNotice = isSn
             ? removeUserCaseInsensitive(baseOverride.shortNoticeCancellations ?? [], swap.user)
             : addUserUniqueCaseInsensitive(baseOverride.shortNoticeCancellations ?? [], swap.user);
+          const nextParticipants = includesUserCaseInsensitive(baseOverride.participants, swap.user)
+            ? baseOverride.participants
+            : addUserUniqueCaseInsensitive(baseOverride.participants, swap.user);
 
           const nextOverride: CourseDateOverride = {
             ...baseOverride,
+            participants: nextParticipants,
             shortNoticeCancellations: nextShortNotice,
           };
-          const idx = filteredOverrides.findIndex(
-            (o) => o.courseId === swap.toCourseId && o.date === swap.toDate,
-          );
-          setOverrides((prev) => {
-            const updated = [...prev];
-            if (idx >= 0) {
-              updated[idx] = nextOverride;
-              updateOverride(swap.toCourseId, swap.toDate, {
-                shortNoticeCancellations: nextShortNotice,
-              });
-            } else {
-              updated.push(nextOverride);
-              createOverride(nextOverride);
-            }
-            return updated;
-          });
+          const idx = findOverrideIndex(filteredOverrides, swap.toCourseId, swap.toDate);
+          try {
+            await persistCourseDateOverride(
+              swap.toCourseId,
+              swap.toDate,
+              nextOverride,
+              idx >= 0,
+            );
+            setOverrides((prev) =>
+              upsertCourseDateOverride(prev, nextOverride, swap.toCourseId, swap.toDate),
+            );
+          } catch (err) {
+            console.error("Error in cancelSwap (cutoff SN):", err);
+            alert("Fehler beim Speichern der Absage. Bitte erneut versuchen.");
+            await fetchData();
+          }
           return;
         }
 

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.test.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.test.ts
@@ -47,6 +47,18 @@ describe("cutoffOverrideValidation", () => {
     expect(error).toBe("Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.");
   });
 
+  it("erlaubt SN-Setzen innerhalb des Cutoff bei bestehendem participants-Eintrag", () => {
+    const before = makeOverride();
+    const after = makeOverride({ shortNoticeCancellations: ["alice"] });
+    const error = validateSelfServiceOverrideTransition({
+      ...baseInput,
+      before,
+      after,
+      now: new Date(2099, 5, 15, 9, 30),
+    });
+    expect(error).toBeNull();
+  });
+
   it("erlaubt SN-Rücknahme innerhalb des Cutoff", () => {
     const before = makeOverride({ shortNoticeCancellations: ["alice"] });
     const after = makeOverride({ shortNoticeCancellations: [] });

--- a/backend/src/lambdas/shared/cutoffOverrideValidation.ts
+++ b/backend/src/lambdas/shared/cutoffOverrideValidation.ts
@@ -81,6 +81,11 @@ export function validateSelfServiceOverrideTransition(input: {
     return null;
   }
 
+  // SN setzen im Cutoff: Teilnehmer bleibt in participants (Platz belegt).
+  if (!wasSn && isSn && isParticipant && inCutoff) {
+    return null;
+  }
+
   if (!wasSn && isSn && !inCutoff) {
     return "Kurzfristige Absage ist nur kurz vor Kursbeginn möglich.";
   }

--- a/backend/src/lambdas/updateOverride/index.ts
+++ b/backend/src/lambdas/updateOverride/index.ts
@@ -119,7 +119,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const touchesCutoffFields =
       updates.participants !== undefined || updates.shortNoticeCancellations !== undefined;
 
-    if (touchesCutoffFields && userId && tenantsTable) {
+    const subjectNickname = actingForUserId ?? userId;
+    if (touchesCutoffFields && subjectNickname && tenantsTable) {
       const tenantSettings = await loadTenantSettings(client, tenantsTable, tenantId);
       const merged = mergeOverrideUpdate(before, baseParticipants, updates);
       merged.courseId = Number(legacyCourseId);
@@ -131,7 +132,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       }
 
       const transitionError = validateSelfServiceOverrideTransition({
-        actorNickname: userId,
+        actorNickname: subjectNickname,
         courseTime,
         dateIso: date,
         tenantSettings,


### PR DESCRIPTION
## Summary

- Fixes #184: kurzfristige Absage im Cutoff wird zuverlässig persistiert (`await` auf Override-API vor `processPromotions`, Fehler werden nicht mehr verschluckt).
- Backend: `validateSelfServiceOverrideTransition` erlaubt SN setzen/aufheben im Cutoff (behebt 400 bei Absage und „Am Zieltermin kurzfristig absagen“).
- Vertretung: Cutoff-Validierung nutzt `actingForUserId` statt nur den eingeloggten Admin.
- App: eingetauschte Nutzer werden bei Ziel-SN ggf. in `participants` ergänzt (Invariante).

## Test plan

- [ ] Termin absagen im Cutoff → Reload → SN-Chip bleibt
- [ ] SN-Rücknahme im Cutoff
- [ ] Aktiver Tausch: „Am Zieltermin kurzfristig absagen“ / Zurücknehmen
- [ ] Gleiches in Vertretungsmodus für einen Teilnehmer
- [ ] `npm test` in `app/` und `backend/` (cutoffOverrideValidation, useCourseSwaps)


Made with [Cursor](https://cursor.com)