### PR TITLE
Label course card chips and status for screen readers (#197)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -527,6 +527,9 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 .chip {
   background: #f0f0f0;

--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -103,6 +103,21 @@ describe("CourseCard", () => {
     expect(visibleLabel).toHaveAttribute("aria-label", "Termin für Yoga Basic");
   });
 
+  it("verknüpft Teilnehmer-Chips mit beschrifteter Liste", () => {
+    renderCourseCard({
+      overrides: [
+        {
+          ...baseOverride,
+          participants: ["alice", "bob"],
+        },
+      ],
+    });
+
+    expect(screen.getByRole("list", { name: /Teilnehmer/i })).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: /Warteliste/i })).toBeInTheDocument();
+    expect(screen.getByText("bob")).toHaveAttribute("aria-label", "bob, regulär eingetragen");
+  });
+
   it("markiert eigene kurzfristige Absage mit chip-self und short-notice", () => {
     const overrideSn: CourseDateOverride = {
       ...baseOverride,
@@ -114,7 +129,10 @@ describe("CourseCard", () => {
 
     const selfSn = container.querySelector(".chip.chip-self.short-notice");
     expect(selfSn).toHaveTextContent("alice");
-    expect(selfSn?.getAttribute("title")).toMatch(/Du — kurzfristig abgesagt/i);
+    expect(selfSn).toHaveAttribute(
+      "aria-label",
+      "alice, du, kurzfristig abgesagt, Platz bleibt belegt",
+    );
   });
 
   it("zeigt getauschte und kurzfristig abgesagte andere Teilnehmer dezenter als den eigenen Chip", () => {
@@ -132,6 +150,12 @@ describe("CourseCard", () => {
     expect(screen.getByText("bob").closest(".chip")).not.toHaveClass("chip-self");
     expect(screen.getByText("carol").closest(".chip")).toHaveClass("short-notice");
     expect(screen.getByText("carol").closest(".chip")).not.toHaveClass("chip-self");
+    expect(screen.getByText("bob").closest(".chip")).toHaveAttribute("aria-label", "bob, getauscht");
+    expect(screen.getByText("carol").closest(".chip")).toHaveAttribute(
+      "aria-label",
+      "carol, kurzfristig abgesagt, Platz bleibt belegt",
+    );
+    expect(container.querySelector(".chip.chip-self")).toHaveAttribute("aria-label", "alice, du");
   });
 
   it("hebt den eigenen Chip in Teilnehmer- und Warteliste grün hervor", () => {
@@ -146,8 +170,10 @@ describe("CourseCard", () => {
     const selfChips = container.querySelectorAll(".chip.chip-self");
     expect(selfChips).toHaveLength(2);
     expect(selfChips[0]).toHaveTextContent("alice");
-    expect(selfChips[0]).toHaveAttribute("title", "Du");
-    expect(container.querySelector(".chip.wait.chip-self")).toHaveAttribute("title", "Du (Warteliste)");
+    expect(container.querySelector(".chip.wait.chip-self")).toHaveAttribute(
+      "aria-label",
+      "alice, du auf der Warteliste",
+    );
     expect(screen.getByText("bob").closest(".chip")).not.toHaveClass("chip-self");
   });
 
@@ -167,6 +193,7 @@ describe("CourseCard", () => {
     });
 
     expect(screen.getByText("Automatisch inaktiv")).toBeInTheDocument();
+    expect(screen.getByLabelText("Kursstatus: Automatisch inaktiv")).toBeInTheDocument();
     expect(screen.getByText(/automatisch beendet/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
   });
@@ -185,9 +212,9 @@ describe("CourseCard", () => {
       initialSelectedDate: new Date("2099-06-16T10:00:00Z"),
     });
 
-    expect(screen.getByTitle(/Termin entfällt/i)).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /Termin entfällt \(vom Studio abgesagt\)/i })).toBeInTheDocument();
     expect(screen.getByText(/vom Studio abgesagt/i)).toBeInTheDocument();
-    expect(screen.getByText("entfällt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Kapazität entfällt")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Termin absagen/i })).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /6\/16\/2099 \(entfällt\)/i })).toBeInTheDocument();
   });

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -138,6 +138,29 @@ const CourseTermActionButton = forwardRef<HTMLButtonElement, CourseTermActionBut
 
 type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
 
