### PR TITLE
Add AdminPanel landmarks and table semantics for a11y

### DIFF
--- a/app/src/components/AdminPanel.test.tsx
+++ b/app/src/components/AdminPanel.test.tsx
@@ -50,7 +50,7 @@ describe("AdminPanel", () => {
       expect(within(panel).getByText("alice")).toBeInTheDocument();
       expect(within(panel).getByText("Teilnehmerin")).toBeInTheDocument();
       expect(within(panel).getByText("alice@example.com")).toBeInTheDocument();
-      expect(within(panel).getByLabelText("Status: ohne Login")).toBeInTheDocument();
+      expect(within(panel).getByText("ohne Login")).toBeInTheDocument();
       expect(within(panel).getByLabelText("Einladen alice")).not.toBeDisabled();
       expect(within(panel).getByLabelText("Bearbeiten alice")).not.toBeDisabled();
       expect(within(panel).queryByLabelText("Löschen alice")).not.toBeInTheDocument();
@@ -1171,6 +1171,37 @@ describe("AdminPanel", () => {
       expect(mockedGetParticipants).toHaveBeenLastCalledWith({ search: "bob" });
       expect(within(panel).getByText("bob")).toBeInTheDocument();
     });
+  });
+
+  it("stellt Landmark und Tabellen-Semantik für die Teilnehmerverwaltung bereit", async () => {
+    mockedGetParticipants.mockResolvedValueOnce([
+      {
+        tenantId: "default-tenant",
+        userId: "alice",
+        role: "participant",
+        email: "alice@example.com",
+        status: "no_login",
+      },
+    ]);
+
+    const { container } = render(<AdminPanel />);
+    const panel = container.querySelector<HTMLElement>(".admin-panel");
+    if (!panel) throw new Error("Panel not found");
+
+    await waitFor(() => {
+      expect(within(panel).getByText("alice")).toBeInTheDocument();
+    });
+
+    const section = panel.querySelector<HTMLElement>('section[aria-labelledby="participants-heading"]');
+    if (!section) throw new Error("Participants section not found");
+    const scoped = within(section);
+    expect(scoped.getByRole("heading", { level: 3, name: /teilnehmer verwalten/i })).toBeInTheDocument();
+    expect(scoped.getByRole("table", { name: /teilnehmerliste/i })).toBeInTheDocument();
+    expect(scoped.getByRole("columnheader", { name: /nickname/i })).toBeInTheDocument();
+    expect(within(panel).getByLabelText("Teilnehmer suchen")).toBeInTheDocument();
+    expect(within(panel).getByLabelText("Neuer Teilnehmer")).toBeInTheDocument();
+    expect(scoped.getByLabelText("Auswählen alice")).toBeInTheDocument();
+    expect(scoped.getByLabelText("Einladen alice")).toBeInTheDocument();
   });
 });
 

--- a/app/src/components/AdminPanel.tsx
+++ b/app/src/components/AdminPanel.tsx
@@ -944,9 +944,11 @@ export default function AdminPanel({
         <StudioSettingsSection tenant={tenant} onSaved={onTenantUpdated} />
       ) : null}
       <div className="admin-panel">
-      <div>
+      <section aria-labelledby="participants-heading">
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.5rem" }}>
-          <h3 style={{ margin: 0 }}>Teilnehmer verwalten</h3>
+          <h3 id="participants-heading" style={{ margin: 0 }}>
+            Teilnehmer verwalten
+          </h3>
           <button
             type="button"
             title="Neuer Teilnehmer"
