### PR TITLE
Accessible term select and course term actions (#196)

### DIFF
--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -39,6 +39,9 @@ const baseSwap: Swap = {
   status: "pending",
 };
 
+const selectedTermActionName = (action: string) =>
+  new RegExp(`${action}, yoga basic, 16\\.06\\.2099`, "i");
+
 function renderCourseCard(overrides: Partial<React.ComponentProps<typeof CourseCard>> = {}) {
   const now = new Date("2099-06-10T10:00:00Z");
   const dates = [new Date("2099-06-16T10:00:00Z")];
@@ -230,15 +233,35 @@ describe("CourseCard", () => {
     );
   });
 
-  it("benennt Kernaktionen mit Kurskontext für Screenreader", () => {
+  it("benennt Kernaktionen mit Termin- und Kurskontext für Screenreader", () => {
     renderCourseCard();
 
     expect(
-      screen.getByRole("button", { name: /termin absagen für yoga basic/i }),
+      screen.getByRole("button", { name: selectedTermActionName("Termin absagen") }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /tauschen anfragen für yoga basic/i }),
+      screen.getByRole("button", { name: selectedTermActionName("Tauschen anfragen") }),
     ).toBeInTheDocument();
+  });
+
+  it("enthält Tausch-Status im aria-label der Aktion", () => {
+    const targetCourse: Course = {
+      ...baseCourse,
+      id: 2,
+      name: "Yoga Advanced",
+    };
+
+    renderCourseCard({
+      swaps: [baseSwap],
+      allCourses: [baseCourse, targetCourse],
+    });
+
+    const cancelButton = screen.getByRole("button", {
+      name: selectedTermActionName("Tauschanfragen abbrechen"),
+    });
+    expect(cancelButton.getAttribute("aria-label")).toMatch(
+      /Tauschanfrage für 17\.06\.2099 · Yoga Advanced/i,
+    );
   });
 
   it("ruft onToggleAbsence auf, wenn 'Termin absagen' geklickt wird", () => {
@@ -246,7 +269,7 @@ describe("CourseCard", () => {
 
     const { props } = renderCourseCard({ onToggleAbsence });
 
-    const button = screen.getByRole("button", { name: /termin absagen für yoga basic/i });
+    const button = screen.getByRole("button", { name: selectedTermActionName("Termin absagen") });
     fireEvent.click(button);
 
     expect(onToggleAbsence).toHaveBeenCalledTimes(1);
@@ -262,7 +285,9 @@ describe("CourseCard", () => {
 
     renderCourseCard({ swaps, cancelSwap });
 
-    const button = screen.getByRole("button", { name: /tauschanfragen abbrechen für yoga basic/i });
+    const button = screen.getByRole("button", {
+      name: selectedTermActionName("Tauschanfragen abbrechen"),
+    });
     fireEvent.click(button);
 
     expect(cancelSwap).toHaveBeenCalledTimes(1);
@@ -316,7 +341,7 @@ describe("CourseCard", () => {
       overrides: [cancelledOverride],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /anderen termin wählen für yoga basic/i }));
+    fireEvent.click(screen.getByRole("button", { name: selectedTermActionName("Anderen Termin wählen") }));
     expect(screen.getByRole("heading", { name: /Anderen Termin wählen/i })).toBeInTheDocument();
     expect(screen.queryByText(/folgt/i)).not.toBeInTheDocument();
   });
@@ -349,7 +374,9 @@ describe("CourseCard", () => {
     });
 
     // Swap-Modal öffnen (es kann mehrere gleich benannte Buttons geben)
-    const [swapButton] = screen.getAllByRole("button", { name: /tauschen anfragen für yoga basic/i });
+    const [swapButton] = screen.getAllByRole("button", {
+      name: selectedTermActionName("Tauschen anfragen"),
+    });
     fireEvent.click(swapButton);
 
     expect(screen.getByText(/Tauschanfrage starten/i)).toBeInTheDocument();
@@ -409,7 +436,7 @@ describe("CourseCard", () => {
     });
 
     const swapButtons = screen.getAllByRole("button", {
-      name: /weitere tauschanfrage \(1 offene anfragen\) für yoga basic/i,
+      name: selectedTermActionName("Weitere Tauschanfrage"),
     });
     fireEvent.click(swapButtons[swapButtons.length - 1]);
 

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach } from "vitest";
 import CourseCard from "./CourseCard";
@@ -53,7 +53,7 @@ function renderCourseCard(overrides: Partial<React.ComponentProps<typeof CourseC
     dates,
     overrides: [baseOverride],
     swaps: [],
-    onToggleAbsence: vi.fn(),
+    onToggleAbsence: vi.fn().mockResolvedValue(true),
     confirmSwap: vi.fn(),
     requestSwap: vi.fn(),
     cancelSwap: vi.fn(),
@@ -264,19 +264,58 @@ describe("CourseCard", () => {
     );
   });
 
-  it("ruft onToggleAbsence auf, wenn 'Termin absagen' geklickt wird", () => {
-    const onToggleAbsence = vi.fn();
+  it("ruft onToggleAbsence auf, wenn 'Termin absagen' geklickt wird", async () => {
+    const onToggleAbsence = vi.fn().mockResolvedValue(true);
 
     const { props } = renderCourseCard({ onToggleAbsence });
 
     const button = screen.getByRole("button", { name: selectedTermActionName("Termin absagen") });
     fireEvent.click(button);
 
-    expect(onToggleAbsence).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onToggleAbsence).toHaveBeenCalledTimes(1);
+    });
     const [courseArg, dateIsoArg, userNameArg] = onToggleAbsence.mock.calls[0];
     expect(courseArg).toEqual(props.course);
     expect(userNameArg).toBe("alice");
     expect(typeof dateIsoArg).toBe("string");
+  });
+
+  it("meldet erfolgreiche Terminabsage über aria-live", async () => {
+    const onToggleAbsence = vi.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(true), 0)),
+    );
+
+    renderCourseCard({ onToggleAbsence });
+
+    fireEvent.click(screen.getByRole("button", { name: selectedTermActionName("Termin absagen") }));
+
+    expect(screen.getByText(/speichere absage/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/termin abgesagt für yoga basic, 16\.06\.2099/i)).toBeInTheDocument();
+    });
+  });
+
+  it("meldet Absage-Rücknahme über aria-live", async () => {
+    const cancelledOverride: CourseDateOverride = {
+      ...baseOverride,
+      participants: [],
+    };
+
+    renderCourseCard({
+      overrides: [cancelledOverride],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: selectedTermActionName("Absage zurücknehmen") }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/absage zurückgenommen für yoga basic, 16\.06\.2099/i),
+      ).toBeInTheDocument();
+    });
   });
 
   it("ruft cancelSwap auf, wenn 'Tauschanfragen abbrechen' geklickt wird", () => {

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -87,7 +87,10 @@ describe("CourseCard", () => {
     renderCourseCard();
 
     const select = screen.getByRole("combobox", { name: /termin für yoga basic/i });
-    expect(screen.getByLabelText("Termin für Yoga Basic")).toBe(select);
+    const visibleLabel = screen.getByText("Termine");
+    expect(visibleLabel.tagName).toBe("LABEL");
+    expect(visibleLabel).toHaveAttribute("for", select.id);
+    expect(visibleLabel).toHaveAttribute("aria-label", "Termin für Yoga Basic");
   });
 
   it("markiert eigene kurzfristige Absage mit chip-self und short-notice", () => {

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -182,6 +182,33 @@ describe("CourseCard", () => {
     expect(screen.getByRole("option", { name: /6\/16\/2099 \(entfällt\)/i })).toBeInTheDocument();
   });
 
+  it("zeigt keinen Phantom-Termin bei leerem dates trotz seriesEndDate", () => {
+    const phantomCourse: Course = {
+      ...baseCourse,
+      weekday: "Tue",
+      seriesStartDate: "2026-06-07",
+      seriesEndDate: "2026-06-07",
+      dates: [],
+      status: "active",
+      planningMode: "bounded_series",
+    };
+
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    renderCourseCard({
+      course: phantomCourse,
+      dates: [],
+      overrides: [],
+    });
+
+    const select = screen.getByRole("combobox", { name: /termin für yoga basic/i });
+    expect(select).toBeDisabled();
+    expect(screen.queryByText(/letzter termin/i)).not.toBeInTheDocument();
+    const hintId = select.getAttribute("aria-describedby");
+    expect(document.getElementById(hintId!)).toHaveTextContent(
+      /kein termin im kurszeitraum für yoga basic/i,
+    );
+  });
+
   it("deaktiviert Datumsauswahl, wenn keine zukünftigen Termine vorhanden sind", () => {
     const courseWithoutFutureDates: Course = {
       ...baseCourse,

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -83,11 +83,11 @@ describe("CourseCard", () => {
     expect(schedule).toHaveAttribute("aria-label", "Montag · 10:00");
   });
 
-  it("verknüpft Terminauswahl mit Label", () => {
+  it("verknüpft Terminauswahl mit kursbezogenem Label", () => {
     renderCourseCard();
 
-    const select = screen.getByRole("combobox", { name: /termine/i });
-    expect(screen.getByLabelText("Termine:")).toBe(select);
+    const select = screen.getByRole("combobox", { name: /termin für yoga basic/i });
+    expect(screen.getByLabelText("Termin für Yoga Basic")).toBe(select);
   });
 
   it("markiert eigene kurzfristige Absage mit chip-self und short-notice", () => {
@@ -191,8 +191,24 @@ describe("CourseCard", () => {
       overrides: [],
     });
 
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", { name: /termin für yoga basic/i });
     expect(select).toBeDisabled();
+    const hintId = select.getAttribute("aria-describedby");
+    expect(hintId).toBeTruthy();
+    expect(document.getElementById(hintId!)).toHaveTextContent(
+      /keine anstehenden termine für yoga basic/i,
+    );
+  });
+
+  it("benennt Kernaktionen mit Kurskontext für Screenreader", () => {
+    renderCourseCard();
+
+    expect(
+      screen.getByRole("button", { name: /termin absagen für yoga basic/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /tauschen anfragen für yoga basic/i }),
+    ).toBeInTheDocument();
   });
 
   it("ruft onToggleAbsence auf, wenn 'Termin absagen' geklickt wird", () => {
@@ -200,7 +216,7 @@ describe("CourseCard", () => {
 
     const { props } = renderCourseCard({ onToggleAbsence });
 
-    const button = screen.getByRole("button", { name: /Termin absagen/i });
+    const button = screen.getByRole("button", { name: /termin absagen für yoga basic/i });
     fireEvent.click(button);
 
     expect(onToggleAbsence).toHaveBeenCalledTimes(1);
@@ -216,7 +232,7 @@ describe("CourseCard", () => {
 
     renderCourseCard({ swaps, cancelSwap });
 
-    const button = screen.getByRole("button", { name: /Tauschanfragen abbrechen/i });
+    const button = screen.getByRole("button", { name: /tauschanfragen abbrechen für yoga basic/i });
     fireEvent.click(button);
 
     expect(cancelSwap).toHaveBeenCalledTimes(1);
@@ -270,7 +286,7 @@ describe("CourseCard", () => {
       overrides: [cancelledOverride],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Anderen Termin wählen/i }));
+    fireEvent.click(screen.getByRole("button", { name: /anderen termin wählen für yoga basic/i }));
     expect(screen.getByRole("heading", { name: /Anderen Termin wählen/i })).toBeInTheDocument();
     expect(screen.queryByText(/folgt/i)).not.toBeInTheDocument();
   });
@@ -303,7 +319,7 @@ describe("CourseCard", () => {
     });
 
     // Swap-Modal öffnen (es kann mehrere gleich benannte Buttons geben)
-    const [swapButton] = screen.getAllByRole("button", { name: /Tauschen anfragen/i });
+    const [swapButton] = screen.getAllByRole("button", { name: /tauschen anfragen für yoga basic/i });
     fireEvent.click(swapButton);
 
     expect(screen.getByText(/Tauschanfrage starten/i)).toBeInTheDocument();
@@ -362,7 +378,9 @@ describe("CourseCard", () => {
       overrides: [baseOverride],
     });
 
-    const swapButtons = screen.getAllByRole("button", { name: /Weitere Tauschanfrage/i });
+    const swapButtons = screen.getAllByRole("button", {
+      name: /weitere tauschanfrage \(1 offene anfragen\) für yoga basic/i,
+    });
     fireEvent.click(swapButtons[swapButtons.length - 1]);
 
     expect(screen.getByText(/Tauschanfrage starten/i)).toBeInTheDocument();

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -285,7 +285,7 @@ export default function CourseCard({
       ? getInactiveGraceLastDayIso(course, tenantSettings)
       : undefined;
   const lastActualOccurrenceIso = useMemo(
-    () => lastScheduledOccurrenceIso(course),
+    () => lastScheduledOccurrenceIso({ dates: course.dates }),
     [course.dates],
   );
   const lastOccurrenceDate =

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -456,8 +456,12 @@ export default function CourseCard({
             Keine anstehenden Termine für {course.name}.
           </span>
         )}
-        <label htmlFor={termSelectId} className="muted course-row-label">
-          Termin für {course.name}
+        <label
+          htmlFor={termSelectId}
+          className="muted course-row-label"
+          aria-label={`Termin für ${course.name}`}
+        >
+          Termine
         </label>
         <select
           id={termSelectId}

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -60,6 +60,10 @@ function sameDayUTC(a: Date, b: Date) {
   );
 }
 
+function courseActionLabel(courseName: string, action: string): string {
+  return `${action} für ${courseName}`;
+}
+
 function SwapModalHint({ label, children }: { label: string; children: ReactNode }) {
   const hintId = useId();
   const [open, setOpen] = useState(false);
@@ -359,6 +363,9 @@ export default function CourseCard({
   const titleId = useId();
   const scheduleDescId = useId();
   const termSelectId = useId();
+  const termSelectDisabledHintId = useId();
+  const termSelectDisabled = hasNoUpcomingDates && !showLastTermInSelect;
+  const actionLabel = (action: string) => courseActionLabel(course.name, action);
 
   return (
     <article
@@ -444,18 +451,24 @@ export default function CourseCard({
       </div>
 
       <div className="course-row">
+        {termSelectDisabled && (
+          <span id={termSelectDisabledHintId} className="visually-hidden">
+            Keine anstehenden Termine für {course.name}.
+          </span>
+        )}
         <label htmlFor={termSelectId} className="muted course-row-label">
-          Termine:
+          Termin für {course.name}
         </label>
         <select
           id={termSelectId}
-          value={hasNoUpcomingDates && !showLastTermInSelect ? "" : selectedDate}
+          value={termSelectDisabled ? "" : selectedDate}
           onChange={(e) => {
             const next = new Date(e.target.value);
             setSelectedDate(e.target.value);
             onDateChange?.(next);
           }}
-          disabled={hasNoUpcomingDates && !showLastTermInSelect}
+          disabled={termSelectDisabled}
+          aria-describedby={termSelectDisabled ? termSelectDisabledHintId : undefined}
         >
           {showLastTermInSelect && lastOccurrenceDate ? (
             <option value={lastOccurrenceDate.toISOString()}>
@@ -577,78 +590,103 @@ export default function CourseCard({
             <>
               {/* Falls User den Ursprungstermin noch nicht abgesagt hat → Absage-Button trotzdem anzeigen */}
               {swapForThisTerm.status === "pending" &&
-                originallyParticipant && (
-                  <button
-                    className="danger"
-                    onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                  >
-                    {hasCancelled ? "Absage zuruecknehmen" : "Termin absagen"}
-                  </button>
-                
-              )}
+                originallyParticipant && (() => {
+                  const absenceAction = hasCancelled ? "Absage zurücknehmen" : "Termin absagen";
+                  return (
+                    <button
+                      type="button"
+                      className="danger"
+                      aria-label={actionLabel(absenceAction)}
+                      onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                    >
+                      {absenceAction}
+                    </button>
+                  );
+                })()}
 
-              <button
-                className="secondary danger"
-                onClick={() => cancelSwap(swapForThisTerm, course.id)}
-              >
-                {swapForThisTerm.status === "pending"
-                  ? "Tauschanfragen abbrechen"
-                  : swapForThisTerm.status === "active" &&
-                      swapForThisTerm.toCourseId === course.id &&
-                      isWithinCancellationSwapCutoff(
-                        swapForThisTerm.toDate,
-                        allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
-                        cutoffMinutes,
-                      )
-                    ? isShortNoticeCancelled(
-                        overrides.find(
-                          (o) =>
-                            o.courseId === swapForThisTerm.toCourseId &&
-                            o.date === swapForThisTerm.toDate,
-                        ),
-                        userName,
-                      )
-                      ? "Tauschabsage zurücknehmen"
-                      : "Am Zieltermin kurzfristig absagen"
-                    : "Tausch abbrechen"}
-              </button>
+              {(() => {
+                const cancelSwapAction =
+                  swapForThisTerm.status === "pending"
+                    ? "Tauschanfragen abbrechen"
+                    : swapForThisTerm.status === "active" &&
+                        swapForThisTerm.toCourseId === course.id &&
+                        isWithinCancellationSwapCutoff(
+                          swapForThisTerm.toDate,
+                          allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
+                          cutoffMinutes,
+                        )
+                      ? isShortNoticeCancelled(
+                          overrides.find(
+                            (o) =>
+                              o.courseId === swapForThisTerm.toCourseId &&
+                              o.date === swapForThisTerm.toDate,
+                          ),
+                          userName,
+                        )
+                        ? "Tauschabsage zurücknehmen"
+                        : "Am Zieltermin kurzfristig absagen"
+                      : "Tausch abbrechen";
+                return (
+                  <button
+                    type="button"
+                    className="secondary danger"
+                    aria-label={actionLabel(cancelSwapAction)}
+                    onClick={() => cancelSwap(swapForThisTerm, course.id)}
+                  >
+                    {cancelSwapAction}
+                  </button>
+                );
+              })()}
             </>
           ) : (
             <>
               {isShortNotice ? (
                 <button
+                  type="button"
                   className="danger"
+                  aria-label={actionLabel("Absage zurücknehmen")}
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
                 >
                   Absage zurücknehmen
                 </button>
               ) : isParticipant ? (
                 <button
+                  type="button"
                   className="danger"
+                  aria-label={actionLabel("Termin absagen")}
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
                 >
                   Termin absagen
                 </button>
               ) : canUndoRegularAbsence ? (
-                <button onClick={() => onToggleAbsence(course, selectedDateKey, userName)}>
+                <button
+                  type="button"
+                  aria-label={actionLabel("Absage zurücknehmen")}
+                  onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                >
                   Absage zurücknehmen
                 </button>
               ) : hasCancelled ? null : (
                 notEnrolledInTermHint
               )}
 
-              {canSwapFromOrigin && (
-                <button
-                  className="secondary"
-                  onClick={() => {
-                    setSwapDateIso(null);
-                    setSwapDateIsoWaitlist(null);
-                    setShowSwapModal(true);
-                  }}
-                >
-                  {hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen"}
-                </button>
-              )}
+              {canSwapFromOrigin && (() => {
+                const swapAction = hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen";
+                return (
+                  <button
+                    type="button"
+                    className="secondary"
+                    aria-label={actionLabel(swapAction)}
+                    onClick={() => {
+                      setSwapDateIso(null);
+                      setSwapDateIsoWaitlist(null);
+                      setShowSwapModal(true);
+                    }}
+                  >
+                    {swapAction}
+                  </button>
+                );
+              })()}
               {originInCutoff && (originallyParticipant || hasCancelled) && !canSwapFromOrigin && (
                 <p className="muted small" role="status">
                   Weniger als {cutoffMinutes} Minuten vor Termin — kein Tausch mehr möglich.
@@ -660,9 +698,12 @@ export default function CourseCard({
           {/* 🆕 Wenn schon pending-Requests existieren: zusätzlicher Button */}
               {hasPendingRequestsFromOrigin && canSwapFromOrigin && (
                 <button
+                  type="button"
                   className="secondary"
+                  aria-label={actionLabel(
+                    `Weitere Tauschanfrage (${pendingCount} offene Anfragen)`,
+                  )}
                   onClick={() => {
-                    // zwinge Nutzer zur bewussten Auswahl: nichts vorauswählen
                     setSwapDateIso(null);
                     setSwapDateIsoWaitlist(null);
                     setShowSwapModal(true);
@@ -676,19 +717,27 @@ export default function CourseCard({
 
       ) : showPastTermSwapActions ? (
         <div className="actions">
-          {swapForThisTerm ? (
-            <button
-              className="secondary danger"
-              onClick={() => cancelSwap(swapForThisTerm, course.id)}
-            >
-              {swapForThisTerm.status === "pending"
+          {swapForThisTerm ? (() => {
+            const cancelAction =
+              swapForThisTerm.status === "pending"
                 ? "Tauschanfragen abbrechen"
-                : "Tausch abbrechen"}
-            </button>
-          ) : canSwapFromPastCancelled ? (
+                : "Tausch abbrechen";
+            return (
+              <button
+                type="button"
+                className="secondary danger"
+                aria-label={actionLabel(cancelAction)}
+                onClick={() => cancelSwap(swapForThisTerm, course.id)}
+              >
+                {cancelAction}
+              </button>
+            );
+          })() : canSwapFromPastCancelled ? (
             <>
               <button
+                type="button"
                 className="secondary"
+                aria-label={actionLabel("Anderen Termin wählen")}
                 onClick={() => {
                   setSwapDateIso(null);
                   setSwapDateIsoWaitlist(null);
@@ -699,7 +748,11 @@ export default function CourseCard({
               </button>
               {hasPendingRequestsFromOrigin && (
                 <button
+                  type="button"
                   className="secondary"
+                  aria-label={actionLabel(
+                    `Weitere Tauschanfrage (${pendingCount} offene Anfragen)`,
+                  )}
                   onClick={() => {
                     setSwapDateIso(null);
                     setSwapDateIsoWaitlist(null);
@@ -714,18 +767,24 @@ export default function CourseCard({
           ) : null}
         </div>
       ) : isSelectedTermExcluded && includePastTermsInSelect ? (
-        swapForThisTerm ? (
-          <div className="actions">
-            <button
-              className="secondary danger"
-              onClick={() => cancelSwap(swapForThisTerm, course.id)}
-            >
-              {swapForThisTerm.status === "pending"
-                ? "Tauschanfrage abbrechen"
-                : "Tausch abbrechen"}
-            </button>
-          </div>
-        ) : null
+        swapForThisTerm ? (() => {
+          const cancelAction =
+            swapForThisTerm.status === "pending"
+              ? "Tauschanfrage abbrechen"
+              : "Tausch abbrechen";
+          return (
+            <div className="actions">
+              <button
+                type="button"
+                className="secondary danger"
+                aria-label={actionLabel(cancelAction)}
+                onClick={() => cancelSwap(swapForThisTerm, course.id)}
+              >
+                {cancelAction}
+              </button>
+            </div>
+          );
+        })() : null
       ) : isPastOccurrence && !participantActionsLocked ? (
         <p className="muted small course-past-term-note" role="status">
           Vergangener Termin — keine Änderungen mehr möglich.
@@ -735,7 +794,9 @@ export default function CourseCard({
           {swapForWaitlist ? (
             <div className="actions">
               <button
+                type="button"
                 className="secondary danger"
+                aria-label={actionLabel("Tauschanfrage abbrechen")}
                 onClick={() => cancelSwap(swapForWaitlist, course.id)}
               >
                 Tauschanfrage abbrechen
@@ -751,13 +812,20 @@ export default function CourseCard({
         <div className="actions course-inactive-swap-actions">
           {userSwapsOnCourse.map((swap) => (
             <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
-              <button
-                type="button"
-                className="secondary danger"
-                onClick={() => cancelSwap(swap, course.id)}
-              >
-                {swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}
-              </button>
+              {(() => {
+                const cancelAction =
+                  swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen";
+                return (
+                  <button
+                    type="button"
+                    className="secondary danger"
+                    aria-label={actionLabel(cancelAction)}
+                    onClick={() => cancelSwap(swap, course.id)}
+                  >
+                    {cancelAction}
+                  </button>
+                );
+              })()}
             </div>
           ))}
         </div>

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -3,8 +3,8 @@ import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
   buildCourseOccurrenceLocal,
-  courseEndDateIso,
   formatCourseIsoDateDe,
+  lastScheduledOccurrenceIso,
   getInactiveGraceLastDayIso,
   isCourseInInactiveGracePeriod,
   isWithinPostCourseEndGrace,
@@ -284,10 +284,16 @@ export default function CourseCard({
     inPostEndGrace || inInactiveGrace
       ? getInactiveGraceLastDayIso(course, tenantSettings)
       : undefined;
-  const lastOccurrenceIso = courseEndDateIso(course);
+  const lastActualOccurrenceIso = useMemo(
+    () => lastScheduledOccurrenceIso(course),
+    [course.dates],
+  );
   const lastOccurrenceDate =
-    lastOccurrenceIso != null ? buildCourseOccurrenceLocal(lastOccurrenceIso, course.time) : null;
-  const showLastTermInSelect = hasNoUpcomingDates && lastOccurrenceDate != null && inPostEndGrace;
+    lastActualOccurrenceIso != null
+      ? buildCourseOccurrenceLocal(lastActualOccurrenceIso, course.time)
+      : null;
+  const showLastTermInSelect =
+    hasNoUpcomingDates && lastOccurrenceDate != null && inPostEndGrace;
   const showAutoInactiveBadge =
     participantActionsLocked && looksLikeAutomaticallyInactive(course, hasUpcomingDates);
   const userSwapsOnCourse = useMemo(
@@ -352,7 +358,7 @@ export default function CourseCard({
     if (showLastTermInSelect && lastOccurrenceDate) {
       setSelectedDate(lastOccurrenceDate.toISOString());
     }
-  }, [includePastTermsInSelect, showLastTermInSelect, lastOccurrenceIso, course.time, lastOccurrenceDate]);
+  }, [includePastTermsInSelect, showLastTermInSelect, lastActualOccurrenceIso, course.time, lastOccurrenceDate]);
 
   const initialSelectedTime = initialSelectedDate?.getTime();
   useEffect(() => {
@@ -453,7 +459,9 @@ export default function CourseCard({
       <div className="course-row">
         {termSelectDisabled && (
           <span id={termSelectDisabledHintId} className="visually-hidden">
-            Keine anstehenden Termine für {course.name}.
+            {(course.dates ?? []).length === 0
+              ? `Kein Termin im Kurszeitraum für ${course.name}.`
+              : `Keine anstehenden Termine für ${course.name}.`}
           </span>
         )}
         <label

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -60,8 +60,63 @@ function sameDayUTC(a: Date, b: Date) {
   );
 }
 
-function courseActionLabel(courseName: string, action: string): string {
-  return `${action} für ${courseName}`;
+function courseTermActionLabel(
+  courseName: string,
+  action: string,
+  termIso: string,
+  extras: string[] = [],
+): string {
+  return [action, courseName, formatCourseIsoDateDe(termIso), ...extras].join(", ");
+}
+
+function formatSwapStatusLine(swap: Swap, courseId: number, allCourses: Course[]): string {
+  const courseName = (id: number) => allCourses.find((c) => c.id === id)?.name ?? "Kurs";
+  if (swap.status === "pending" && swap.fromCourseId === courseId) {
+    return `Tauschanfrage für ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
+  }
+  if (swap.status === "pending" && swap.toCourseId === courseId) {
+    return `Tauschanfrage zu ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
+  }
+  if (swap.fromCourseId === courseId) {
+    return `Getauscht mit ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
+  }
+  return `Getauscht von ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
+}
+
+function swapTermIsoForCourse(swap: Swap, courseId: number): string {
+  return swap.fromCourseId === courseId ? swap.fromDate : swap.toDate;
+}
+
+type CourseTermActionButtonProps = {
+  action: string;
+  courseName: string;
+  termIso: string;
+  labelExtras?: string[];
+  className?: string;
+  title?: string;
+  onClick: () => void;
+};
+
+function CourseTermActionButton({
+  action,
+  courseName,
+  termIso,
+  labelExtras = [],
+  className,
+  title,
+  onClick,
+}: CourseTermActionButtonProps) {
+  return (
+    <button
+      type="button"
+      className={className}
+      aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
+      title={title}
+      onClick={onClick}
+    >
+      {action}
+    </button>
+  );
 }
 
 function SwapModalHint({ label, children }: { label: string; children: ReactNode }) {
@@ -371,7 +426,29 @@ export default function CourseCard({
   const termSelectId = useId();
   const termSelectDisabledHintId = useId();
   const termSelectDisabled = hasNoUpcomingDates && !showLastTermInSelect;
-  const actionLabel = (action: string) => courseActionLabel(course.name, action);
+
+  const swapStatusLines = useMemo(
+    () =>
+      hasNoUpcomingDates
+        ? []
+        : allSwapsForThisTerm.map((swap) => formatSwapStatusLine(swap, course.id, allCourses)),
+    [hasNoUpcomingDates, allSwapsForThisTerm, course.id, allCourses],
+  );
+
+  const showCutoffHint =
+    canUseFullTermActions &&
+    !swapForThisTerm &&
+    originInCutoff &&
+    (originallyParticipant || hasCancelled) &&
+    !canSwapFromOrigin;
+
+  const cutoffStatusLabel = showCutoffHint
+    ? `Weniger als ${cutoffMinutes} Minuten vor Termin, kein Tausch mehr möglich`
+    : undefined;
+
+  const swapStatusExtras = swapStatusLines.length > 0 ? swapStatusLines : undefined;
+  const cutoffExtras = cutoffStatusLabel ? [cutoffStatusLabel] : undefined;
+  const termActionExtras = [...(swapStatusExtras ?? []), ...(cutoffExtras ?? [])];
 
   return (
     <article
@@ -602,19 +679,16 @@ export default function CourseCard({
             <>
               {/* Falls User den Ursprungstermin noch nicht abgesagt hat → Absage-Button trotzdem anzeigen */}
               {swapForThisTerm.status === "pending" &&
-                originallyParticipant && (() => {
-                  const absenceAction = hasCancelled ? "Absage zurücknehmen" : "Termin absagen";
-                  return (
-                    <button
-                      type="button"
-                      className="danger"
-                      aria-label={actionLabel(absenceAction)}
-                      onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                    >
-                      {absenceAction}
-                    </button>
-                  );
-                })()}
+                originallyParticipant && (
+                  <CourseTermActionButton
+                    action={hasCancelled ? "Absage zurücknehmen" : "Termin absagen"}
+                    courseName={course.name}
+                    termIso={selectedDateKey}
+                    labelExtras={termActionExtras}
+                    className="danger"
+                    onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                  />
+                )}
 
               {(() => {
                 const cancelSwapAction =
@@ -639,68 +713,65 @@ export default function CourseCard({
                         : "Am Zieltermin kurzfristig absagen"
                       : "Tausch abbrechen";
                 return (
-                  <button
-                    type="button"
+                  <CourseTermActionButton
+                    action={cancelSwapAction}
+                    courseName={course.name}
+                    termIso={selectedDateKey}
+                    labelExtras={termActionExtras}
                     className="secondary danger"
-                    aria-label={actionLabel(cancelSwapAction)}
                     onClick={() => cancelSwap(swapForThisTerm, course.id)}
-                  >
-                    {cancelSwapAction}
-                  </button>
+                  />
                 );
               })()}
             </>
           ) : (
             <>
               {isShortNotice ? (
-                <button
-                  type="button"
+                <CourseTermActionButton
+                  action="Absage zurücknehmen"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
                   className="danger"
-                  aria-label={actionLabel("Absage zurücknehmen")}
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                >
-                  Absage zurücknehmen
-                </button>
+                />
               ) : isParticipant ? (
-                <button
-                  type="button"
+                <CourseTermActionButton
+                  action="Termin absagen"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
                   className="danger"
-                  aria-label={actionLabel("Termin absagen")}
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                >
-                  Termin absagen
-                </button>
+                />
               ) : canUndoRegularAbsence ? (
-                <button
-                  type="button"
-                  aria-label={actionLabel("Absage zurücknehmen")}
+                <CourseTermActionButton
+                  action="Absage zurücknehmen"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
                   onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
-                >
-                  Absage zurücknehmen
-                </button>
+                />
               ) : hasCancelled ? null : (
                 notEnrolledInTermHint
               )}
 
-              {canSwapFromOrigin && (() => {
-                const swapAction = hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen";
-                return (
-                  <button
-                    type="button"
-                    className="secondary"
-                    aria-label={actionLabel(swapAction)}
-                    onClick={() => {
-                      setSwapDateIso(null);
-                      setSwapDateIsoWaitlist(null);
-                      setShowSwapModal(true);
-                    }}
-                  >
-                    {swapAction}
-                  </button>
-                );
-              })()}
-              {originInCutoff && (originallyParticipant || hasCancelled) && !canSwapFromOrigin && (
-                <p className="muted small" role="status">
+              {canSwapFromOrigin && (
+                <CourseTermActionButton
+                  action={hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen"}
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="secondary"
+                  onClick={() => {
+                    setSwapDateIso(null);
+                    setSwapDateIsoWaitlist(null);
+                    setShowSwapModal(true);
+                  }}
+                />
+              )}
+              {showCutoffHint && (
+                <p className="muted small" role="status" aria-hidden="true">
                   Weniger als {cutoffMinutes} Minuten vor Termin — kein Tausch mehr möglich.
                 </p>
               )}
@@ -709,94 +780,86 @@ export default function CourseCard({
           )}
           {/* 🆕 Wenn schon pending-Requests existieren: zusätzlicher Button */}
               {hasPendingRequestsFromOrigin && canSwapFromOrigin && (
-                <button
-                  type="button"
+                <CourseTermActionButton
+                  action="Weitere Tauschanfrage"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
                   className="secondary"
-                  aria-label={actionLabel(
-                    `Weitere Tauschanfrage (${pendingCount} offene Anfragen)`,
-                  )}
+                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
                   onClick={() => {
                     setSwapDateIso(null);
                     setSwapDateIsoWaitlist(null);
                     setShowSwapModal(true);
                   }}
-                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                >
-                  Weitere Tauschanfrage
-                </button>
+                />
               )}
         </div>
 
       ) : showPastTermSwapActions ? (
         <div className="actions">
-          {swapForThisTerm ? (() => {
-            const cancelAction =
-              swapForThisTerm.status === "pending"
-                ? "Tauschanfragen abbrechen"
-                : "Tausch abbrechen";
-            return (
-              <button
-                type="button"
-                className="secondary danger"
-                aria-label={actionLabel(cancelAction)}
-                onClick={() => cancelSwap(swapForThisTerm, course.id)}
-              >
-                {cancelAction}
-              </button>
-            );
-          })() : canSwapFromPastCancelled ? (
+          {swapForThisTerm ? (
+            <CourseTermActionButton
+              action={
+                swapForThisTerm.status === "pending"
+                  ? "Tauschanfragen abbrechen"
+                  : "Tausch abbrechen"
+              }
+              courseName={course.name}
+              termIso={selectedDateKey}
+              labelExtras={termActionExtras}
+              className="secondary danger"
+              onClick={() => cancelSwap(swapForThisTerm, course.id)}
+            />
+          ) : canSwapFromPastCancelled ? (
             <>
-              <button
-                type="button"
+              <CourseTermActionButton
+                action="Anderen Termin wählen"
+                courseName={course.name}
+                termIso={selectedDateKey}
+                labelExtras={termActionExtras}
                 className="secondary"
-                aria-label={actionLabel("Anderen Termin wählen")}
                 onClick={() => {
                   setSwapDateIso(null);
                   setSwapDateIsoWaitlist(null);
                   setShowSwapModal(true);
                 }}
-              >
-                Anderen Termin wählen
-              </button>
+              />
               {hasPendingRequestsFromOrigin && (
-                <button
-                  type="button"
+                <CourseTermActionButton
+                  action="Weitere Tauschanfrage"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
                   className="secondary"
-                  aria-label={actionLabel(
-                    `Weitere Tauschanfrage (${pendingCount} offene Anfragen)`,
-                  )}
+                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
                   onClick={() => {
                     setSwapDateIso(null);
                     setSwapDateIsoWaitlist(null);
                     setShowSwapModal(true);
                   }}
-                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                >
-                  Weitere Tauschanfrage
-                </button>
+                />
               )}
             </>
           ) : null}
         </div>
       ) : isSelectedTermExcluded && includePastTermsInSelect ? (
-        swapForThisTerm ? (() => {
-          const cancelAction =
-            swapForThisTerm.status === "pending"
-              ? "Tauschanfrage abbrechen"
-              : "Tausch abbrechen";
-          return (
-            <div className="actions">
-              <button
-                type="button"
-                className="secondary danger"
-                aria-label={actionLabel(cancelAction)}
-                onClick={() => cancelSwap(swapForThisTerm, course.id)}
-              >
-                {cancelAction}
-              </button>
-            </div>
-          );
-        })() : null
+        swapForThisTerm ? (
+          <div className="actions">
+            <CourseTermActionButton
+              action={
+                swapForThisTerm.status === "pending"
+                  ? "Tauschanfrage abbrechen"
+                  : "Tausch abbrechen"
+              }
+              courseName={course.name}
+              termIso={selectedDateKey}
+              labelExtras={termActionExtras}
+              className="secondary danger"
+              onClick={() => cancelSwap(swapForThisTerm, course.id)}
+            />
+          </div>
+        ) : null
       ) : isPastOccurrence && !participantActionsLocked ? (
         <p className="muted small course-past-term-note" role="status">
           Vergangener Termin — keine Änderungen mehr möglich.
@@ -805,14 +868,14 @@ export default function CourseCard({
         <>
           {swapForWaitlist ? (
             <div className="actions">
-              <button
-                type="button"
+              <CourseTermActionButton
+                action="Tauschanfrage abbrechen"
+                courseName={course.name}
+                termIso={selectedDateKey}
+                labelExtras={termActionExtras}
                 className="secondary danger"
-                aria-label={actionLabel("Tauschanfrage abbrechen")}
                 onClick={() => cancelSwap(swapForWaitlist, course.id)}
-              >
-                Tauschanfrage abbrechen
-              </button>
+              />
             </div>
           ) : (
             notEnrolledInTermHint
@@ -824,54 +887,23 @@ export default function CourseCard({
         <div className="actions course-inactive-swap-actions">
           {userSwapsOnCourse.map((swap) => (
             <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
-              {(() => {
-                const cancelAction =
-                  swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen";
-                return (
-                  <button
-                    type="button"
-                    className="secondary danger"
-                    aria-label={actionLabel(cancelAction)}
-                    onClick={() => cancelSwap(swap, course.id)}
-                  >
-                    {cancelAction}
-                  </button>
-                );
-              })()}
+              <CourseTermActionButton
+                action={swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}
+                courseName={course.name}
+                termIso={swapTermIsoForCourse(swap, course.id)}
+                labelExtras={[formatSwapStatusLine(swap, course.id, allCourses)]}
+                className="secondary danger"
+                onClick={() => cancelSwap(swap, course.id)}
+              />
             </div>
           ))}
         </div>
       )}
 
-      {/* Status-Text separat unter den Buttons */}
-      {!hasNoUpcomingDates && allSwapsForThisTerm.length > 0 && (
-        <div className="muted small status-text">
-          {allSwapsForThisTerm.map((swap, idx) => (
-            <div key={idx}>
-          {swap.status === "pending" && swap.fromCourseId === course.id
-            ? `Tauschanfrage für ${new Date(
-                swap.toDate
-              ).toLocaleDateString()} · ${
-                allCourses.find((c) => c.id === swap.toCourseId)?.name
-              }`
-            : swap.status === "pending" && swap.toCourseId === course.id
-            ? `Tauschanfrage zu ${new Date(
-                swap.fromDate
-              ).toLocaleDateString()} · ${
-                allCourses.find((c) => c.id === swap.toCourseId)?.name
-              }`
-            : swap.fromCourseId === course.id
-            ? `Getauscht mit ${new Date(
-                swap.toDate
-              ).toLocaleDateString()} · ${
-                allCourses.find((c) => c.id === swap.toCourseId)?.name
-              }`
-            : `Getauscht von ${new Date(
-                swap.fromDate
-              ).toLocaleDateString()} · ${
-                allCourses.find((c) => c.id === swap.fromCourseId)?.name
-              }`}
-            </div>
+      {swapStatusLines.length > 0 && (
+        <div className="muted small status-text" role="status" aria-hidden="true">
+          {swapStatusLines.map((line) => (
+            <div key={line}>{line}</div>
           ))}
         </div>
       )}

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -39,7 +39,7 @@ type Props = {
   /** Teilnehmer-Ansicht: keine neuen Absagen/Tauschanfragen bei inaktivem Kurs. */
   participantActionsLocked?: boolean;
   tenantSettings?: TenantSettings;
-  onToggleAbsence: (course: Course, dateIso: string, userName: string) => void;
+  onToggleAbsence: (course: Course, dateIso: string, userName: string) => Promise<boolean>;
   confirmSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
   requestSwap: (fromCourse: Course, fromDateIso: string, toCourseId: number, toDateIso: string, userName: string) => void;
   cancelSwap: (swap: Swap, clickedCourseId: number) => void;
@@ -94,6 +94,8 @@ type CourseTermActionButtonProps = {
   labelExtras?: string[];
   className?: string;
   title?: string;
+  disabled?: boolean;
+  busy?: boolean;
   onClick: () => void;
 };
 
@@ -104,6 +106,8 @@ function CourseTermActionButton({
   labelExtras = [],
   className,
   title,
+  disabled,
+  busy,
   onClick,
 }: CourseTermActionButtonProps) {
   return (
@@ -111,12 +115,36 @@ function CourseTermActionButton({
       type="button"
       className={className}
       aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
+      aria-busy={busy || undefined}
+      disabled={disabled}
       title={title}
       onClick={onClick}
     >
       {action}
     </button>
   );
+}
+
+type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
+
+function formatAbsenceAnnouncement(
+  courseName: string,
+  termIso: string,
+  outcome: "saving" | AbsenceToggleOutcome | "error",
+): string {
+  const term = formatCourseIsoDateDe(termIso);
+  switch (outcome) {
+    case "saving":
+      return "Speichere Absage …";
+    case "cancelled":
+      return `Termin abgesagt für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
+    case "shortNoticeCancelled":
+      return `Kurzfristige Absage gespeichert für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
+    case "undo":
+      return `Absage zurückgenommen für ${courseName}, ${term}. Du nimmst wieder am Termin teil.`;
+    case "error":
+      return "Fehler beim Speichern der Absage.";
+  }
 }
 
 function SwapModalHint({ label, children }: { label: string; children: ReactNode }) {
@@ -179,6 +207,8 @@ export default function CourseCard({
   const [swapDateIso, setSwapDateIso] = useState<string | null>(null);
   const [swapDateIsoWaitlist, setSwapDateIsoWaitlist] = useState<string | null>(null);
   const [showSwapModal, setShowSwapModal] = useState(false);
+  const [absenceSaving, setAbsenceSaving] = useState(false);
+  const [absenceAnnouncement, setAbsenceAnnouncement] = useState("");
 
   const userName = currentUser.nickname;
   const selectedDateKey = toDateKey(new Date(selectedDate));
@@ -450,12 +480,46 @@ export default function CourseCard({
   const cutoffExtras = cutoffStatusLabel ? [cutoffStatusLabel] : undefined;
   const termActionExtras = [...(swapStatusExtras ?? []), ...(cutoffExtras ?? [])];
 
+  const handleToggleAbsence = useCallback(
+    async (outcome: AbsenceToggleOutcome) => {
+      setAbsenceSaving(true);
+      setAbsenceAnnouncement(formatAbsenceAnnouncement(course.name, selectedDateKey, "saving"));
+      try {
+        const succeeded = await onToggleAbsence(course, selectedDateKey, userName);
+        if (!succeeded) {
+          setAbsenceAnnouncement("");
+          return;
+        }
+        setAbsenceAnnouncement(
+          formatAbsenceAnnouncement(course.name, selectedDateKey, outcome),
+        );
+      } catch {
+        setAbsenceAnnouncement(formatAbsenceAnnouncement(course.name, selectedDateKey, "error"));
+      } finally {
+        setAbsenceSaving(false);
+      }
+    },
+    [course, onToggleAbsence, selectedDateKey, userName],
+  );
+
+  useEffect(() => {
+    setAbsenceAnnouncement("");
+  }, [selectedDateKey]);
+
   return (
     <article
       className={`course-card${participantActionsLocked ? " course-card--inactive-participant" : ""}`}
       aria-labelledby={titleId}
       aria-describedby={scheduleDescId}
     >
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="visually-hidden"
+      >
+        {absenceAnnouncement}
+      </span>
       <div className="course-head">
         <div className="course-head-primary">
           <div className="course-head-title">
@@ -686,7 +750,11 @@ export default function CourseCard({
                     termIso={selectedDateKey}
                     labelExtras={termActionExtras}
                     className="danger"
-                    onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                    busy={absenceSaving}
+                    disabled={absenceSaving}
+                    onClick={() =>
+                      handleToggleAbsence(hasCancelled ? "undo" : "cancelled")
+                    }
                   />
                 )}
 
@@ -733,7 +801,9 @@ export default function CourseCard({
                   termIso={selectedDateKey}
                   labelExtras={termActionExtras}
                   className="danger"
-                  onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                  busy={absenceSaving}
+                  disabled={absenceSaving}
+                  onClick={() => handleToggleAbsence("undo")}
                 />
               ) : isParticipant ? (
                 <CourseTermActionButton
@@ -742,7 +812,13 @@ export default function CourseCard({
                   termIso={selectedDateKey}
                   labelExtras={termActionExtras}
                   className="danger"
-                  onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                  busy={absenceSaving}
+                  disabled={absenceSaving}
+                  onClick={() =>
+                    handleToggleAbsence(
+                      originInCutoff ? "shortNoticeCancelled" : "cancelled",
+                    )
+                  }
                 />
               ) : canUndoRegularAbsence ? (
                 <CourseTermActionButton
@@ -750,7 +826,9 @@ export default function CourseCard({
                   courseName={course.name}
                   termIso={selectedDateKey}
                   labelExtras={termActionExtras}
-                  onClick={() => onToggleAbsence(course, selectedDateKey, userName)}
+                  busy={absenceSaving}
+                  disabled={absenceSaving}
+                  onClick={() => handleToggleAbsence("undo")}
                 />
               ) : hasCancelled ? null : (
                 notEnrolledInTermHint

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from "react";
+import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -94,36 +94,45 @@ type CourseTermActionButtonProps = {
   labelExtras?: string[];
   className?: string;
   title?: string;
-  disabled?: boolean;
+  inactive?: boolean;
   busy?: boolean;
   onClick: () => void;
 };
 
-function CourseTermActionButton({
-  action,
-  courseName,
-  termIso,
-  labelExtras = [],
-  className,
-  title,
-  disabled,
-  busy,
-  onClick,
-}: CourseTermActionButtonProps) {
-  return (
-    <button
-      type="button"
-      className={className}
-      aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
-      aria-busy={busy || undefined}
-      disabled={disabled}
-      title={title}
-      onClick={onClick}
-    >
-      {action}
-    </button>
-  );
-}
+const CourseTermActionButton = forwardRef<HTMLButtonElement, CourseTermActionButtonProps>(
+  function CourseTermActionButton(
+    {
+      action,
+      courseName,
+      termIso,
+      labelExtras = [],
+      className,
+      title,
+      inactive,
+      busy,
+      onClick,
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={className}
+        aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
+        aria-busy={busy || undefined}
+        aria-disabled={inactive || undefined}
+        title={title}
+        onClick={() => {
+          if (inactive) return;
+          onClick();
+        }}
+      >
+        {action}
+      </button>
+    );
+  },
+);
 
 type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
 
@@ -209,6 +218,8 @@ export default function CourseCard({
   const [showSwapModal, setShowSwapModal] = useState(false);
   const [absenceSaving, setAbsenceSaving] = useState(false);
   const [absenceAnnouncement, setAbsenceAnnouncement] = useState("");
+  const absenceButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreAbsenceFocusRef = useRef(false);
 
   const userName = currentUser.nickname;
   const selectedDateKey = toDateKey(new Date(selectedDate));
@@ -480,8 +491,41 @@ export default function CourseCard({
   const cutoffExtras = cutoffStatusLabel ? [cutoffStatusLabel] : undefined;
   const termActionExtras = [...(swapStatusExtras ?? []), ...(cutoffExtras ?? [])];
 
+  const swapPendingAbsenceAction = useMemo((): {
+    action: string;
+    outcome: AbsenceToggleOutcome;
+  } | null => {
+    if (swapForThisTerm?.status === "pending" && originallyParticipant) {
+      return {
+        action: hasCancelled ? "Absage zurücknehmen" : "Termin absagen",
+        outcome: hasCancelled ? "undo" : "cancelled",
+      };
+    }
+    return null;
+  }, [swapForThisTerm, originallyParticipant, hasCancelled]);
+
+  const primaryAbsenceAction = useMemo((): {
+    action: string;
+    outcome: AbsenceToggleOutcome;
+  } | null => {
+    if (isShortNotice) {
+      return { action: "Absage zurücknehmen", outcome: "undo" };
+    }
+    if (isParticipant) {
+      return {
+        action: "Termin absagen",
+        outcome: originInCutoff ? "shortNoticeCancelled" : "cancelled",
+      };
+    }
+    if (canUndoRegularAbsence) {
+      return { action: "Absage zurücknehmen", outcome: "undo" };
+    }
+    return null;
+  }, [isShortNotice, isParticipant, canUndoRegularAbsence, originInCutoff]);
+
   const handleToggleAbsence = useCallback(
     async (outcome: AbsenceToggleOutcome) => {
+      if (absenceSaving) return;
       setAbsenceSaving(true);
       setAbsenceAnnouncement(formatAbsenceAnnouncement(course.name, selectedDateKey, "saving"));
       try {
@@ -490,6 +534,7 @@ export default function CourseCard({
           setAbsenceAnnouncement("");
           return;
         }
+        restoreAbsenceFocusRef.current = true;
         setAbsenceAnnouncement(
           formatAbsenceAnnouncement(course.name, selectedDateKey, outcome),
         );
@@ -499,12 +544,18 @@ export default function CourseCard({
         setAbsenceSaving(false);
       }
     },
-    [course, onToggleAbsence, selectedDateKey, userName],
+    [absenceSaving, course, onToggleAbsence, selectedDateKey, userName],
   );
 
   useEffect(() => {
     setAbsenceAnnouncement("");
   }, [selectedDateKey]);
+
+  useEffect(() => {
+    if (!restoreAbsenceFocusRef.current) return;
+    absenceButtonRef.current?.focus();
+    restoreAbsenceFocusRef.current = false;
+  });
 
   return (
     <article
@@ -742,19 +793,17 @@ export default function CourseCard({
           {swapForThisTerm ? (
             <>
               {/* Falls User den Ursprungstermin noch nicht abgesagt hat → Absage-Button trotzdem anzeigen */}
-              {swapForThisTerm.status === "pending" &&
-                originallyParticipant && (
+              {swapPendingAbsenceAction && (
                   <CourseTermActionButton
-                    action={hasCancelled ? "Absage zurücknehmen" : "Termin absagen"}
+                    ref={absenceButtonRef}
+                    action={swapPendingAbsenceAction.action}
                     courseName={course.name}
                     termIso={selectedDateKey}
                     labelExtras={termActionExtras}
                     className="danger"
                     busy={absenceSaving}
-                    disabled={absenceSaving}
-                    onClick={() =>
-                      handleToggleAbsence(hasCancelled ? "undo" : "cancelled")
-                    }
+                    inactive={absenceSaving}
+                    onClick={() => handleToggleAbsence(swapPendingAbsenceAction.outcome)}
                   />
                 )}
 
@@ -794,41 +843,17 @@ export default function CourseCard({
             </>
           ) : (
             <>
-              {isShortNotice ? (
+              {primaryAbsenceAction ? (
                 <CourseTermActionButton
-                  action="Absage zurücknehmen"
+                  ref={absenceButtonRef}
+                  action={primaryAbsenceAction.action}
                   courseName={course.name}
                   termIso={selectedDateKey}
                   labelExtras={termActionExtras}
                   className="danger"
                   busy={absenceSaving}
-                  disabled={absenceSaving}
-                  onClick={() => handleToggleAbsence("undo")}
-                />
-              ) : isParticipant ? (
-                <CourseTermActionButton
-                  action="Termin absagen"
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  className="danger"
-                  busy={absenceSaving}
-                  disabled={absenceSaving}
-                  onClick={() =>
-                    handleToggleAbsence(
-                      originInCutoff ? "shortNoticeCancelled" : "cancelled",
-                    )
-                  }
-                />
-              ) : canUndoRegularAbsence ? (
-                <CourseTermActionButton
-                  action="Absage zurücknehmen"
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  busy={absenceSaving}
-                  disabled={absenceSaving}
-                  onClick={() => handleToggleAbsence("undo")}
+                  inactive={absenceSaving}
+                  onClick={() => handleToggleAbsence(primaryAbsenceAction.outcome)}
                 />
               ) : hasCancelled ? null : (
                 notEnrolledInTermHint

--- a/app/src/components/CourseWeekView.test.tsx
+++ b/app/src/components/CourseWeekView.test.tsx
@@ -30,6 +30,7 @@ const sampleCourse: Course = {
 };
 
 const noop = () => {};
+const noopToggleAbsence = async () => true;
 
 const baseProps = {
   weekAnchor: new Date(2099, 5, 2),
@@ -42,7 +43,7 @@ const baseProps = {
   swaps: [],
   currentUser: baseUser,
   canSeeCourseManagement: false,
-  onToggleAbsence: noop,
+  onToggleAbsence: noopToggleAbsence,
   confirmSwap: noop,
   requestSwap: noop,
   cancelSwap: noop,

--- a/app/src/components/CourseWeekView.tsx
+++ b/app/src/components/CourseWeekView.tsx
@@ -22,7 +22,7 @@ type Props = {
   currentUser: User;
   canSeeCourseManagement: boolean;
   tenantSettings?: TenantSettings;
-  onToggleAbsence: (course: Course, dateIso: string, userName: string) => void;
+  onToggleAbsence: (course: Course, dateIso: string, userName: string) => Promise<boolean>;
   confirmSwap: (
     fromCourse: Course,
     fromDateIso: string,

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -223,7 +223,7 @@ export function useCourseSwaps(
 
       if (hasActiveSwapFromOrigin) {
         alert("Absagen nicht möglich, solange ein aktiver Tausch vom Ursprungstermin besteht.");
-        return;
+        return false;
       }
 
       const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
@@ -245,7 +245,7 @@ export function useCourseSwaps(
             `Achtung: Für diesen Termin existiert eine Warteliste (${waitlist.length} Person(en)). ` +
               `Deine Absage hat direkte Auswirkungen – jemand rückt automatisch nach. Möchtest du fortfahren?`,
           );
-          if (!proceed) return;
+          if (!proceed) return false;
         }
       }
 
@@ -266,7 +266,7 @@ export function useCourseSwaps(
       if (!isIn && !isSn) {
         if (activePastCount > 0) {
           alert("Diese Absage kann nicht mehr zurückgenommen werden, weil ein aktiver Tausch in der Vergangenheit liegt.");
-          return;
+          return false;
         }
         const warningParts: string[] = [
           "Absage zurücknehmen und wieder am Termin teilnehmen?",
@@ -279,7 +279,7 @@ export function useCourseSwaps(
           warningParts.push(`Aktive zukünftige Tausche (${activeFutureCount}) werden aufgehoben.`);
         }
         const proceed = confirm(warningParts.join(" "));
-        if (!proceed) return;
+        if (!proceed) return false;
         if (originSwaps.length > 0) {
           await cleanupAllSwapsFromOrigin(course.id, dateIso, userName);
         }
@@ -312,7 +312,7 @@ export function useCourseSwaps(
       } else {
         if (nextParticipants.length >= maxCapacity) {
           alert("Dieser Termin ist inzwischen voll – Rücknahme nicht möglich.");
-          return;
+          return false;
         }
         nextParticipants = addUserUniqueCaseInsensitive(nextParticipants, userName);
       }
@@ -342,10 +342,12 @@ export function useCourseSwaps(
         await fetchData();
       }
 
+      return true;
     } catch (err) {
         console.error('Error in onToggleAbsence:', err);
         alert("Fehler beim Speichern der Absage. Bitte erneut versuchen.");
         await fetchData();
+        return false;
       }
     },
     // courses, currentUser.nickname kept so callback updates when they change

--- a/app/src/shared/courseStatus.test.ts
+++ b/app/src/shared/courseStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   courseEndDateIso,
+  lastScheduledOccurrenceIso,
   getInactiveGraceLastDayIso,
   hasUpcomingCourseOccurrences,
   isCourseInInactiveGracePeriod,
@@ -24,6 +25,22 @@ const baseCourse: Course = {
 describe("courseStatus", () => {
   it("ermittelt Kursende aus seriesEndDate", () => {
     expect(courseEndDateIso({ ...baseCourse, seriesEndDate: "2026-05-10" })).toBe("2026-05-10");
+  });
+
+  it("lastScheduledOccurrenceIso nutzt nur dates ohne seriesEndDate", () => {
+    expect(
+      lastScheduledOccurrenceIso({
+        ...baseCourse,
+        seriesEndDate: "2026-06-07",
+        dates: [],
+      }),
+    ).toBeUndefined();
+    expect(
+      lastScheduledOccurrenceIso({
+        ...baseCourse,
+        dates: ["2026-05-10", "2026-06-14"],
+      }),
+    ).toBe("2026-06-14");
   });
 
   it("prüft Nachlauf für inaktive Kurse", () => {

--- a/app/src/shared/courseStatus.test.ts
+++ b/app/src/shared/courseStatus.test.ts
@@ -28,16 +28,9 @@ describe("courseStatus", () => {
   });
 
   it("lastScheduledOccurrenceIso nutzt nur dates ohne seriesEndDate", () => {
+    expect(lastScheduledOccurrenceIso({ dates: [] })).toBeUndefined();
     expect(
       lastScheduledOccurrenceIso({
-        ...baseCourse,
-        seriesEndDate: "2026-06-07",
-        dates: [],
-      }),
-    ).toBeUndefined();
-    expect(
-      lastScheduledOccurrenceIso({
-        ...baseCourse,
         dates: ["2026-05-10", "2026-06-14"],
       }),
     ).toBe("2026-06-14");

--- a/shared/src/courseStatus.ts
+++ b/shared/src/courseStatus.ts
@@ -62,6 +62,18 @@ export function courseEndDateIso(
   return trimmed[0];
 }
 
+/** Letzter geplanter Termin nur aus `dates` (ohne seriesEndDate-Fallback). */
+export function lastScheduledOccurrenceIso(
+  course: Pick<Course, "dates">,
+): string | undefined {
+  const raw = course.dates ?? [];
+  const valid = raw.filter((d) => typeof d === "string" && ISO_DATE_ONLY.test(d.trim()));
+  if (valid.length === 0) return undefined;
+  const trimmed = valid.map((d) => d.trim());
+  trimmed.sort((a, b) => b.localeCompare(a));
+  return trimmed[0];
+}
+
 export function getInactiveGraceLastDayIso(
   course: Pick<Course, "seriesEndDate" | "visibleUntil" | "dates" | "status">,
   settings?: TenantSettings,


### PR DESCRIPTION
## Summary

- Label term `<select>` for screen readers (`Termin für …`) while keeping visible label **Termine**
- Introduce `CourseTermActionButton` with descriptive `aria-label` (action, course, date, swap status, cutoff)
- Announce absence toggle results via `aria-live` region; keep focus on absence button after save
- Fix phantom „letzter Termin“ option when `dates` is empty but weekday falls outside block range
- `onToggleAbsence` returns `Promise<boolean>` for UI feedback on success/abort

Part of #171 (parent stays open).

Closes #196

## Test plan

- [x] `CourseCard.test.tsx` (19 tests)
- [x] `CourseWeekView.test.tsx` (mock signature fix)
- [x] `courseStatus.test.ts` / `lastScheduledOccurrenceIso`
- [ ] VoiceOver: term select reads course context once, not „Termine“ twice
- [ ] VoiceOver: action buttons include swap status/cutoff in one label (no duplicate date via `aria-describedby`)
- [ ] VoiceOver: „Termin absagen“ → live „Speichere …“ → „Termin abgesagt …“, focus stays on „Absage zurücknehmen“
- [ ] No phantom last-term option for empty weekday in bounded block


Made with [Cursor](https://cursor.com)