+const TERM_MARKER_EXCLUDED_LABEL = "Termin entfällt (vom Studio abgesagt)";
+const TERM_MARKER_PAST_LABEL = "Vergangener Termin im Nachlauf";
+const TERM_MARKER_CUTOFF_LABEL = "Kurz vor Termin (Cutoff)";
+
+function courseStatusBadgeLabel(autoInactive: boolean): string {
+  return autoInactive ? "Kursstatus: Automatisch inaktiv" : "Kursstatus: Inaktiv";
+}
+
+function participantChipAriaLabel(
+  name: string,
+  { isSelf, isSn, isSwapped }: { isSelf: boolean; isSn: boolean; isSwapped: boolean },
+): string {
+  if (isSn && isSelf) return `${name}, du, kurzfristig abgesagt, Platz bleibt belegt`;
+  if (isSn) return `${name}, kurzfristig abgesagt, Platz bleibt belegt`;
+  if (isSwapped) return `${name}, getauscht`;
+  if (isSelf) return `${name}, du`;
+  return `${name}, regulär eingetragen`;
+}
+
+function waitlistChipAriaLabel(name: string, isSelf: boolean): string {
+  return isSelf ? `${name}, du auf der Warteliste` : `${name}, auf der Warteliste`;
+}
+
 function formatAbsenceAnnouncement(
   courseName: string,
   termIso: string,
@@ -441,6 +464,8 @@ export default function CourseCard({
   const scheduleDescId = useId();
   const termSelectId = useId();
   const termSelectDisabledHintId = useId();
+  const participantsLabelId = useId();
+  const waitlistLabelId = useId();
   const termSelectDisabled = hasNoUpcomingDates && !showLastTermInSelect;
 
   const swapStatusLines = useMemo(
@@ -541,6 +566,8 @@ export default function CourseCard({
   }, []);
 
   const swapModalTitle = hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten";
+  const showAutoInactiveStatusBadge =
+    showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace);
 
   return (
     <article
@@ -580,7 +607,9 @@ export default function CourseCard({
               {showExcludedTermMarker && (
                 <span
                   className="course-term-visual-marker course-term-visual-marker--excluded"
-                  title="Termin entfällt (vom Studio abgesagt)"
+                  role="img"
+                  aria-label={TERM_MARKER_EXCLUDED_LABEL}
+                  title={TERM_MARKER_EXCLUDED_LABEL}
                 >
                   <CalendarX size={12} aria-hidden="true" />
                 </span>
@@ -588,7 +617,9 @@ export default function CourseCard({
               {showPastGraceMarker && (
                 <span
                   className="course-term-visual-marker course-term-visual-marker--past"
-                  title="Vergangener Termin im Nachlauf"
+                  role="img"
+                  aria-label={TERM_MARKER_PAST_LABEL}
+                  title={TERM_MARKER_PAST_LABEL}
                 >
                   <History size={12} aria-hidden="true" />
                 </span>
@@ -596,7 +627,9 @@ export default function CourseCard({
               {showCutoffMarker && (
                 <span
                   className="course-term-visual-marker course-term-visual-marker--cutoff"
-                  title="Kurz vor Termin (Cutoff)"
+                  role="img"
+                  aria-label={TERM_MARKER_CUTOFF_LABEL}
+                  title={TERM_MARKER_CUTOFF_LABEL}
                 >
                   <Clock3 size={12} aria-hidden="true" />
                 </span>
@@ -606,14 +639,13 @@ export default function CourseCard({
           {participantActionsLocked && (
             <span
               className={`course-status-badge ${
-                showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+                showAutoInactiveStatusBadge
                   ? "course-status-badge--auto"
                   : "course-status-badge--inactive"
               }`}
+              aria-label={courseStatusBadgeLabel(showAutoInactiveStatusBadge)}
             >
-              {showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
-                ? "Automatisch inaktiv"
-                : "Inaktiv"}
+              {showAutoInactiveStatusBadge ? "Automatisch inaktiv" : "Inaktiv"}
             </span>
           )}
         </div>
@@ -623,7 +655,9 @@ export default function CourseCard({
         <div className="muted">Kapazität</div>
         <div>
           {showExcludedTermMarker ? (
-            <span className="muted">entfällt</span>
+            <span className="muted" aria-label="Kapazität entfällt">
+              entfällt
+            </span>
           ) : (
             <>
               {participants.length}/{course.capacity}
@@ -683,82 +717,87 @@ export default function CourseCard({
       </div>
 
       <div className="course-row list-row">
-        <div className="label muted">Teilnehmer</div>
-        <div className="chips">
+        <div id={participantsLabelId} className="label muted">
+          Teilnehmer
+        </div>
+        <ul className="chips" aria-labelledby={participantsLabelId}>
           {showExcludedTermMarker ? (
-            <span className="chip muted small">—</span>
+            <li className="chip muted small" aria-label="Keine Teilnehmer, Termin entfällt">
+              —
+            </li>
           ) : (
             <>
-              {participants.length === 0 && <span className="chip">—</span>}
+              {participants.length === 0 && (
+                <li className="chip" aria-label="Keine Teilnehmer eingetragen">
+                  —
+                </li>
+              )}
               {participants.map((name) => {
                 const isSelf = name.toLowerCase() === userNameLower;
                 const isSn = shortNotice.some((n) => n.toLowerCase() === name.toLowerCase());
                 const isSwapped = swapped.includes(name);
+                const chipLabel = participantChipAriaLabel(name, { isSelf, isSn, isSwapped });
                 return (
-                  <span
+                  <li
                     className={`chip${isSelf ? " chip-self" : ""}${
                       isSn ? " short-notice" : isSwapped ? " swapped" : ""
                     }`}
                     key={name}
-                    title={
-                      isSn && isSelf
-                        ? "Du — kurzfristig abgesagt, Platz bleibt belegt"
-                        : isSn
-                          ? "Kurzfristig abgesagt — Platz bleibt belegt"
-                          : isSelf
-                            ? "Du"
-                            : undefined
-                    }
+                    aria-label={chipLabel}
                   >
                     {name}
-                  </span>
+                  </li>
                 );
               })}
               {visibleFreeSpots > 0 &&
                 Array.from({ length: regularFreeSpots }).map((_, idx) => (
-                  <span className="chip free" key={`free-${idx}`}>
+                  <li className="chip free" key={`free-${idx}`} aria-label="Freier Platz">
                     frei
-                  </span>
+                  </li>
                 ))}
               {showOverbookingDetails &&
                 overbookFreeSpots > 0 &&
                 Array.from({ length: overbookFreeSpots }).map((_, idx) => (
-                  <span
+                  <li
                     className="chip overbook-free"
                     key={`overbook-free-${idx}`}
-                    title="Platz in der Überplanung"
+                    aria-label="Freier Überplanungsplatz"
                   >
                     +frei
-                  </span>
+                  </li>
                 ))}
             </>
           )}
-        </div>
+        </ul>
       </div>
 
       {/* Warteliste anzeigen */}
       <div className="course-row list-row">
-        <div className="label muted">Warteliste</div>
-        <div className="chips">
+        <div id={waitlistLabelId} className="label muted">
+          Warteliste
+        </div>
+        <ul className="chips" aria-labelledby={waitlistLabelId}>
           {showExcludedTermMarker ? (
-            <span className="chip muted small">—</span>
+            <li className="chip muted small" aria-label="Keine Warteliste, Termin entfällt">
+              —
+            </li>
           ) : waitlist.length === 0 ? (
-            <span className="chip muted small">Keine Anfragen</span>
+            <li className="chip muted small">Keine Anfragen</li>
           ) : (
             waitlist.map((name) => {
               const isSelf = name.toLowerCase() === userNameLower;
               return (
-                <span
+                <li
                   className={`chip wait${isSelf ? " chip-self" : ""}`}
                   key={name}
-                  title={isSelf ? "Du (Warteliste)" : undefined}
+                  aria-label={waitlistChipAriaLabel(name, isSelf)}
                 >
                   {name}
-                </span>
+                </li>
               );
             })
           )}
-        </div>
+        </ul>
       </div>
 
       {inactiveNotice && (


### PR DESCRIPTION
## Summary

- Teilnehmer- und Warteliste-Chips als beschriftete Listen (`aria-labelledby`) mit verständlichen `aria-label`s (regulär, getauscht, kurzfristig abgesagt, du).
- Kursstatus-Badge, Termin-Marker und Kapazität „entfällt“ mit beschreibenden Labels für Screenreader.
- Doppelte `title`-Ansagen an Chips entfernt (VoiceOver-Duplikate).

Teil von #171.

Closes #197

**Bekannte Einschränkung:** Die VoiceOver-Elementreihenfolge für den Kursstatus-Badge bleibt unverändert (nach der Uhrzeit). Der ausführliche Inaktiv-Hinweis (`role="status"`) liefert den Kontext zuverlässig.

## Test plan

- [ ] VoiceOver: Teilnehmer-Chips als „Teilnehmer, Liste“ mit Status (regulär / getauscht / SN / du)
- [ ] VoiceOver: Warteliste mit „du auf der Warteliste“
- [ ] Inaktiver Kurs: Badge „Kursstatus: …“ und Hinweistext hörbar
- [ ] Wochenansicht: Marker „Termin entfällt“ / Nachlauf / Cutoff als beschreibender Text
- [ ] `npm test -- --run src/components/CourseCard.test.tsx`


Made with [Cursor](https://cursor.com)