### PR TITLE
#171.2 A11y: CoursesShell (Wochennav, Toggle, Status)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -123,17 +123,24 @@ body {
   display: inline-flex;
   border: 1px solid #d1d5db;
   border-radius: 8px;
-  overflow: hidden;
   background: #fff;
+  padding: 4px;
+  gap: 0;
 }
 
 .course-views-toggle-btn {
   border: none;
   background: transparent;
-  padding: 8px 14px;
+  padding: 6px 12px;
   font-size: 14px;
   cursor: pointer;
   color: #374151;
+  border-radius: 4px;
+}
+
+.course-views-toggle-btn:focus-visible {
+  position: relative;
+  z-index: 1;
 }
 
 .course-views-toggle-btn.is-active {
@@ -184,6 +191,20 @@ body {
 .course-week-nav-btn:hover,
 .course-week-nav-today:hover {
   background: #f3f4f6;
+}
+
+.course-week-nav-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.course-week-nav-btn:disabled:hover {
+  background: #fff;
+}
+
+.course-week-panel,
+.course-list-panel {
+  margin: 0;
 }
 
 .course-views-hint {

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -71,7 +71,7 @@ export default function CourseWeekView({
   if (loading) {
     return (
       <div className="course-week-view" role="status" aria-live="polite">
-        Loading...
+        Kurse werden geladen…
       </div>
     );
   }

--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -4,23 +4,66 @@ import userEvent from "@testing-library/user-event";
 import CoursesShell from "./CoursesShell";
 import { User, Tenant, UserTenantMembership } from "shared/types";
 
+const { mockUseCoursesData, createCoursesDataMock } = vi.hoisted(() => {
+  type MockCoursesData = {
+    loading: boolean;
+    error: string | null;
+    courses: [];
+    weekCourseRows: [];
+    hiddenPastCourseCount: number;
+    overrides: [];
+    swaps: [];
+    confirmSwap: ReturnType<typeof vi.fn>;
+    requestSwap: ReturnType<typeof vi.fn>;
+    cancelSwap: ReturnType<typeof vi.fn>;
+    onToggleAbsence: ReturnType<typeof vi.fn>;
+    earliestWeekAnchor: Date;
+  };
+
+  const createCoursesDataMock = (overrides: Partial<MockCoursesData> = {}): MockCoursesData => ({
+    loading: false,
+    error: null,
+    courses: [],
+    weekCourseRows: [],
+    hiddenPastCourseCount: 0,
+    overrides: [],
+    swaps: [],
+    confirmSwap: vi.fn(),
+    requestSwap: vi.fn(),
+    cancelSwap: vi.fn(),
+    onToggleAbsence: vi.fn(),
+    earliestWeekAnchor: new Date(2026, 0, 5),
+    ...overrides,
+  });
+
+  return {
+    createCoursesDataMock,
+    mockUseCoursesData: vi.fn(() => createCoursesDataMock()),
+  };
+});
+
 vi.mock("./CourseList", () => ({
   default: () => <div>CourseList Mock</div>,
 }));
 
 vi.mock("../hooks/useCoursesData", () => ({
-  useCoursesData: () => ({
-    loading: false,
-    error: null,
-    weekCourseRows: [],
-    hiddenPastCourseCount: 0,
-    overrides: [],
-    earliestWeekAnchor: new Date(2026, 0, 5),
-  }),
+  useCoursesData: () => mockUseCoursesData(),
 }));
 
 vi.mock("./CourseWeekView", () => ({
-  default: () => <div>CourseWeekView Mock</div>,
+  default: ({ loading, error }: { loading?: boolean; error?: string | null }) => {
+    if (loading) {
+      return (
+        <div role="status" aria-live="polite">
+          Kurse werden geladen…
+        </div>
+      );
+    }
+    if (error) {
+      return <div role="alert">{error}</div>;
+    }
+    return <div>CourseWeekView Mock</div>;
+  },
 }));
 
 const baseUser: User = {
@@ -49,6 +92,7 @@ const adminMembership: UserTenantMembership = {
 describe("CoursesShell", () => {
   beforeEach(() => {
     cleanup();
+    mockUseCoursesData.mockReturnValue(createCoursesDataMock());
   });
 
   afterEach(() => {
@@ -67,6 +111,10 @@ describe("CoursesShell", () => {
     expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
     expect(screen.queryByRole("group", { name: /kursansicht/i })).not.toBeInTheDocument();
     expect(screen.getByRole("navigation", { name: /kalenderwoche/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /wochenansicht/i })).toHaveAttribute(
+      "aria-describedby",
+      "course-views-hint",
+    );
   });
 
   it("lets admin switch between week and course overview", async () => {
@@ -79,13 +127,19 @@ describe("CoursesShell", () => {
       />,
     );
 
+    const weekToggle = screen.getByRole("button", { name: /wochenansicht/i });
+    const listToggle = screen.getByRole("button", { name: /kursübersicht/i });
+    expect(weekToggle).toHaveAttribute("aria-controls", "course-week-panel");
+    expect(listToggle).toHaveAttribute("aria-controls", "course-list-panel");
+
     expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /kursübersicht/i }));
+    await user.click(listToggle);
+    expect(screen.getByRole("region", { name: /kursübersicht/i })).toBeInTheDocument();
     expect(screen.getByText("CourseList Mock")).toBeInTheDocument();
     expect(screen.queryByRole("navigation", { name: /kalenderwoche/i })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /wochenansicht/i }));
+    await user.click(weekToggle);
     expect(screen.getByText("CourseWeekView Mock")).toBeInTheDocument();
   });
 
@@ -101,8 +155,97 @@ describe("CoursesShell", () => {
 
     const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
     const label = within(nav).getByText(/^KW \d+ · /);
+    expect(label).toHaveAttribute("aria-live", "polite");
     const before = label.textContent;
     await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
     expect(label.textContent).not.toBe(before);
   });
+
+  it("setzt Fokus auf Nächste Woche nach Sprung zur frühesten KW", async () => {
+    const user = userEvent.setup();
+    const currentWeek = startOfWeekMonday(new Date());
+    const previousWeek = new Date(currentWeek);
+    previousWeek.setDate(previousWeek.getDate() - 7);
+
+    mockUseCoursesData.mockReturnValue(
+      createCoursesDataMock({ earliestWeekAnchor: previousWeek }),
+    );
+
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
+    const prevBtn = within(nav).getByRole("button", { name: /vorherige woche/i });
+    const nextBtn = within(nav).getByRole("button", { name: /nächste woche/i });
+
+    expect(prevBtn).not.toBeDisabled();
+    await user.click(prevBtn);
+
+    expect(prevBtn).toBeDisabled();
+    expect(nextBtn).toHaveFocus();
+    expect(document.getElementById("course-week-nav-limit-status")).toHaveTextContent(
+      "Früheste sichtbare Kalenderwoche erreicht.",
+    );
+  });
+
+  it("erklärt deaktivierte Vorherige-Woche-Schaltfläche", () => {
+    mockUseCoursesData.mockReturnValue(
+      createCoursesDataMock({ earliestWeekAnchor: startOfWeekMonday(new Date()) }),
+    );
+
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    const prevBtn = screen.getByRole("button", { name: /vorherige woche/i });
+    expect(prevBtn).toBeDisabled();
+    expect(prevBtn).toHaveAttribute("aria-describedby", "course-week-nav-prev-limit");
+    expect(screen.getByText(/früheste sichtbare kalenderwoche erreicht/i)).toBeInTheDocument();
+  });
+
+  it("zeigt Lade- und Fehlerzustand in der Wochenansicht", () => {
+    mockUseCoursesData.mockReturnValue(createCoursesDataMock({ loading: true }));
+
+    const { rerender } = render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    expect(screen.getByText(/kurse werden geladen/i)).toBeInTheDocument();
+
+    mockUseCoursesData.mockReturnValue(
+      createCoursesDataMock({ error: "Netzwerkfehler" }),
+    );
+
+    rerender(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Netzwerkfehler");
+  });
 });
+
+function startOfWeekMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import CourseList from "./CourseList";
 import CourseWeekView from "./CourseWeekView";
@@ -65,6 +65,21 @@ export default function CoursesShell({
 
   const weekLabel = formatWeekNavLabel(weekAnchor);
   const canGoToPreviousWeek = weekAnchor.getTime() > earliestWeekAnchor.getTime();
+  const prevWeekBtnRef = useRef<HTMLButtonElement>(null);
+  const nextWeekBtnRef = useRef<HTMLButtonElement>(null);
+  const [weekLimitAnnouncement, setWeekLimitAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (canGoToPreviousWeek) {
+      setWeekLimitAnnouncement("");
+      return;
+    }
+    const prevBtn = prevWeekBtnRef.current;
+    if (prevBtn && document.activeElement === prevBtn) {
+      setWeekLimitAnnouncement("Früheste sichtbare Kalenderwoche erreicht.");
+      nextWeekBtnRef.current?.focus();
+    }
+  }, [canGoToPreviousWeek, weekAnchor]);
 
   return (
     <>
@@ -75,6 +90,7 @@ export default function CoursesShell({
               type="button"
               className={`course-views-toggle-btn${viewMode === "week" ? " is-active" : ""}`}
               aria-pressed={viewMode === "week"}
+              aria-controls="course-week-panel"
               onClick={() => setViewMode("week")}
             >
               Wochenansicht
@@ -83,6 +99,7 @@ export default function CoursesShell({
               type="button"
               className={`course-views-toggle-btn${viewMode === "courses" ? " is-active" : ""}`}
               aria-pressed={viewMode === "courses"}
+              aria-controls="course-list-panel"
               onClick={() => setViewMode("courses")}
             >
               Kursübersicht
@@ -92,11 +109,25 @@ export default function CoursesShell({
 
         {viewMode === "week" && (
           <nav className="course-week-nav" aria-label="Kalenderwoche">
+            <span
+              id="course-week-nav-limit-status"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="visually-hidden"
+            >
+              {weekLimitAnnouncement}
+            </span>
+            <span id="course-week-nav-prev-limit" className="visually-hidden">
+              Früheste sichtbare Kalenderwoche erreicht
+            </span>
             <button
+              ref={prevWeekBtnRef}
               type="button"
               className="course-week-nav-btn"
               aria-label="Vorherige Woche"
               disabled={!canGoToPreviousWeek}
+              aria-describedby={!canGoToPreviousWeek ? "course-week-nav-prev-limit" : undefined}
               onClick={() =>
                 setWeekAnchor((prev) => {
                   const next = addWeeks(prev, -1);
@@ -106,8 +137,16 @@ export default function CoursesShell({
             >
               <ChevronLeft size={18} aria-hidden="true" />
             </button>
-            <span className="course-week-nav-label">{weekLabel}</span>
+            <span
+              id="course-week-nav-label"
+              className="course-week-nav-label"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {weekLabel}
+            </span>
             <button
+              ref={nextWeekBtnRef}
               type="button"
               className="course-week-nav-btn"
               aria-label="Nächste Woche"
@@ -118,6 +157,7 @@ export default function CoursesShell({
             <button
               type="button"
               className="course-week-nav-today"
+              aria-label="Zur aktuellen Kalenderwoche springen"
               onClick={() => setWeekAnchor(startOfWeekMonday(new Date()))}
             >
               Heute
@@ -127,9 +167,14 @@ export default function CoursesShell({
       </div>
 
       {viewMode === "week" && (
-        <>
-          <p className="muted course-views-hint">
-            Klicke in deinen Kursen auf <em>„Termin absagen“</em> oder <em>„Tauschen anfragen“</em>.
+        <section
+          id="course-week-panel"
+          className="course-week-panel"
+          aria-label="Wochenansicht"
+          aria-describedby="course-views-hint"
+        >
+          <p id="course-views-hint" className="muted course-views-hint">
+            In deinen Kursen: „Termin absagen“ oder „Tauschen anfragen“ wählen.
           </p>
           <CourseWeekView
             weekAnchor={weekAnchor}
@@ -149,16 +194,18 @@ export default function CoursesShell({
             requestSwap={requestSwap}
             cancelSwap={cancelSwap}
           />
-        </>
+        </section>
       )}
 
       {viewMode === "courses" && canSeeCourseManagement && (
-        <CourseList
-          currentUser={currentUser}
-          tenant={tenant}
-          membership={membership}
-          forceParticipantView={forceParticipantView}
-        />
+        <section id="course-list-panel" className="course-list-panel" aria-label="Kursübersicht">
+          <CourseList
+            currentUser={currentUser}
+            tenant={tenant}
+            membership={membership}
+            forceParticipantView={forceParticipantView}
+          />
+        </section>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

- Poliert `CoursesShell` für Tastatur und Screenreader: Wochennavigation, Ansicht-Toggle, Status-Hinweise (#171 Schritt 2).
- KW-Label mit `aria-live`; Grenz-Hinweis per Live-Region beim Erreichen der frühesten Woche; Fokus springt danach zu „Nächste Woche“.
- View-Toggle mit `aria-controls`, sichtbarem Fokus-Rahmen (kein Clip durch `overflow: hidden`).
- Wochen- und Kursübersicht-Panels als `<section>`; Hinweistext per `aria-describedby`.
- Ladehinweis in `CourseWeekView` auf Deutsch.
- Erweiterte Tests in `CoursesShell.test.tsx`.

Parent: #171 · Closes #193

## Test plan

- [x] `npm test -- --run src/components/CoursesShell.test.tsx`
- [x] Manuell: Tab durch Wochennav und Toggle (Admin), Fokus-Rahmen vollständig sichtbar
- [x] Manuell: Vorherige Woche bis Grenze → Grenz-Hinweis + Fokus auf Nächste Woche
- [x] Manuell: Toggle Wochenansicht ↔ Kursübersicht


Made with [Cursor](https://cursor.com)