### PR TITLE
#171.1 A11y: App-Shell (Skip-Links, Landmarks, Fokus)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -23,6 +23,84 @@ body {
   --delegation-card-border: #f6d9a8;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-links {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  left: 16px;
+  z-index: 10001;
+  margin: 0;
+  padding: 8px 16px;
+  border: none;
+  font: inherit;
+  cursor: pointer;
+  background: #1e40af;
+  color: #fff;
+  border-radius: 0 0 6px 6px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.skip-links .skip-link:nth-child(1) {
+  top: 8px;
+}
+
+.skip-links .skip-link:nth-child(2) {
+  top: 48px;
+}
+
+.skip-links .skip-link:nth-child(3) {
+  top: 88px;
+}
+
+/* Jeder Link einzeln versteckt — kein Clip am Container (Safari Tab-Bug) */
+.skip-link:not(:focus):not(:focus-visible) {
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  width: auto;
+  height: auto;
+  padding: 8px 16px;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+}
+
+.app-error {
+  color: #b91c1c;
+  text-align: center;
+  margin: 1rem;
+}
+
+#main-content {
+  scroll-margin-top: 12px;
+}
+
 .main-section {
   margin-top: 1rem;
 }
@@ -245,11 +323,17 @@ body {
 
 /* Header */
 .app-top {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
   margin-bottom: 20px;
+  padding: 4px 0 8px;
+  background: #f5f5f5;
+  scroll-margin-top: 8px;
 }
 .userbox {
   display: flex;
@@ -529,7 +613,7 @@ textarea:focus-visible,
 button:focus-visible,
 a:focus-visible {
   outline: 3px solid #93c5fd;
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 .not-enrolled {
@@ -990,6 +1074,10 @@ a:focus-visible {
 .app-footer a:hover {
   text-decoration: underline;
 }
+.app-footer-nav {
+  display: inline;
+}
+
 .app-footer .sep {
   margin: 0 0.5rem;
 }

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -8,6 +8,16 @@ import { canManageParticipants } from "shared/permissions";
 
 const coursesShellMock = vi.fn<(props: unknown) => void>();
 
+const { createMockUseAppAuth } = vi.hoisted(() => ({
+  createMockUseAppAuth: (overrides?: { error?: string | null; isLoading?: boolean }) => ({
+    user: null,
+    isLoading: overrides?.isLoading ?? false,
+    error: overrides?.error ?? null,
+    login: vi.fn().mockResolvedValue(false),
+    logout: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 vi.mock("./components/Login", () => ({
   default: () => <div>Login Mock</div>,
 }));
@@ -15,12 +25,30 @@ vi.mock("./components/Login", () => ({
 vi.mock("./components/CoursesShell", () => ({
   default: (props: unknown) => {
     coursesShellMock(props);
-    return <div>CoursesShell Mock</div>;
+    return (
+      <div>
+        <div id="course-toolbar">
+          <button type="button" aria-label="Vorherige Woche">
+            Prev
+          </button>
+          <select aria-label="Kurstermin">
+            <option>Termin</option>
+          </select>
+        </div>
+        <span>CoursesShell Mock</span>
+      </div>
+    );
   },
 }));
 
 vi.mock("./components/AdminPanel", () => ({
-  default: () => <div>AdminPanel Mock</div>,
+  default: () => (
+    <div>
+      <input aria-label="Studioname" />
+      <input aria-label="Teilnehmer suchen" />
+      <span>AdminPanel Mock</span>
+    </div>
+  ),
 }));
 
 vi.mock("./components/Invite", () => ({
@@ -44,11 +72,7 @@ vi.mock("./components/OpenSourceLicenses", () => ({
 }));
 
 vi.mock("./auth/useAppAuth", () => ({
-  useAppAuth: () => ({
-    logout: vi.fn().mockResolvedValue(undefined),
-    isLoading: false,
-    error: null,
-  }),
+  useAppAuth: vi.fn(() => createMockUseAppAuth()),
 }));
 
 vi.mock("aws-amplify/auth", () => ({
@@ -73,6 +97,145 @@ vi.mock("shared/permissions", () => ({
   canInviteParticipants: vi.fn(() => true),
   canManageParticipants: vi.fn(() => true),
 }));
+
+async function renderLoggedInAdmin() {
+  const { fetchAuthSession } = await import("aws-amplify/auth");
+  const { getTenantContext } = await import("./api/tenantContext");
+  const { getParticipants } = await import("./api/participants");
+
+  vi.mocked(fetchAuthSession).mockResolvedValue({
+    tokens: {
+      idToken: {
+        payload: {
+          nickname: "admin",
+          email: "admin@example.com",
+          "custom:role": "admin",
+        },
+      },
+    },
+  } as unknown as never);
+
+  vi.mocked(getTenantContext).mockResolvedValue({
+    tenant: { tenantId: "default-tenant", name: "Default" },
+    membership: { tenantId: "default-tenant", userId: "admin", role: "admin" },
+  } as unknown as never);
+
+  vi.mocked(getParticipants).mockResolvedValue([] as unknown as never);
+
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText(/hi, admin/i)).toBeInTheDocument();
+  });
+}
+
+describe("App shell a11y", () => {
+  beforeEach(async () => {
+    cleanup();
+    vi.clearAllMocks();
+    coursesShellMock.mockClear();
+    vi.mocked(canManageParticipants).mockReturnValue(true);
+    setActingForUserId(null);
+    setActorUserId(null);
+    const { useAppAuth } = await import("./auth/useAppAuth");
+    vi.mocked(useAppAuth).mockReturnValue(createMockUseAppAuth());
+  });
+
+  it("bietet Skip-Link und main-Landmark mit Kurs- und Verwaltungsbereich", async () => {
+    await renderLoggedInAdmin();
+
+    await waitFor(() => {
+      expect(screen.getByText("AdminPanel Mock")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("navigation", { name: /seitenüberspringen/i })).toBeInTheDocument();
+    const skipControl = screen.getByRole("button", { name: /zum inhalt/i });
+    expect(skipControl).toHaveAttribute("type", "button");
+
+    const main = screen.getByRole("main");
+    const coursesSection = document.getElementById("main-content");
+    expect(coursesSection).not.toHaveAttribute("tabindex");
+    expect(main).toContainElement(coursesSection);
+    expect(screen.getByRole("navigation", { name: /benutzer-menü/i })).toBeInTheDocument();
+    expect(main).toContainElement(screen.getByRole("heading", { level: 2, name: /kurse/i }));
+    expect(main).toContainElement(document.getElementById("admin-heading"));
+    expect(main).toContainElement(screen.getByText("CoursesShell Mock"));
+    expect(main).toContainElement(screen.getByText("AdminPanel Mock"));
+  });
+
+  it("springt mit Leertaste zur Wochennavigation im Kursbereich", async () => {
+    await renderLoggedInAdmin();
+
+    const toolbar = document.getElementById("course-toolbar");
+    expect(toolbar).not.toBeNull();
+    const weekButton = screen.getByRole("button", { name: /vorherige woche/i });
+    const scrollIntoView = vi.fn();
+    const focus = vi.fn();
+    toolbar!.scrollIntoView = scrollIntoView;
+    weekButton.focus = focus;
+
+    const skipControl = screen.getByRole("button", { name: /zum inhalt/i });
+    skipControl.focus();
+    await userEvent.keyboard(" ");
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("Tab-Reihenfolge: Skip-Links, Menü, Kurse, Verwaltung, Footer", async () => {
+    const user = userEvent.setup();
+    await renderLoggedInAdmin();
+
+    await waitFor(() => {
+      expect(screen.getByText("AdminPanel Mock")).toBeInTheDocument();
+    });
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /zum menü/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /zum inhalt/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /zum fußbereich/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /logout/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /vertretung/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: /vorherige woche/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: /kurstermin/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("textbox", { name: /studioname/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("textbox", { name: /teilnehmer suchen/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: /impressum/i })).toHaveFocus();
+  });
+
+  it("meldet Auth-Fehler als Alert", async () => {
+    const { useAppAuth } = await import("./auth/useAppAuth");
+    vi.mocked(useAppAuth).mockReturnValue(
+      createMockUseAppAuth({ error: "Sitzung abgelaufen" }),
+    );
+
+    await renderLoggedInAdmin();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Sitzung abgelaufen");
+  });
+});
 
 describe("App delegation mode", () => {
   beforeEach(() => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -177,6 +177,38 @@ function MainApp() {
     setPendingActingForUserId(null);
   };
 
+  const FOCUSABLE_SELECTOR =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  const focusFirstIn = (root: HTMLElement | null) => {
+    if (!root) return;
+    const firstFocusable = root.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    firstFocusable?.focus({ preventScroll: true });
+  };
+
+  const handleSkipToMenu = () => {
+    const nav = document.getElementById("site-nav");
+    if (nav) {
+      focusFirstIn(nav);
+      return;
+    }
+    focusFirstIn(document.getElementById("main-content"));
+  };
+
+  const handleSkipToContent = () => {
+    const target = document.getElementById("course-toolbar") ?? document.getElementById("main-content");
+    if (!target) return;
+    target.scrollIntoView({ block: "start" });
+    focusFirstIn(target);
+  };
+
+  const handleSkipToFooter = () => {
+    const footerNav = document.getElementById("site-footer-nav");
+    if (!footerNav) return;
+    footerNav.scrollIntoView({ block: "end" });
+    focusFirstIn(footerNav);
+  };
+
   const effectiveUser: User | null = currentUser
     ? actingForUserIdState
       ? {
@@ -189,13 +221,30 @@ function MainApp() {
 
   return (
     <div className="app-container">
+      <nav className="skip-links" aria-label="Seitenüberspringen">
+        <button type="button" className="skip-link" onClick={handleSkipToMenu}>
+          Zum Menü
+        </button>
+        <button type="button" className="skip-link" onClick={handleSkipToContent}>
+          Zum Inhalt
+        </button>
+        <button type="button" className="skip-link" onClick={handleSkipToFooter}>
+          Zum Fußbereich
+        </button>
+      </nav>
       <header className="app-top">
         <h1>YogaSwap</h1>
         {currentUser && (
-          <div className="userbox">
+          <nav id="site-nav" className="userbox" aria-label="Benutzer-Menü">
             <span>Hi, {currentUser.nickname}</span>
             <div className="header-action-group">
-              <button className="header-action-btn" onClick={handleLogout} disabled={isLoading}>
+              <button
+                id="logout-btn"
+                type="button"
+                className="header-action-btn"
+                onClick={handleLogout}
+                disabled={isLoading}
+              >
                 {isLoading ? "..." : "Logout"}
               </button>
               {canDelegate && (
@@ -212,12 +261,12 @@ function MainApp() {
                 </button>
               )}
             </div>
-          </div>
+          </nav>
         )}
       </header>
 
       {error && (
-        <div className="error" style={{ color: "red", textAlign: "center", margin: "1rem" }}>
+        <div className="app-error" role="alert">
           {error}
         </div>
       )}
@@ -241,30 +290,42 @@ function MainApp() {
         </div>
       )}
 
-      {!effectiveUser ? (
-        <Login onLogin={handleLogin} />
-      ) : (
-        <section
-          className={`main-section main-section-courses${actingForUserIdState ? " is-delegation-active" : ""}`}
-        >
-          <CoursesShell
-            currentUser={effectiveUser}
-            tenant={tenant ?? undefined}
-            membership={membership ?? undefined}
-            forceParticipantView={Boolean(actingForUserIdState)}
-          />
-        </section>
-      )}
+      <main>
+        {!effectiveUser ? (
+          <section id="main-content" className="main-section" aria-label="Anmeldung">
+            <Login onLogin={handleLogin} />
+          </section>
+        ) : (
+          <section
+            id="main-content"
+            className={`main-section main-section-courses${actingForUserIdState ? " is-delegation-active" : ""}`}
+            aria-labelledby="courses-heading"
+          >
+            <h2 id="courses-heading" className="visually-hidden">
+              Kurse
+            </h2>
+            <CoursesShell
+              currentUser={effectiveUser}
+              tenant={tenant ?? undefined}
+              membership={membership ?? undefined}
+              forceParticipantView={Boolean(actingForUserIdState)}
+            />
+          </section>
+        )}
 
-      {currentUser && canInvite && !actingForUserIdState && (
-        <section className="main-section main-section-admin">
-          <AdminPanel
-            canEditRoles={(membership?.role ?? currentUser.role) === "admin"}
-            tenant={tenant}
-            onTenantUpdated={(updated) => setTenant(updated)}
-          />
-        </section>
-      )}
+        {currentUser && canInvite && !actingForUserIdState && (
+          <section className="main-section main-section-admin" aria-labelledby="admin-heading">
+            <h2 id="admin-heading" className="visually-hidden">
+              Verwaltung
+            </h2>
+            <AdminPanel
+              canEditRoles={(membership?.role ?? currentUser.role) === "admin"}
+              tenant={tenant}
+              onTenantUpdated={(updated) => setTenant(updated)}
+            />
+          </section>
+        )}
+      </main>
 
       {pendingActingForUserId && (
         <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Vertretung bestätigen">
@@ -300,12 +361,17 @@ function MainApp() {
 
       <footer className="app-footer">
         <span className="copyright">© {new Date().getFullYear()} Karin Schrader</span>
-        <span className="sep">·</span>
-        <Link to="/impressum">Impressum</Link>
-        <span className="sep">·</span>
-        <Link to="/datenschutz">Datenschutz</Link>
-        <span className="sep">·</span>
-        <Link to="/open-source-lizenzen">Open-Source-Lizenzen</Link>
+        <nav id="site-footer-nav" className="app-footer-nav" aria-label="Rechtliches und Lizenzen">
+          <Link to="/impressum">Impressum</Link>
+          <span className="sep" aria-hidden="true">
+            ·
+          </span>
+          <Link to="/datenschutz">Datenschutz</Link>
+          <span className="sep" aria-hidden="true">
+            ·
+          </span>
+          <Link to="/open-source-lizenzen">Open-Source-Lizenzen</Link>
+        </nav>
       </footer>
     </div>
   );

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -68,7 +68,7 @@ export default function CoursesShell({
 
   return (
     <>
-      <div className="course-views-toolbar">
+      <div id="course-toolbar" className="course-views-toolbar">
         {canSeeCourseManagement && (
           <div className="course-views-toggle" role="group" aria-label="Kursansicht">
             <button

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -49,10 +49,6 @@ button {
 button:hover {
   border-color: #646cff;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
 
 @media (prefers-color-scheme: light) {
   :root {


### PR DESCRIPTION
## Summary

- Strukturiert die App-Shell (`App.tsx`) mit `main`, Nav-Landmarks und versteckten `<h2>` für Kurse/Verwaltung (#171 Schritt 1).
- Fügt Skip-Buttons hinzu (Zum Menü, Zum Inhalt, Zum Fußbereich) inkl. Safari-tauglichem Verstecken pro Button.
- Einheitliche sichtbare `:focus-visible`-Outlines; Auth-Fehler als `role="alert"`; sticky Header.
- Sprungziel „Zum Inhalt“ über `#course-toolbar` in `CoursesShell`.
- Tests für Landmarks, Skip-Verhalten und Tab-Reihenfolge in `App.test.tsx`.

Parent: #171 · Sub-Issue: Closes #192

## Test plan

- [x] `npm test -- --run src/App.test.tsx`
- [ ] Seite neu laden, Tab durch Skip-Links → Logout → Wochennav (Safari: „Tab jedes Element“ aktiv)
- [ ] „Zum Inhalt“ + Leertaste → Fokus auf Wochennavigation
- [ ] Layout unverändert (Header, Kurse, Admin, Footer)


Made with [Cursor](https://cursor.com)