### PR TITLE
Block swap cancel when both terms are in the past (#203)

### DIFF
--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -325,6 +325,50 @@ describe("CourseCard", () => {
     });
   });
 
+  it("blendet Tausch abbrechen aus, wenn Ursprung und Ziel vergangen sind", () => {
+    const pastOrigin = "2020-01-06";
+    const pastTarget = "2020-01-13";
+    const course: Course = {
+      ...baseCourse,
+      dates: [pastOrigin],
+      participants: ["alice"],
+    };
+    const targetCourse: Course = {
+      ...baseCourse,
+      id: 2,
+      name: "Yoga Advanced",
+      dates: [pastTarget],
+    };
+    const swaps: Swap[] = [
+      {
+        ...baseSwap,
+        fromDate: pastOrigin,
+        toDate: pastTarget,
+        toCourseId: 2,
+        status: "active",
+      },
+    ];
+
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0));
+    renderCourseCard({
+      course,
+      allCourses: [course, targetCourse],
+      dates: [new Date(`${pastOrigin}T12:00:00.000Z`)],
+      overrides: [
+        {
+          courseId: 1,
+          date: pastOrigin,
+          participants: [],
+          swapped: ["alice"],
+        },
+      ],
+      swaps,
+      includePastTermsInSelect: true,
+    });
+
+    expect(screen.queryByRole("button", { name: /Tausch abbrechen/i })).not.toBeInTheDocument();
+  });
+
   it("ruft cancelSwap auf, wenn 'Tauschanfragen abbrechen' geklickt wird", () => {
     const cancelSwap = vi.fn();
     const swaps: Swap[] = [baseSwap];

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -12,6 +12,7 @@ import {
 } from "shared/courseStatus";
 import { resolveSwapWindow } from "shared/tenantSettings";
 import {
+  canCancelSwap,
   canCreateSwapFromOrigin,
   hasEffectiveCancellation,
   isShortNoticeCancelled,
@@ -369,6 +370,10 @@ export default function CourseCard({
       ),
     [swaps, userName, course.id],
   );
+  const cancellableUserSwapsOnCourse = useMemo(
+    () => userSwapsOnCourse.filter((swap) => canCancelSwap(swap, allCourses)),
+    [userSwapsOnCourse, allCourses],
+  );
   const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
   const isSelectedTermExcluded = isExcludedCourseDate(course, selectedDateKey);
   const showPastGraceMarker =
@@ -394,12 +399,14 @@ export default function CourseCard({
     participants,
     originallyParticipant,
   });
+  const swapForThisTermCancellable =
+    swapForThisTerm != null && canCancelSwap(swapForThisTerm, allCourses);
   const showPastTermSwapActions =
     !participantActionsLocked &&
     !isSelectedTermExcluded &&
     isPastOccurrence &&
     (isParticipant || originallyParticipant || hasCancelled) &&
-    (swapForThisTerm != null || canSwapFromPastCancelled);
+    (swapForThisTermCancellable || canSwapFromPastCancelled);
   const excludedTermNotice = showExcludedTermMarker
     ? "Dieser Termin entfällt — vom Studio abgesagt."
     : null;
@@ -785,39 +792,40 @@ export default function CourseCard({
                   />
                 )}
 
-              {(() => {
-                const cancelSwapAction =
-                  swapForThisTerm.status === "pending"
-                    ? "Tauschanfragen abbrechen"
-                    : swapForThisTerm.status === "active" &&
-                        swapForThisTerm.toCourseId === course.id &&
-                        isWithinCancellationSwapCutoff(
-                          swapForThisTerm.toDate,
-                          allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
-                          cutoffMinutes,
-                        )
-                      ? isShortNoticeCancelled(
-                          overrides.find(
-                            (o) =>
-                              o.courseId === swapForThisTerm.toCourseId &&
-                              o.date === swapForThisTerm.toDate,
-                          ),
-                          userName,
-                        )
-                        ? "Tauschabsage zurücknehmen"
-                        : "Am Zieltermin kurzfristig absagen"
-                      : "Tausch abbrechen";
-                return (
-                  <CourseTermActionButton
-                    action={cancelSwapAction}
-                    courseName={course.name}
-                    termIso={selectedDateKey}
-                    labelExtras={termActionExtras}
-                    className="secondary danger"
-                    onClick={() => cancelSwap(swapForThisTerm, course.id)}
-                  />
-                );
-              })()}
+              {swapForThisTermCancellable &&
+                (() => {
+                  const cancelSwapAction =
+                    swapForThisTerm.status === "pending"
+                      ? "Tauschanfragen abbrechen"
+                      : swapForThisTerm.status === "active" &&
+                          swapForThisTerm.toCourseId === course.id &&
+                          isWithinCancellationSwapCutoff(
+                            swapForThisTerm.toDate,
+                            allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
+                            cutoffMinutes,
+                          )
+                        ? isShortNoticeCancelled(
+                            overrides.find(
+                              (o) =>
+                                o.courseId === swapForThisTerm.toCourseId &&
+                                o.date === swapForThisTerm.toDate,
+                            ),
+                            userName,
+                          )
+                          ? "Tauschabsage zurücknehmen"
+                          : "Am Zieltermin kurzfristig absagen"
+                        : "Tausch abbrechen";
+                  return (
+                    <CourseTermActionButton
+                      action={cancelSwapAction}
+                      courseName={course.name}
+                      termIso={selectedDateKey}
+                      labelExtras={termActionExtras}
+                      className="secondary danger"
+                      onClick={() => cancelSwap(swapForThisTerm, course.id)}
+                    />
+                  );
+                })()}
             </>
           ) : (
             <>
@@ -871,7 +879,7 @@ export default function CourseCard({
 
       ) : showPastTermSwapActions ? (
         <div className="actions">
-          {swapForThisTerm ? (
+          {swapForThisTermCancellable ? (
             <CourseTermActionButton
               action={
                 swapForThisTerm.status === "pending"
@@ -909,7 +917,7 @@ export default function CourseCard({
           ) : null}
         </div>
       ) : isSelectedTermExcluded && includePastTermsInSelect ? (
-        swapForThisTerm ? (
+        swapForThisTermCancellable ? (
           <div className="actions">
             <CourseTermActionButton
               action={
@@ -931,7 +939,7 @@ export default function CourseCard({
         </p>
       ) : !participantActionsLocked && !hasNoUpcomingDates ? (
         <>
-          {swapForWaitlist ? (
+          {swapForWaitlist && canCancelSwap(swapForWaitlist, allCourses) ? (
             <div className="actions">
               <CourseTermActionButton
                 action="Tauschanfrage abbrechen"
@@ -948,9 +956,9 @@ export default function CourseCard({
         </>
       ) : null}
 
-      {participantActionsLocked && userSwapsOnCourse.length > 0 && (
+      {participantActionsLocked && cancellableUserSwapsOnCourse.length > 0 && (
         <div className="actions course-inactive-swap-actions">
-          {userSwapsOnCourse.map((swap) => (
+          {cancellableUserSwapsOnCourse.map((swap) => (
             <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
               <CourseTermActionButton
                 action={swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}

--- a/app/src/components/useCourseSwaps.test.ts
+++ b/app/src/components/useCourseSwaps.test.ts
@@ -366,6 +366,57 @@ describe("useCourseSwaps", () => {
     expect(processPromotions).toHaveBeenCalledTimes(1);
   });
 
+  it("cancelSwap blockiert Abbrechen bei vergangenem Ursprung und Ziel", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0));
+
+    const targetCourse: Course = {
+      ...course,
+      id: 2,
+      dates: ["2020-01-13"],
+    };
+    const historicalSwap: Swap = {
+      ...pendingSwap,
+      fromDate: "2020-01-06",
+      toDate: "2020-01-13",
+      toCourseId: 2,
+      status: "active",
+    };
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn();
+    const setSwaps = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course, targetCourse],
+        [baseOverride],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [historicalSwap],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.cancelSwap(historicalSwap, 1);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Vergangenheit"),
+    );
+    expect(deleteSwap).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+
   it("confirmSwap löst übrige pending Anfragen vom selben Ursprung auf", async () => {
     const fetchData = vi.fn().mockResolvedValue(undefined);
     const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) =>

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -4,6 +4,7 @@ import { overrideCourseUidFields, swapCourseUidFields } from "../lib/courseUid";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
   addUserUniqueCaseInsensitive,
+  canCancelSwap,
   canCreateSwapFromOrigin,
   includesUserCaseInsensitive,
   isShortNoticeCancelled,
@@ -609,6 +610,12 @@ export function useCourseSwaps(
     async (swap: Swap, clickedCourseId: number) => {
       try {
         console.log("[cancelSwap use] START", { swap, clickedCourseId, swaps });
+        if (!canCancelSwap(swap, courses)) {
+          alert(
+            "Dieser Tausch kann nicht mehr abgebrochen werden — Ursprung und Zieltermin liegen in der Vergangenheit.",
+          );
+          return;
+        }
         const isOrigin = swap.fromCourseId === clickedCourseId;
         const targetCourse = courses.find((c) => c.id === swap.toCourseId);
         const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);

--- a/app/src/lib/courseTermActions.ts
+++ b/app/src/lib/courseTermActions.ts
@@ -4,12 +4,14 @@ import {
 } from "shared/cancellationSwapCutoff";
 import {
   addCalendarDaysIsoUtc,
-  buildCourseOccurrenceLocal,
   courseEndDateIso,
   DEFAULT_INACTIVE_GRACE_DAYS_AFTER_END,
+  isOccurrenceInPast,
   isWithinPostCourseEndGrace,
   toIsoDateUtc,
 } from "shared/courseStatus";
+
+export { isOccurrenceInPast };
 import type { Course, CourseDateOverride, TenantSettings } from "shared/types";
 import { addWeeks, startOfWeekMonday } from "./courseWeek";
 import { isWeekEntirelyInPast, weekRangeKeys } from "./courseWeekOccurrences";
@@ -150,15 +152,6 @@ export function earliestAllowedWeekStart(
   now: Date = new Date(),
 ): Date {
   return computeEarliestWeekAnchor(courses, settings, now);
-}
-
-export function isOccurrenceInPast(
-  isoDate: string,
-  courseTime: string,
-  now: Date = new Date(),
-): boolean {
-  const occurrence = buildCourseOccurrenceLocal(isoDate, courseTime);
-  return occurrence != null && occurrence < now;
 }
 
 /** Vergangener Termin: nur Tausch aus rechtzeitiger Absage (RC), nicht Kurzfrist. */

--- a/app/src/shared/cancellationSwapCutoff.test.ts
+++ b/app/src/shared/cancellationSwapCutoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  canCancelSwap,
   canCreateSwapFromOrigin,
   isShortNoticeCancelled,
   isSwapTargetInCutoffWindow,
@@ -73,5 +74,37 @@ describe("cancellationSwapCutoff", () => {
     expect(
       isShortNoticeCancelled({ shortNoticeCancellations: ["Alice"] }, "alice"),
     ).toBe(true);
+  });
+
+  it("canCancelSwap blocks cancel when origin and target are both past", () => {
+    const courses = [
+      { id: 1, time: "10:00" },
+      { id: 2, time: "10:00" },
+    ];
+    const now = new Date(2026, 0, 1, 12, 0);
+    const swap = {
+      fromCourseId: 1,
+      fromDate: "2020-01-06",
+      toCourseId: 2,
+      toDate: "2020-01-13",
+    };
+
+    expect(canCancelSwap(swap, courses, now)).toBe(false);
+  });
+
+  it("canCancelSwap allows cancel when target is still in the future", () => {
+    const courses = [
+      { id: 1, time: "10:00" },
+      { id: 2, time: "10:00" },
+    ];
+    const now = new Date(2020, 0, 10, 12, 0);
+    const swap = {
+      fromCourseId: 1,
+      fromDate: "2020-01-06",
+      toCourseId: 2,
+      toDate: "2099-06-20",
+    };
+
+    expect(canCancelSwap(swap, courses, now)).toBe(true);
   });
 });

--- a/backend/src/lambdas/deleteSwap/index.test.ts
+++ b/backend/src/lambdas/deleteSwap/index.test.ts
@@ -1,13 +1,13 @@
-import { DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+import { DeleteItemCommand, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { handler } from "./index";
 
-// DynamoDB Mock Setup
 jest.mock("@aws-sdk/client-dynamodb", () => {
   const mockSend = jest.fn();
   return {
     DynamoDBClient: jest.fn(() => ({ send: mockSend })),
     DeleteItemCommand: jest.fn((input) => input),
+    GetItemCommand: jest.fn((input) => input),
     mockSend,
   };
 });
@@ -19,7 +19,11 @@ describe("deleteSwap Lambda", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...OLD_ENV, SWAPS_TABLE: "test-swaps" };
+    process.env = {
+      ...OLD_ENV,
+      SWAPS_TABLE: "test-swaps",
+      COURSES_TABLE: "test-courses",
+    };
     mockSend.mockReset();
   });
 
@@ -31,7 +35,7 @@ describe("deleteSwap Lambda", () => {
     ({
       pathParameters: swapId ? { swapId } : null,
       queryStringParameters: user ? { user } : null,
-    } as any);
+    } as APIGatewayProxyEvent);
 
   test("returns 400 if swapId or user is missing", async () => {
     const event = makeEvent(undefined, "Nia");
@@ -42,20 +46,66 @@ describe("deleteSwap Lambda", () => {
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  test("deletes an existing swap successfully", async () => {
+  test("returns 404 when swap does not exist", async () => {
     mockSend.mockResolvedValueOnce({});
 
-    const event = makeEvent("abc123", "Nia");
+    const event = makeEvent("missing-swap", "Nia");
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body).error).toBe("Swap not found");
+    expect(GetItemCommand).toHaveBeenCalled();
+    expect(DeleteItemCommand).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 when origin and target are both in the past", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          fromDate: { S: "2020-01-06" },
+          toDate: { S: "2020-01-13" },
+          fromCourseId: { S: "1" },
+          toCourseId: { S: "2" },
+        },
+      })
+      .mockResolvedValueOnce({ Item: { time: { S: "10:00" } } })
+      .mockResolvedValueOnce({ Item: { time: { S: "10:00" } } });
+
+    const event = makeEvent("2020-01-06_1_2020-01-13_2", "Nia");
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toContain("Vergangenheit");
+    expect(DeleteItemCommand).not.toHaveBeenCalled();
+  });
+
+  test("deletes an existing swap when target is still in the future", async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Item: {
+          fromDate: { S: "2020-01-06" },
+          toDate: { S: "2099-06-20" },
+          fromCourseId: { S: "1" },
+          toCourseId: { S: "2" },
+        },
+      })
+      .mockResolvedValueOnce({ Item: { time: { S: "10:00" } } })
+      .mockResolvedValueOnce({ Item: { time: { S: "10:00" } } })
+      .mockResolvedValueOnce({});
+
+    const event = makeEvent("2020-01-06_1_2099-06-20_2", "Nia");
     const result = await handler(event);
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body).message).toBe("Swap deleted successfully");
-
     expect(DeleteItemCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         TableName: "test-swaps",
-        Key: { tenantId: { S: "default-tenant" }, user_swapId: { S: "Nia#abc123" } },
-      })
+        Key: {
+          tenantId: { S: "default-tenant" },
+          user_swapId: { S: "Nia#2020-01-06_1_2099-06-20_2" },
+        },
+      }),
     );
   });
 

--- a/backend/src/lambdas/deleteSwap/index.ts
+++ b/backend/src/lambdas/deleteSwap/index.ts
@@ -1,10 +1,27 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+import { DeleteItemCommand, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { canCancelSwap } from "@yogaswap/shared";
 import { getTenantContext } from "../shared/tenantContext";
 import { dynamoClient } from "../shared/dynamoClient";
 import { getDelegationErrorResponse } from "../shared/delegation";
 
 const client = dynamoClient;
+
+async function loadCourseTime(
+  tenantId: string,
+  coursesTable: string,
+  courseId: string,
+): Promise<string | null> {
+  const response = await client.send(
+    new GetItemCommand({
+      TableName: coursesTable,
+      Key: { tenantId: { S: tenantId }, courseId: { S: courseId } },
+      ConsistentRead: true,
+    }),
+  );
+  if (!response.Item) return null;
+  return response.Item.time?.S ?? "";
+}
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const { tenantId, userId, actingForUserId } = getTenantContext(event);
@@ -14,15 +31,25 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     actingForUserId,
   });
   if (delegationErrorResponse) return delegationErrorResponse;
+
   const swapId = event.pathParameters?.swapId;
   const user = event.queryStringParameters?.user;
-  console.log('DeleteSwap params:', { swapId, user });
-  console.log('deleteSwap tenant context:', { tenantId, userId, actingForUserId });
-  
+  const swapsTable = process.env.SWAPS_TABLE;
+  const coursesTable = process.env.COURSES_TABLE;
+
+  console.log("DeleteSwap params:", { swapId, user });
+  console.log("deleteSwap tenant context:", { tenantId, userId, actingForUserId });
+
   if (!swapId || !user) {
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "Missing swapId or user parameter" }),
+    };
+  }
+  if (!swapsTable) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "SWAPS_TABLE env var is not set" }),
     };
   }
 
@@ -34,24 +61,77 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     swapId,
     user,
   });
-  const command = new DeleteItemCommand({
-    TableName: process.env.SWAPS_TABLE,
-    Key: {
-      tenantId: { S: tenantId },
-      user_swapId: { S: user_swapId },
-    },
-  });
 
   try {
-    console.log('DeleteSwap command:', command.input);
+    const swapItem = await client.send(
+      new GetItemCommand({
+        TableName: swapsTable,
+        Key: {
+          tenantId: { S: tenantId },
+          user_swapId: { S: user_swapId },
+        },
+        ConsistentRead: true,
+      }),
+    );
+
+    if (!swapItem.Item) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: "Swap not found" }),
+      };
+    }
+
+    const fromDate = swapItem.Item.fromDate?.S;
+    const toDate = swapItem.Item.toDate?.S;
+    const fromCourseId = swapItem.Item.fromCourseId?.S;
+    const toCourseId = swapItem.Item.toCourseId?.S;
+
+    if (fromDate && toDate && fromCourseId && toCourseId && coursesTable) {
+      const [fromTime, toTime] = await Promise.all([
+        loadCourseTime(tenantId, coursesTable, fromCourseId),
+        loadCourseTime(tenantId, coursesTable, toCourseId),
+      ]);
+
+      if (fromTime != null && toTime != null) {
+        const swap = {
+          fromCourseId: Number.parseInt(fromCourseId, 10),
+          fromDate,
+          toCourseId: Number.parseInt(toCourseId, 10),
+          toDate,
+        };
+        const courses = [
+          { id: swap.fromCourseId, time: fromTime },
+          { id: swap.toCourseId, time: toTime },
+        ];
+        if (!canCancelSwap(swap, courses)) {
+          return {
+            statusCode: 403,
+            body: JSON.stringify({
+              error:
+                "Dieser Tausch kann nicht mehr abgebrochen werden — Ursprung und Zieltermin liegen in der Vergangenheit.",
+            }),
+          };
+        }
+      }
+    }
+
+    const command = new DeleteItemCommand({
+      TableName: swapsTable,
+      Key: {
+        tenantId: { S: tenantId },
+        user_swapId: { S: user_swapId },
+      },
+    });
+
+    console.log("DeleteSwap command:", command.input);
     await client.send(command);
-    console.log('DeleteSwap success:', { swapId, user });
+    console.log("DeleteSwap success:", { swapId, user });
     return {
       statusCode: 200,
       body: JSON.stringify({ message: "Swap deleted successfully" }),
     };
   } catch (err) {
-    console.error('Error deleting swap:', err);
+    console.error("Error deleting swap:", err);
     return {
       statusCode: 500,
       body: JSON.stringify({ error: "Internal Server Error" }),

--- a/projects/yogaswap/main.tf
+++ b/projects/yogaswap/main.tf
@@ -85,10 +85,11 @@ locals {
     "delete_swap" = {
       name             = "delete-swap"
       file_name        = "deleteSwap.zip"
-      dynamodb_actions = ["dynamodb:DeleteItem"]
-      table_arns       = [module.swaps_table.table_arn]
+      dynamodb_actions = ["dynamodb:DeleteItem", "dynamodb:GetItem"]
+      table_arns       = [module.swaps_table.table_arn, module.courses_table.table_arn]
       tables = {
-        "SWAPS_TABLE" = module.swaps_table.table_name
+        "SWAPS_TABLE"   = module.swaps_table.table_name
+        "COURSES_TABLE" = module.courses_table.table_name
       }
       s3_actions   = []
       s3_resources = []

--- a/shared/src/cancellationSwapCutoff.ts
+++ b/shared/src/cancellationSwapCutoff.ts
@@ -1,5 +1,5 @@
-import { buildCourseOccurrenceLocal } from "./courseStatus";
-import type { CourseDateOverride, TenantSettings } from "./types";
+import { buildCourseOccurrenceLocal, isOccurrenceInPast } from "./courseStatus";
+import type { Course, CourseDateOverride, Swap, TenantSettings } from "./types";
 
 export const DEFAULT_CANCELLATION_SWAP_CUTOFF_MINUTES = 60;
 const MAX_CUTOFF_MINUTES = 24 * 60;
@@ -103,4 +103,27 @@ export function addUserUniqueCaseInsensitive(list: string[], user: string): stri
 export function removeUserCaseInsensitive(list: string[], user: string): string[] {
   const needle = user.toLowerCase();
   return list.filter((entry) => entry.toLowerCase() !== needle);
+}
+
+function resolveCourseTime(courses: Pick<Course, "id" | "time">[], courseId: number): string {
+  return courses.find((course) => course.id === courseId)?.time ?? "";
+}
+
+/** Tausch nicht mehr abbrechen, wenn Ursprung und Ziel vergangen sind (#203). */
+export function canCancelSwap(
+  swap: Pick<Swap, "fromCourseId" | "fromDate" | "toCourseId" | "toDate">,
+  courses: Pick<Course, "id" | "time">[],
+  now: Date = new Date(),
+): boolean {
+  const originPast = isOccurrenceInPast(
+    swap.fromDate,
+    resolveCourseTime(courses, swap.fromCourseId),
+    now,
+  );
+  const targetPast = isOccurrenceInPast(
+    swap.toDate,
+    resolveCourseTime(courses, swap.toCourseId),
+    now,
+  );
+  return !(originPast && targetPast);
 }

--- a/shared/src/courseStatus.ts
+++ b/shared/src/courseStatus.ts
@@ -15,6 +15,16 @@ export function buildCourseOccurrenceLocal(isoDate: string, time: string): Date 
   return new Date(base.getFullYear(), base.getMonth(), base.getDate(), hours, minutes);
 }
 
+/** Termin (Datum + Uhrzeit) liegt in der Vergangenheit. */
+export function isOccurrenceInPast(
+  isoDate: string,
+  courseTime: string,
+  now: Date = new Date(),
+): boolean {
+  const occurrence = buildCourseOccurrenceLocal(isoDate, courseTime);
+  return occurrence != null && occurrence < now;
+}
+
 /** Mindestens ein Termin liegt in der Zukunft (Datum + Uhrzeit). */
 export function hasUpcomingCourseOccurrences(
   dateIsos: string[],


### PR DESCRIPTION
## Summary

- Gemeinsame Regel `canCancelSwap` in `shared`: Abbrechen blockieren, wenn **Ursprung und Zieltermin** vergangen sind (pending und active gleich behandelt).
- UI: Cancel-Buttons in `CourseCard` und Guard in `useCourseSwaps` nur noch bei erlaubtem Abbrechen.
- Backend: `deleteSwap` lädt Swap + Kurszeiten und antwortet mit `403`, falls die Regel greift (Defense in Depth).
- Terraform: `delete_swap`-Lambda erhält `GetItem` auf Swaps/Courses und `COURSES_TABLE`.

Closes #203

## Test plan

- [ ] Vergangener Ursprung + zukünftiger Zieltermin → „Tausch abbrechen“ weiterhin sichtbar und funktionsfähig
- [ ] Beide Termine vergangen → kein Cancel-Button, kein API-Delete
- [ ] Inaktiver Kurs mit historischem Tausch → Cancel-Button fehlt in der Swap-Liste
- [ ] `npm test -- --run src/shared/cancellationSwapCutoff.test.ts src/components/CourseCard.test.tsx src/components/useCourseSwaps.test.ts`
- [ ] `cd backend && npm test -- --testPathPatterns=deleteSwap`


Made with [Cursor](https://cursor.com)