### PR TITLE
Extract accessible CourseSwapModal with dialog semantics (#195)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -35,6 +35,10 @@ body {
   border: 0;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .skip-links {
   margin: 0;
   padding: 0;
@@ -644,6 +648,26 @@ button:focus-visible,
 a:focus-visible {
   outline: 3px solid #93c5fd;
   outline-offset: 2px;
+}
+
+/*
+ * Modals use a focus trap with programmatic .focus(), which often skips :focus-visible.
+ * Show rings on :focus inside .modal; hide again for pointer clicks on links/buttons.
+ */
+.modal :is(
+  button,
+  a,
+  input,
+  select,
+  textarea,
+  [tabindex]:not([tabindex="-1"])
+):focus {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
+}
+
+.modal :is(button, a):focus:not(:focus-visible) {
+  outline: none;
 }
 
 .not-enrolled {

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -42,6 +42,13 @@ const baseSwap: Swap = {
 const selectedTermActionName = (action: string) =>
   new RegExp(`${action}, yoga basic, 16\\.06\\.2099`, "i");
 
+function openSwapModal() {
+  const [swapButton] = screen.getAllByRole("button", {
+    name: selectedTermActionName("Tauschen anfragen"),
+  });
+  fireEvent.click(swapButton);
+}
+
 function renderCourseCard(overrides: Partial<React.ComponentProps<typeof CourseCard>> = {}) {
   const now = new Date("2099-06-10T10:00:00Z");
   const dates = [new Date("2099-06-16T10:00:00Z")];
@@ -385,6 +392,26 @@ describe("CourseCard", () => {
     expect(screen.queryByText(/folgt/i)).not.toBeInTheDocument();
   });
 
+  it("öffnet das Swap-Modal aus der Kurskarte", () => {
+    const alternativeCourse: Course = {
+      ...baseCourse,
+      id: 2,
+      name: "Yoga Abend",
+      dates: ["2099-06-20"],
+      participants: [],
+    };
+
+    renderCourseCard({
+      allCourses: [baseCourse, alternativeCourse],
+    });
+
+    openSwapModal();
+
+    expect(
+      screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic, 16\.06\.2099/i }),
+    ).toBeInTheDocument();
+  });
+
   it("öffnet das Swap-Modal und ruft confirmSwap bzw. requestSwap korrekt auf", () => {
     const confirmSwap = vi.fn();
     const requestSwap = vi.fn();
@@ -418,7 +445,8 @@ describe("CourseCard", () => {
     });
     fireEvent.click(swapButton);
 
-    expect(screen.getByText(/Tauschanfrage starten/i)).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic, 16\.06\.2099/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Tauschanfrage starten/i })).toBeInTheDocument();
 
     // Es gibt mindestens einen freien Ersatztermin
     expect(screen.getByText(/Es stehen 1 freie Termin\(e\) zur Auswahl\./i)).toBeInTheDocument();
@@ -427,7 +455,9 @@ describe("CourseCard", () => {
 
     const freeSlotsHint = screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i });
     fireEvent.click(freeSlotsHint);
-    expect(screen.getByRole("note")).toHaveTextContent(/gleichzeitig von deinem aktuellen Termin ab/i);
+    expect(screen.getByRole("region", { name: /Freie Tauschtermine/i })).toHaveTextContent(
+      /gleichzeitig von deinem aktuellen Termin ab/i,
+    );
 
     // Button ist deaktiviert und bleibt es auch, da keine Auswahl möglich ist
     const confirmButton = screen.getByRole("button", { name: /Bestätigen/i });
@@ -479,7 +509,8 @@ describe("CourseCard", () => {
     });
     fireEvent.click(swapButtons[swapButtons.length - 1]);
 
-    expect(screen.getByText(/Tauschanfrage starten/i)).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic, 16\.06\.2099/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Tauschanfrage starten/i })).toBeInTheDocument();
     expect(document.querySelector('option[value^="2099-06-21T"]')).toBeInTheDocument();
     expect(document.querySelector('option[value^="2099-06-20T"]')).not.toBeInTheDocument();
   });

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
+import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -27,6 +27,7 @@ import {
 import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
 import { weekdayLabelDe } from "../lib/weekdayLabels";
 import type { SwapSettings } from "../types";
+import CourseSwapModal from "./CourseSwapModal";
 
 type Props = {
   course: Course;
@@ -156,37 +157,6 @@ function formatAbsenceAnnouncement(
   }
 }
 
-function SwapModalHint({ label, children }: { label: string; children: ReactNode }) {
-  const hintId = useId();
-  const [open, setOpen] = useState(false);
-
-  return (
-    <span className="swap-modal-hint-wrap">
-      <button
-        type="button"
-        className="studio-field-hint"
-        title={label}
-        aria-expanded={open}
-        aria-controls={hintId}
-        aria-label={`Hilfe: ${label}`}
-        onMouseDown={(event) => event.preventDefault()}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          setOpen((prev) => !prev);
-        }}
-      >
-        ?
-      </button>
-      {open && (
-        <div id={hintId} role="note" className="studio-field-hint-popover swap-modal-hint-popover">
-          {children}
-        </div>
-      )}
-    </span>
-  );
-}
-
 export default function CourseCard({
   course,
   allCourses,
@@ -213,8 +183,6 @@ export default function CourseCard({
   const [selectedDate, setSelectedDate] = useState<string>(
     () => (initialSelectedDate ?? dates[0])?.toISOString() || "",
   );
-  const [swapDateIso, setSwapDateIso] = useState<string | null>(null);
-  const [swapDateIsoWaitlist, setSwapDateIsoWaitlist] = useState<string | null>(null);
   const [showSwapModal, setShowSwapModal] = useState(false);
   const [absenceSaving, setAbsenceSaving] = useState(false);
   const [absenceAnnouncement, setAbsenceAnnouncement] = useState("");
@@ -557,6 +525,16 @@ export default function CourseCard({
     restoreAbsenceFocusRef.current = false;
   });
 
+  const openSwapModal = useCallback(() => {
+    setShowSwapModal(true);
+  }, []);
+
+  const closeSwapModal = useCallback(() => {
+    setShowSwapModal(false);
+  }, []);
+
+  const swapModalTitle = hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten";
+
   return (
     <article
       className={`course-card${participantActionsLocked ? " course-card--inactive-participant" : ""}`}
@@ -866,11 +844,7 @@ export default function CourseCard({
                   termIso={selectedDateKey}
                   labelExtras={termActionExtras}
                   className="secondary"
-                  onClick={() => {
-                    setSwapDateIso(null);
-                    setSwapDateIsoWaitlist(null);
-                    setShowSwapModal(true);
-                  }}
+                  onClick={openSwapModal}
                 />
               )}
               {showCutoffHint && (
@@ -890,11 +864,7 @@ export default function CourseCard({
                   labelExtras={termActionExtras}
                   className="secondary"
                   title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                  onClick={() => {
-                    setSwapDateIso(null);
-                    setSwapDateIsoWaitlist(null);
-                    setShowSwapModal(true);
-                  }}
+                  onClick={openSwapModal}
                 />
               )}
         </div>
@@ -922,11 +892,7 @@ export default function CourseCard({
                 termIso={selectedDateKey}
                 labelExtras={termActionExtras}
                 className="secondary"
-                onClick={() => {
-                  setSwapDateIso(null);
-                  setSwapDateIsoWaitlist(null);
-                  setShowSwapModal(true);
-                }}
+                onClick={openSwapModal}
               />
               {hasPendingRequestsFromOrigin && (
                 <CourseTermActionButton
@@ -936,11 +902,7 @@ export default function CourseCard({
                   labelExtras={termActionExtras}
                   className="secondary"
                   title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                  onClick={() => {
-                    setSwapDateIso(null);
-                    setSwapDateIsoWaitlist(null);
-                    setShowSwapModal(true);
-                  }}
+                  onClick={openSwapModal}
                 />
               )}
             </>
@@ -1010,147 +972,23 @@ export default function CourseCard({
           ))}
         </div>
       )}
-      {/* Swap-Modal */}
       {(canUseFullTermActions || canSwapFromPastCancelled) && showSwapModal && (
-        <div className="modal-backdrop">
-          <div className="modal">
-            <h4>
-              {hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten"}
-            </h4>
-            <p>
-              Ausgewählter Termin:{" "}
-              <strong>
-                {new Date(selectedDate).toLocaleDateString()}
-              </strong>{" "}
-              · {course.name}
-            </p>
-
-            {availableSwapDates.length > 0 || waitlistDates.length > 0 ? (
-              <>
-                <div className="swap-modal-section-head">
-                  <span className="swap-modal-section-title">Freie Termine</span>
-                  <SwapModalHint label="Freie Tauschtermine">
-                    <p>
-                      Termine mit freien Plätzen zwischen{" "}
-                      <strong>
-                        {swapWindow.minOffsetDays} und {swapWindow.maxOffsetDays} Tagen
-                      </strong>{" "}
-                      nach deinem Kurstermin (nur in der Zukunft). Mit der Bestätigung eines Zieltermins
-                      meldest du dich gleichzeitig von deinem aktuellen Termin ab.
-                    </p>
-                  </SwapModalHint>
-                </div>
-                {availableSwapDates.length > 0 ? (
-                  <>
-                    <p className="muted">
-                      Es stehen {availableSwapDates.length} freie Termin(e) zur Auswahl.
-                    </p>
-                    <select
-                      value={swapDateIso ?? ""}
-                      onChange={(e) => {
-                        setSwapDateIso(e.target.value || null);
-                        setSwapDateIsoWaitlist(null);
-                      }}
-                    >
-                      <option value="" disabled>
-                        Bitte freien Termin auswählen…
-                      </option>
-                      {availableSwapDates.map((swapDate, idx) => (
-                        <option key={idx} value={swapDate.date.toISOString()}>
-                          {new Intl.DateTimeFormat("de-DE", {
-                            year: "numeric",
-                            month: "2-digit",
-                            day: "2-digit",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          }).format(swapDate.date)}
-                        </option>
-                      ))}
-                    </select>
-                  </>
-                ) : (
-                  <p className="muted">Derzeit keine freien Termine im Tauschfenster.</p>
-                )}
-
-                <div className="swap-modal-section-head">
-                  <span className="swap-modal-section-title">Warteliste</span>
-                  <SwapModalHint label="Warteliste im Tauschdialog">
-                    <p>
-                      Ausgebuchte Termine im gleichen Zeitfenster (
-                      <strong>
-                        {swapWindow.minOffsetDays} bis {swapWindow.maxOffsetDays} Tage
-                      </strong>{" "}
-                      nach deinem Kurstermin). Die Anfrage landet auf der Warteliste — noch ohne feste
-                      Buchung.
-                    </p>
-                  </SwapModalHint>
-                </div>
-                {waitlistDates.length > 0 ? (
-                  <>
-                    <p className="muted">
-                      {waitlistDates.length} belegte Termin(e) mit Wartelisten-Option:
-                    </p>
-                    <select
-                      value={swapDateIsoWaitlist ?? ""}
-                      onChange={(e) => {
-                        setSwapDateIsoWaitlist(e.target.value || null);
-                        setSwapDateIso(null);
-                      }}
-                    >
-                      <option value="" disabled>
-                        Bitte belegten Termin wählen…
-                      </option>
-                      {waitlistDates.map((waitlistDate, idx) => (
-                        <option key={idx} value={waitlistDate.date.toISOString()}>
-                          {new Intl.DateTimeFormat("de-DE", {
-                            year: "numeric",
-                            month: "2-digit",
-                            day: "2-digit",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          }).format(waitlistDate.date)}
-                        </option>
-                      ))}
-                    </select>
-                  </>
-                ) : (
-                  <p className="muted">Derzeit keine belegten Termine mit Wartelisten-Option.</p>
-                )}
-              </>
-            ) : (
-              <p className="muted">Keine passenden Ersatztermine verfügbar</p>
-            )}
-
-            <div className="modal-actions">
-              <button onClick={() => setShowSwapModal(false)}>Schließen</button>
-              <button
-                className="primary"
-                onClick={() => {
-                  // jetzt wird direkt in CourseList eingetragen/ausgetragen
-                  if (swapDateIso) {
-                    const target = availableSwapDates.find(
-                      (opt) => opt.date.toISOString() === swapDateIso
-                    );
-                    if (target) {
-                      confirmSwap(course, selectedDateKey, target.course.id, toDateKey(target.date), userName);
-                    }
-                  } else if (swapDateIsoWaitlist) {
-                    const target = waitlistDates.find(
-                      (opt) => opt.date.toISOString() === swapDateIsoWaitlist
-                    );
-                    if (target) {
-                      requestSwap(course, selectedDateKey, target.course.id, toDateKey(target.date), userName);
-                    }
-                  }
-                  setShowSwapModal(false);
-                }}
-                disabled={!swapDateIso && !swapDateIsoWaitlist} // 👉 Button erst aktiv nach Auswahl
-              >
-                Bestätigen
-              </button>
-            </div>
-          </div>
-        </div>
+        <CourseSwapModal
+          title={swapModalTitle}
+          courseName={course.name}
+          originTermIso={selectedDateKey}
+          originTermDisplay={new Date(selectedDate).toLocaleDateString()}
+          swapWindow={swapWindow}
+          availableSwapDates={availableSwapDates}
+          waitlistDates={waitlistDates}
+          onClose={closeSwapModal}
+          onConfirmFree={(targetCourseId, targetDateIso) =>
+            confirmSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
+          }
+          onConfirmWaitlist={(targetCourseId, targetDateIso) =>
+            requestSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
+          }
+        />
       )}
     </article>
   );

--- a/app/src/components/CourseModalFrame.tsx
+++ b/app/src/components/CourseModalFrame.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect } from "react";
 import type { KeyboardEvent, ReactNode, RefObject } from "react";
+import { focusWithVisibleRing } from "../lib/focusWithVisibleRing";
 
 type CourseModalFrameProps = {
   ariaLabel: string;
@@ -21,7 +22,7 @@ export default function CourseModalFrame({
     if (!modalNode) return;
     const active = document.activeElement as Node | null;
     if (active && modalNode.contains(active)) return;
-    modalNode.focus();
+    focusWithVisibleRing(modalNode);
   }, [modalRef]);
 
   return (

--- a/app/src/components/CourseSwapModal.test.tsx
+++ b/app/src/components/CourseSwapModal.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import CourseSwapModal from "./CourseSwapModal";
+import type { Course } from "shared/types";
+
+const baseCourse: Course = {
+  tenantId: "default-tenant",
+  id: 1,
+  name: "Yoga Basic",
+  weekday: "Monday",
+  time: "10:00",
+  capacity: 10,
+  participants: ["alice"],
+  dates: ["2099-06-16"],
+};
+
+const alternativeCourse: Course = {
+  ...baseCourse,
+  id: 2,
+  name: "Yoga Abend",
+  dates: ["2099-06-20"],
+  participants: [],
+};
+
+const swapWindow = { minOffsetDays: -7, maxOffsetDays: 7 };
+
+const freeTargetDate = new Date("2099-06-20T10:00:00Z");
+
+function renderSwapModal(
+  overrides: Partial<React.ComponentProps<typeof CourseSwapModal>> = {},
+) {
+  const onConfirmFree = vi.fn();
+  const onConfirmWaitlist = vi.fn();
+  const onClose = vi.fn();
+
+  render(
+    <CourseSwapModal
+      title="Tauschanfrage starten"
+      courseName={baseCourse.name}
+      originTermIso="2099-06-16"
+      originTermDisplay="16.6.2099"
+      swapWindow={swapWindow}
+      availableSwapDates={[{ course: alternativeCourse, date: freeTargetDate }]}
+      waitlistDates={[]}
+      onConfirmFree={onConfirmFree}
+      onConfirmWaitlist={onConfirmWaitlist}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+
+  return { onConfirmFree, onConfirmWaitlist, onClose };
+}
+
+describe("CourseSwapModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("rendert Dialog mit aria-label und Titel", () => {
+    renderSwapModal();
+
+    expect(
+      screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic, 16\.06\.2099/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Tauschanfrage starten/i })).toBeInTheDocument();
+  });
+
+  it("verknüpft Hilfe-Buttons mit beschreibendem Text für Screenreader", () => {
+    renderSwapModal();
+
+    const freeSlotsHint = screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i });
+    const describedBy = freeSlotsHint.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      /gleichzeitig von deinem aktuellen Termin ab/i,
+    );
+  });
+
+  it("meldet Hilfetext beim Öffnen über aria-live", () => {
+    renderSwapModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i }));
+    const liveAnnouncements = screen
+      .getAllByRole("status")
+      .filter((node) => node.textContent?.includes("gleichzeitig von deinem aktuellen Termin ab"));
+    expect(liveAnnouncements.length).toBeGreaterThan(0);
+    expect(screen.getByRole("region", { name: /Freie Tauschtermine/i })).toBeVisible();
+  });
+
+  it("blendet Hilfe-Popover standardmäßig aus und schließt es wieder", () => {
+    renderSwapModal();
+
+    expect(screen.queryByRole("region", { name: /Freie Tauschtermine/i })).not.toBeInTheDocument();
+
+    const freeSlotsHint = screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i });
+    fireEvent.click(freeSlotsHint);
+    expect(screen.getByRole("region", { name: /Freie Tauschtermine/i })).toBeVisible();
+    expect(freeSlotsHint).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(freeSlotsHint);
+    expect(screen.queryByRole("region", { name: /Freie Tauschtermine/i })).not.toBeInTheDocument();
+    expect(freeSlotsHint).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("zeigt Hilfe-Hinweise und deaktiviert Bestätigen ohne Auswahl", () => {
+    renderSwapModal();
+
+    expect(screen.getByText(/Es stehen 1 freie Termin\(e\) zur Auswahl\./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hilfe: Warteliste im Tauschdialog/i })).toBeInTheDocument();
+
+    const freeSlotsHint = screen.getByRole("button", { name: /Hilfe: Freie Tauschtermine/i });
+    fireEvent.click(freeSlotsHint);
+    expect(screen.getByRole("region", { name: /Freie Tauschtermine/i })).toHaveTextContent(
+      /gleichzeitig von deinem aktuellen Termin ab/i,
+    );
+
+    const confirmButton = screen.getByRole("button", { name: /Bestätigen/i });
+    expect(confirmButton).toBeDisabled();
+    fireEvent.click(confirmButton);
+  });
+
+  it("ruft onClose bei Escape und Schließen auf", () => {
+    const { onClose } = renderSwapModal();
+
+    fireEvent.keyDown(
+      screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic/i }),
+      { key: "Escape" },
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /Schließen/i }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("hält den Fokus im Dialog per Tab", () => {
+    renderSwapModal();
+
+    const dialog = screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic/i });
+    const closeButton = screen.getByRole("button", { name: /Schließen/i });
+    closeButton.focus();
+
+    fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).not.toBe(closeButton);
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it("ruft onConfirmFree nach Terminauswahl auf", () => {
+    const { onConfirmFree, onClose } = renderSwapModal();
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: freeTargetDate.toISOString() },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Bestätigen/i }));
+
+    expect(onConfirmFree).toHaveBeenCalledWith(2, "2099-06-20");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/CourseSwapModal.tsx
+++ b/app/src/components/CourseSwapModal.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useId, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { formatCourseIsoDateDe } from "shared/courseStatus";
+import type { Course } from "shared/types";
+import { toDateKey } from "../lib/dates";
+import { focusWithVisibleRing } from "../lib/focusWithVisibleRing";
+import type { SwapSettings } from "../types";
+import CourseModalFrame from "./CourseModalFrame";
+
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[href]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
+function getFocusableElements(node: HTMLElement): HTMLElement[] {
+  return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+export type SwapTargetOption = {
+  course: Course;
+  date: Date;
+};
+
+type CourseSwapModalProps = {
+  title: string;
+  courseName: string;
+  originTermIso: string;
+  originTermDisplay: string;
+  swapWindow: SwapSettings;
+  availableSwapDates: SwapTargetOption[];
+  waitlistDates: SwapTargetOption[];
+  onConfirmFree: (targetCourseId: number, targetDateIso: string) => void;
+  onConfirmWaitlist: (targetCourseId: number, targetDateIso: string) => void;
+  onClose: () => void;
+};
+
+function SwapModalHint({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description: string;
+  children: ReactNode;
+}) {
+  const descriptionId = useId();
+  const panelId = useId();
+  const [open, setOpen] = useState(false);
+  const [liveMessage, setLiveMessage] = useState("");
+
+  const toggle = () => {
+    setOpen((prev) => {
+      const next = !prev;
+      setLiveMessage(next ? description : "");
+      return next;
+    });
+  };
+
+  return (
+    <span className="swap-modal-hint-wrap">
+      <span id={descriptionId} className="visually-hidden">
+        {description}
+      </span>
+      <span role="status" aria-live="polite" aria-atomic="true" className="visually-hidden">
+        {liveMessage}
+      </span>
+      <button
+        type="button"
+        className="studio-field-hint"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        aria-describedby={descriptionId}
+        aria-label={`Hilfe: ${label}`}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          toggle();
+        }}
+      >
+        ?
+      </button>
+      {open && (
+        <div
+          id={panelId}
+          role="region"
+          aria-label={label}
+          className="studio-field-hint-popover swap-modal-hint-popover"
+        >
+          {children}
+        </div>
+      )}
+    </span>
+  );
+}
+
+const swapOptionLabel = (date: Date) =>
+  new Intl.DateTimeFormat("de-DE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+
+export default function CourseSwapModal({
+  title,
+  courseName,
+  originTermIso,
+  originTermDisplay,
+  swapWindow,
+  availableSwapDates,
+  waitlistDates,
+  onConfirmFree,
+  onConfirmWaitlist,
+  onClose,
+}: CourseSwapModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [swapDateIso, setSwapDateIso] = useState<string | null>(null);
+  const [swapDateIsoWaitlist, setSwapDateIsoWaitlist] = useState<string | null>(null);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const modalNode = modalRef.current;
+      if (!modalNode) return;
+      event.preventDefault();
+
+      const focusables = getFocusableElements(modalNode);
+      if (focusables.length === 0) {
+        focusWithVisibleRing(modalNode);
+        return;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      const currentIndex = active ? focusables.indexOf(active) : -1;
+      if (currentIndex === -1) {
+        focusWithVisibleRing(focusables[0]);
+        return;
+      }
+
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + focusables.length) % focusables.length
+        : (currentIndex + 1) % focusables.length;
+      focusWithVisibleRing(focusables[nextIndex]);
+    },
+    [onClose],
+  );
+
+  const handleConfirm = () => {
+    if (swapDateIso) {
+      const target = availableSwapDates.find((opt) => opt.date.toISOString() === swapDateIso);
+      if (target) {
+        onConfirmFree(target.course.id, toDateKey(target.date));
+      }
+    } else if (swapDateIsoWaitlist) {
+      const target = waitlistDates.find((opt) => opt.date.toISOString() === swapDateIsoWaitlist);
+      if (target) {
+        onConfirmWaitlist(target.course.id, toDateKey(target.date));
+      }
+    }
+    onClose();
+  };
+
+  return (
+    <CourseModalFrame
+      ariaLabel={`${title}, ${courseName}, ${formatCourseIsoDateDe(originTermIso)}`}
+      title={title}
+      modalRef={modalRef}
+      onKeyDown={handleKeyDown}
+    >
+      <p>
+        Ausgewählter Termin: <strong>{originTermDisplay}</strong> · {courseName}
+      </p>
+
+      {availableSwapDates.length > 0 || waitlistDates.length > 0 ? (
+        <>
+          <div className="swap-modal-section-head">
+            <span className="swap-modal-section-title">Freie Termine</span>
+            <SwapModalHint
+              label="Freie Tauschtermine"
+              description={`Termine mit freien Plätzen zwischen ${swapWindow.minOffsetDays} und ${swapWindow.maxOffsetDays} Tagen nach deinem Kurstermin (nur in der Zukunft). Mit der Bestätigung eines Zieltermins meldest du dich gleichzeitig von deinem aktuellen Termin ab.`}
+            >
+              <p>
+                Termine mit freien Plätzen zwischen{" "}
+                <strong>
+                  {swapWindow.minOffsetDays} und {swapWindow.maxOffsetDays} Tagen
+                </strong>{" "}
+                nach deinem Kurstermin (nur in der Zukunft). Mit der Bestätigung eines Zieltermins meldest
+                du dich gleichzeitig von deinem aktuellen Termin ab.
+              </p>
+            </SwapModalHint>
+          </div>
+          {availableSwapDates.length > 0 ? (
+            <>
+              <p className="muted">
+                Es stehen {availableSwapDates.length} freie Termin(e) zur Auswahl.
+              </p>
+              <select
+                value={swapDateIso ?? ""}
+                onChange={(e) => {
+                  setSwapDateIso(e.target.value || null);
+                  setSwapDateIsoWaitlist(null);
+                }}
+              >
+                <option value="" disabled>
+                  Bitte freien Termin auswählen…
+                </option>
+                {availableSwapDates.map((swapDate, idx) => (
+                  <option key={idx} value={swapDate.date.toISOString()}>
+                    {swapOptionLabel(swapDate.date)}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : (
+            <p className="muted">Derzeit keine freien Termine im Tauschfenster.</p>
+          )}
+
+          <div className="swap-modal-section-head">
+            <span className="swap-modal-section-title">Warteliste</span>
+            <SwapModalHint
+              label="Warteliste im Tauschdialog"
+              description={`Ausgebuchte Termine im gleichen Zeitfenster (${swapWindow.minOffsetDays} bis ${swapWindow.maxOffsetDays} Tage nach deinem Kurstermin). Die Anfrage landet auf der Warteliste — noch ohne feste Buchung.`}
+            >
+              <p>
+                Ausgebuchte Termine im gleichen Zeitfenster (
+                <strong>
+                  {swapWindow.minOffsetDays} bis {swapWindow.maxOffsetDays} Tage
+                </strong>{" "}
+                nach deinem Kurstermin). Die Anfrage landet auf der Warteliste — noch ohne feste Buchung.
+              </p>
+            </SwapModalHint>
+          </div>
+          {waitlistDates.length > 0 ? (
+            <>
+              <p className="muted">
+                {waitlistDates.length} belegte Termin(e) mit Wartelisten-Option:
+              </p>
+              <select
+                value={swapDateIsoWaitlist ?? ""}
+                onChange={(e) => {
+                  setSwapDateIsoWaitlist(e.target.value || null);
+                  setSwapDateIso(null);
+                }}
+              >
+                <option value="" disabled>
+                  Bitte belegten Termin wählen…
+                </option>
+                {waitlistDates.map((waitlistDate, idx) => (
+                  <option key={idx} value={waitlistDate.date.toISOString()}>
+                    {swapOptionLabel(waitlistDate.date)}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : (
+            <p className="muted">Derzeit keine belegten Termine mit Wartelisten-Option.</p>
+          )}
+        </>
+      ) : (
+        <p className="muted">Keine passenden Ersatztermine verfügbar</p>
+      )}
+
+      <div className="modal-actions">
+        <button type="button" onClick={onClose}>
+          Schließen
+        </button>
+        <button
+          type="button"
+          className="primary"
+          onClick={handleConfirm}
+          disabled={!swapDateIso && !swapDateIsoWaitlist}
+        >
+          Bestätigen
+        </button>
+      </div>
+    </CourseModalFrame>
+  );
+}

--- a/app/src/lib/focusWithVisibleRing.ts
+++ b/app/src/lib/focusWithVisibleRing.ts
@@ -1,0 +1,6 @@
+type FocusOptionsWithVisible = FocusOptions & { focusVisible?: boolean };
+
+/** Programmatic focus that requests a visible ring (focus trap / modal open). */
+export function focusWithVisibleRing(element: HTMLElement) {
+  element.focus({ focusVisible: true } as FocusOptionsWithVisible);
+}


### PR DESCRIPTION
## Summary

- Tausch-Modal aus `CourseCard` in `CourseSwapModal` ausgelagert und über `CourseModalFrame` als barrierefreien Dialog umgesetzt (`role="dialog"`, `aria-modal`, beschreibendes `aria-label`, Focus-Trap, Escape, Initialfokus).
- Hilfe-Hinweise (`?`) für Screenreader verbessert: dauerhaft verfügbarer Beschreibungstext via `aria-describedby`, `aria-live` beim Öffnen, sichtbares Popover weiterhin per Toggle.
- Sichtbarer Fokus-Rahmen im Modal auch bei programmatischem Fokus (`focusWithVisibleRing` + CSS).

Teil von #171.

Closes #195

## Test plan

- [ ] Swap-Modal aus Kurskarte öffnen — Dialog-Titel und `aria-label` korrekt
- [ ] Tab bleibt im Modal, Escape und „Schließen“ schließen den Dialog
- [ ] `?`-Hilfe: Popover standardmäßig zu, öffnet/schließt per Klick
- [ ] VoiceOver/NVDA: Hilfetext beim Fokus auf `?` und beim Öffnen hörbar
- [ ] Freien Termin wählen und bestätigen — Tausch funktioniert wie zuvor
- [ ] `npm test -- --run src/components/CourseSwapModal.test.tsx src/components/CourseCard.test.tsx`


Made with [Cursor](https://cursor.com)