### PR TITLE
#171.3 A11y: Kursraster-Semantik (article, Landmarks)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -404,6 +404,15 @@ body {
   min-width: 0;
 }
 
+.course-head-primary {
+  min-width: 0;
+  flex: 1;
+}
+
+.course-head-schedule {
+  margin-top: 2px;
+}
+
 .course-head-meta {
   display: inline-flex;
   flex-direction: column;
@@ -1336,6 +1345,10 @@ a:focus-visible {
     gap: 0.5rem;
   }
   .course-head-title {
+    flex: unset;
+    min-width: 0;
+  }
+  .course-head-primary {
     flex: 1;
     min-width: 0;
   }

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -68,6 +68,28 @@ describe("CourseCard", () => {
     cleanup();
   });
 
+  it("rendert Kurskarte als article mit Kurs-Kontext im Namen", () => {
+    renderCourseCard();
+
+    const article = screen.getByRole("article", { name: /kurs:\s*yoga basic/i });
+    expect(article).toHaveClass("course-card");
+    const heading = screen.getByRole("heading", { name: /kurs:\s*yoga basic/i, level: 3 });
+    expect(heading).toHaveTextContent("Yoga Basic");
+    expect(article).toHaveAttribute("aria-labelledby", heading.id);
+    expect(article).toHaveAttribute("aria-describedby");
+    const scheduleDescId = article.getAttribute("aria-describedby");
+    const schedule = document.getElementById(scheduleDescId!);
+    expect(schedule).toHaveTextContent(/monday · 10:00/i);
+    expect(schedule).toHaveAttribute("aria-label", "Montag · 10:00");
+  });
+
+  it("verknüpft Terminauswahl mit Label", () => {
+    renderCourseCard();
+
+    const select = screen.getByRole("combobox", { name: /termine/i });
+    expect(screen.getByLabelText("Termine:")).toBe(select);
+  });
+
   it("markiert eigene kurzfristige Absage mit chip-self und short-notice", () => {
     const overrideSn: CourseDateOverride = {
       ...baseOverride,

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -25,6 +25,7 @@ import {
   isOccurrenceInPast,
 } from "../lib/courseTermActions";
 import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
+import { weekdayLabelDe } from "../lib/weekdayLabels";
 import type { SwapSettings } from "../types";
 
 type Props = {
@@ -355,15 +356,32 @@ export default function CourseCard({
     setSelectedDate(new Date(initialSelectedTime).toISOString());
   }, [initialSelectedTime]);
 
+  const titleId = useId();
+  const scheduleDescId = useId();
+  const termSelectId = useId();
+
   return (
-    <div
+    <article
       className={`course-card${participantActionsLocked ? " course-card--inactive-participant" : ""}`}
+      aria-labelledby={titleId}
+      aria-describedby={scheduleDescId}
     >
       <div className="course-head">
-        <div className="course-head-title">
-          <h3>{course.name}</h3>
-          <div className="muted">
-            {course.weekday} · {course.time}
+        <div className="course-head-primary">
+          <div className="course-head-title">
+            <h3 id={titleId}>
+              <span className="visually-hidden">Kurs: </span>
+              {course.name}
+            </h3>
+          </div>
+          <div
+            className="course-head-schedule muted"
+            id={scheduleDescId}
+            aria-label={`${weekdayLabelDe(course.weekday)} · ${course.time}`}
+          >
+            <span aria-hidden="true">
+              {course.weekday} · {course.time}
+            </span>
           </div>
         </div>
         <div className="course-head-meta">
@@ -426,8 +444,11 @@ export default function CourseCard({
       </div>
 
       <div className="course-row">
-        <div className="muted">Termine:</div>
+        <label htmlFor={termSelectId} className="muted course-row-label">
+          Termine:
+        </label>
         <select
+          id={termSelectId}
           value={hasNoUpcomingDates && !showLastTermInSelect ? "" : selectedDate}
           onChange={(e) => {
             const next = new Date(e.target.value);
@@ -916,6 +937,6 @@ export default function CourseCard({
           </div>
         </div>
       )}
-    </div>
+    </article>
   );
 }

--- a/app/src/components/CourseList.test.tsx
+++ b/app/src/components/CourseList.test.tsx
@@ -140,6 +140,34 @@ describe("CourseList", () => {
     });
   });
 
+  it("strukturiert geladene Kurse als region mit article-Karten", async () => {
+    const mockCourses: Course[] = [
+      {
+        tenantId: "default-tenant",
+        id: 1,
+        name: "Yoga Basic",
+        weekday: "Monday",
+        time: "10:00",
+        capacity: 10,
+        participants: ["alice"],
+        dates: ["2099-06-16"],
+      },
+    ];
+
+    mockedGetCourses.mockResolvedValue(mockCourses);
+    mockedGetOverrides.mockResolvedValue([]);
+    mockedGetSwaps.mockResolvedValue([]);
+
+    render(
+      <CourseList currentUser={baseUser} tenant={baseTenant} membership={baseMembership} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /kursübersicht/i })).toBeInTheDocument();
+      expect(screen.getByRole("article", { name: /kurs:\s*yoga basic/i })).toBeInTheDocument();
+    });
+  });
+
   it("zeigt Empty-State, wenn keine sichtbaren zukünftigen Termine vorhanden sind", async () => {
     const pastOnlyCourses: Course[] = [
       {
@@ -163,7 +191,9 @@ describe("CourseList", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Aktuell keine Kurse in dieser Ansicht/i)).toBeInTheDocument();
+      const emptyState = screen.getByText(/Aktuell keine Kurse in dieser Ansicht/i);
+      expect(emptyState).toBeInTheDocument();
+      expect(emptyState.closest('[role="status"]')).toBeTruthy();
     });
   });
 

--- a/app/src/components/CourseList.tsx
+++ b/app/src/components/CourseList.tsx
@@ -32,6 +32,7 @@ import { getSwaps } from "../api/swaps";
 import { getSwapsByStatus } from "../api/swaps";
 import { getOverrides } from "../api/overrides";
 import { getCourseDates } from "../lib/dates";
+import { WEEKDAY_OPTIONS } from "../lib/weekdayLabels";
 import {
   createCourse,
   deleteCourse,
@@ -91,16 +92,6 @@ const WEEKDAY_ORDER: Record<string, number> = {
   Sun: 7,
   Sunday: 7,
 };
-
-const WEEKDAY_OPTIONS = [
-  { value: "Mon", label: "Montag" },
-  { value: "Tue", label: "Dienstag" },
-  { value: "Wed", label: "Mittwoch" },
-  { value: "Thu", label: "Donnerstag" },
-  { value: "Fri", label: "Freitag" },
-  { value: "Sat", label: "Samstag" },
-  { value: "Sun", label: "Sonntag" },
-] as const;
 
 const STATUS_OPTIONS: Array<{ value: CourseStatus; label: string }> = [
   { value: "inactive", label: "Inaktiv" },
@@ -821,7 +812,7 @@ export default function CourseList({
         </div>
       )}
 
-      <div className="grid">
+      <div className="grid" role="region" aria-label="Kursübersicht">
         {coursesToRender.map((course) => {
           const dates = getCourseDates(course);
           const hasUpcomingDates = dates.length > 0;

--- a/app/src/components/CourseWeekView.test.tsx
+++ b/app/src/components/CourseWeekView.test.tsx
@@ -99,7 +99,16 @@ describe("CourseWeekView", () => {
 
   it("shows empty state when no courses in week", () => {
     render(<CourseWeekView {...baseProps} rows={[]} />);
-    expect(screen.getByText("In dieser Kalenderwoche sind keine Termine sichtbar.")).toBeInTheDocument();
+    const emptyState = screen.getByText("In dieser Kalenderwoche sind keine Termine sichtbar.");
+    expect(emptyState).toBeInTheDocument();
+    expect(emptyState.closest('[role="status"]')).toBeTruthy();
+  });
+
+  it("exposes loading state as status region", () => {
+    render(<CourseWeekView {...baseProps} loading rows={[]} />);
+    const loadingStatus = screen.getByRole("status");
+    expect(loadingStatus).toHaveTextContent(/kurse werden geladen/i);
+    expect(loadingStatus).toHaveAttribute("aria-live", "polite");
   });
 
   it("shows hint when past courses are hidden outside grace", () => {

--- a/app/src/lib/weekdayLabels.test.ts
+++ b/app/src/lib/weekdayLabels.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { weekdayLabelDe } from "./weekdayLabels";
+
+describe("weekdayLabelDe", () => {
+  it("mappt Kurz- und Langformen auf deutsche Vollnamen", () => {
+    expect(weekdayLabelDe("Mon")).toBe("Montag");
+    expect(weekdayLabelDe("Monday")).toBe("Montag");
+    expect(weekdayLabelDe("Thu")).toBe("Donnerstag");
+    expect(weekdayLabelDe("Thursday")).toBe("Donnerstag");
+  });
+
+  it("gibt unbekannte Werte unverändert zurück", () => {
+    expect(weekdayLabelDe("Foo")).toBe("Foo");
+  });
+});

--- a/app/src/lib/weekdayLabels.ts
+++ b/app/src/lib/weekdayLabels.ts
@@ -1,0 +1,31 @@
+const WEEKDAY_LABELS_DE: Record<string, string> = {
+  Sun: "Sonntag",
+  Sunday: "Sonntag",
+  Mon: "Montag",
+  Monday: "Montag",
+  Tue: "Dienstag",
+  Tuesday: "Dienstag",
+  Wed: "Mittwoch",
+  Wednesday: "Mittwoch",
+  Thu: "Donnerstag",
+  Thursday: "Donnerstag",
+  Fri: "Freitag",
+  Friday: "Freitag",
+  Sat: "Samstag",
+  Saturday: "Samstag",
+};
+
+/** Deutsche Vollform für gespeicherte Wochentags-Codes (Mon, Monday, …). */
+export function weekdayLabelDe(weekday: string): string {
+  return WEEKDAY_LABELS_DE[weekday] ?? weekday;
+}
+
+export const WEEKDAY_OPTIONS = [
+  { value: "Mon", label: "Montag" },
+  { value: "Tue", label: "Dienstag" },
+  { value: "Wed", label: "Mittwoch" },
+  { value: "Thu", label: "Donnerstag" },
+  { value: "Fri", label: "Freitag" },
+  { value: "Sat", label: "Samstag" },
+  { value: "Sun", label: "Sonntag" },
+] as const;


### PR DESCRIPTION
## Summary
- Structure course cards as `article` landmarks with a single accessible name (`Kurs: …`) and schedule description
- Add `Kursübersicht` region in `CourseList`; keep week-view empty/loading states as `role="status"`
- Fix duplicate SR announcements (heading label, term select) and announce weekdays in German via `weekdayLabelDe` while visible codes stay until #182

## Test plan
- [x] `CourseCard.test.tsx`, `CourseList.test.tsx`, `CourseWeekView.test.tsx`, `weekdayLabels.test.ts`
- [ ] VoiceOver: Rotor → Überschriften — einmal „Kurs: [Name]“ pro Karte
- [ ] VoiceOver: Tab zum Termin-Dropdown — einmal „Termine“, nicht „Termine: Termine:“
- [ ] VoiceOver: Wochentag als „Montag · …“, nicht „Mon“
- [ ] Sichtliches Layout der Kachel-Header unverändert ok

Closes #194

Made with [Cursor](https://cursor.com)