@@ -1011,8 +1013,13 @@ export default function AdminPanel({
         ) : (
           <div className="participants-table">
             <div className="participants-table-scroll">
-              <div className="participants-table-inner">
               <div
+                className="participants-table-inner"
+                role="table"
+                aria-label="Teilnehmerliste"
+              >
+              <div
+              role="row"
               style={{
                 display: "grid",
                 gridTemplateColumns: "36px 130px 110px 150px minmax(220px, 1fr) 220px",
@@ -1022,7 +1029,7 @@ export default function AdminPanel({
                 marginBottom: "0.5rem",
               }}
             >
-              <span style={{ display: "inline-flex", justifyContent: "center" }}>
+              <span role="columnheader" style={{ display: "inline-flex", justifyContent: "center" }}>
                 <input
                   type="checkbox"
                   aria-label="Alle (einladbar) auswählen"
@@ -1031,15 +1038,16 @@ export default function AdminPanel({
                   onChange={(e) => toggleSelectAllEligible(e.target.checked)}
                 />
               </span>
-              <span>Nickname</span>
-              <span>Rolle</span>
-              <span>Status</span>
-                  <span style={{ whiteSpace: "nowrap" }}>E-Mail</span>
-                  <span style={{ whiteSpace: "nowrap" }}>Aktion</span>
+              <span role="columnheader">Nickname</span>
+              <span role="columnheader">Rolle</span>
+              <span role="columnheader">Status</span>
+                  <span role="columnheader" style={{ whiteSpace: "nowrap" }}>E-Mail</span>
+                  <span role="columnheader" style={{ whiteSpace: "nowrap" }}>Aktion</span>
               </div>
               {safeParticipants.map((p) => (
                 <div
                   key={p.userId}
+                  role="row"
                   style={{
                     display: "grid",
                     gridTemplateColumns: "36px 130px 110px 150px minmax(220px, 1fr) 220px",
@@ -1048,7 +1056,7 @@ export default function AdminPanel({
                     padding: "0.25rem 0",
                   }}
                 >
-                  <span style={{ display: "inline-flex", justifyContent: "center" }}>
+                  <span role="cell" style={{ display: "inline-flex", justifyContent: "center" }}>
                     <input
                       type="checkbox"
                       aria-label={`Auswählen ${p.userId}`}
@@ -1064,14 +1072,18 @@ export default function AdminPanel({
                       onChange={(e) => toggleSelectedInviteUserId(p.userId, e.target.checked)}
                     />
                   </span>
-                  <span style={{ fontWeight: 600 }}>{p.userId}</span>
-                  <span style={{ color: "#374151" }}>{getRoleLabel(p.role)}</span>
+                  <span role="rowheader" style={{ fontWeight: 600 }}>
+                    {p.userId}
+                  </span>
+                  <span role="cell" style={{ color: "#374151" }}>
+                    {getRoleLabel(p.role)}
+                  </span>
                   <span
-                    title={getStatusPresentation(p.status).label}
-                    aria-label={`Status: ${getStatusPresentation(p.status).label}`}
+                    role="cell"
                     style={{ display: "inline-flex", justifyContent: "center", alignItems: "center", gap: 6 }}
                   >
                     <span
+                      aria-hidden="true"
                       style={{
                         width: 10,
                         height: 10,
@@ -1084,6 +1096,7 @@ export default function AdminPanel({
                     </span>
                   </span>
                   <span
+                    role="cell"
                     style={{
                       color: p.email ? "#111827" : "#9ca3af",
                       whiteSpace: "nowrap",
@@ -1091,11 +1104,11 @@ export default function AdminPanel({
                       textOverflow: "ellipsis",
                       minWidth: 0,
                     }}
-                    title={p.email ?? "-"}
                   >
                     {p.email ?? "-"}
                   </span>
                   <div
+                    role="cell"
                     style={{
                       display: "flex",
                       gap: "0.25rem",
@@ -1185,7 +1198,7 @@ export default function AdminPanel({
             </div>
           </div>
         )}
-      </div>
+      </section>
 
       {editingUserId && (
         <div

--- a/app/src/components/StudioSettingsSection.test.tsx
+++ b/app/src/components/StudioSettingsSection.test.tsx
@@ -69,6 +69,12 @@ describe("StudioSettingsSection", () => {
     expect(onSaved).toHaveBeenCalledWith(updatedTenant);
   });
 
+  it("stellt Landmark und beschriftete Formularfelder bereit", () => {
+    render(<StudioSettingsSection tenant={makeTenant()} onSaved={vi.fn()} />);
+    expect(screen.getByRole("region", { name: /studio-einstellungen/i })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /studioname/i })).toBeInTheDocument();
+  });
+
   it("zeigt Validierungsfehler bei ungültigem Cutoff-Wert", async () => {
     render(<StudioSettingsSection tenant={makeTenant()} onSaved={vi.fn()} />);
     fireEvent.change(getCutoffInput(), { target: { value: "1500" } });

--- a/docs/a11y-main-view-qa.md
+++ b/docs/a11y-main-view-qa.md
@@ -82,6 +82,13 @@ Auf einer Karte mit mindestens einem zukünftigen Termin und eingetragenem Teiln
 - [ ] Admin-Aktionen an einer Karte (Bearbeiten, Termine, …) per Tastatur erreichbar
 - [ ] Kein Fokus „stecken bleiben“ außerhalb bewusster Modale
 
+### A8 Optional: Verwaltung (Teilnehmer, Studio-Einstellungen)
+
+- [ ] Verwaltungsbereich unterhalb der Kursliste erreichbar (Landmark „Verwaltung“)
+- [ ] **Teilnehmer verwalten**: Suche, Sammelaktionen, Tabellenkopfzeilen per Screenreader erkennbar
+- [ ] Icon-Buttons (Einladen, Bearbeiten, Löschen) mit beschreibendem Namen
+- [ ] **Studio-Einstellungen** (Admin): Formularfelder mit Label, Speichern per Tastatur
+
 **Ergebnis A:** [ ] bestanden  [ ] mit Anmerkungen (unten)
 
 ---
@@ -128,7 +135,9 @@ cd app && npm test -- --run \
   src/components/CoursesShell.test.tsx \
   src/components/CourseWeekView.test.tsx \
   src/components/CourseCard.test.tsx \
-  src/components/CourseSwapModal.test.tsx
+  src/components/CourseSwapModal.test.tsx \
+  src/components/AdminPanel.test.tsx \
+  src/components/StudioSettingsSection.test.tsx
 ```
 
 - [ ] Alle genannten Tests grün
@@ -158,5 +167,5 @@ Issue anlegen oder an [#171](https://github.com/CurlyKarin/yogaswap/issues/171) 
 
 ## Siehe auch
 
-- [#199 — AdminPanel A11y (optional)](https://github.com/CurlyKarin/yogaswap/issues/199)
+- [#199 — AdminPanel A11y (optional)](https://github.com/CurlyKarin/yogaswap/issues/199) — Landmark, Tabellen-Semantik, Formular-Labels
 - Implementierte Teil-Tickets: #200 (Shell), #201 (Wochennavigation), #202 (Kurskarten), #196/#205 (Terminaktionen), #206 (Swap-Modal), #197/#209 (Chips/Badges)


### PR DESCRIPTION
## Summary
- Teilnehmerverwaltung als Landmark (`section` + Überschrift) und CSS-Grid-Tabelle mit ARIA-Tabellenrollen (`table`, `row`, `columnheader`, `cell`)
- Doppelte Screenreader-Ansagen in Status- und E-Mail-Zellen behoben (redundantes `aria-label`/`title` entfernt)
- Regressionstests für AdminPanel/StudioSettingsSection; QA-Checkliste um Abschnitt A8 ergänzt

Closes #199

## Test plan
- [x] `cd app && npm test -- --run src/components/AdminPanel.test.tsx src/components/StudioSettingsSection.test.tsx`
- [ ] Manuell mit VoiceOver: Teilnehmerliste — Status und E-Mail je einmal vorgelesen
- [ ] Manuell: Tab durch Verwaltungsbereich (Suche, Buttons, Studio-Einstellungen als Admin)


Made with [Cursor](https://cursor.com)