### PR TITLE
Refactor CourseCard into hook, actions, and details

### DIFF
--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
-import { formatCourseIsoDateDe } from "shared/courseStatus";
-import { resolveMaxCapacity, resolveOverbookLimit } from "shared/courseCapacity";
-import { toDateKey } from "../lib/dates";
-import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
-import { weekdayLabelDe } from "../lib/weekdayLabels";
+import { formatAbsenceAnnouncement } from "../lib/courseCardLabels";
+import CourseCardDetails from "./CourseCardDetails";
 import CourseTermActions from "./CourseTermActions";
 import {
   useCourseCardTermState,
@@ -34,50 +30,6 @@ type Props = {
   /** Wochenansicht: Termine der angezeigten KW auch in der Vergangenheit im Dropdown. */
   includePastTermsInSelect?: boolean;
 };
-
-
-const TERM_MARKER_EXCLUDED_LABEL = "Termin entfällt (vom Studio abgesagt)";
-const TERM_MARKER_PAST_LABEL = "Vergangener Termin im Nachlauf";
-const TERM_MARKER_CUTOFF_LABEL = "Kurz vor Termin (Cutoff)";
-
-function courseStatusBadgeLabel(autoInactive: boolean): string {
-  return autoInactive ? "Kursstatus: Automatisch inaktiv" : "Kursstatus: Inaktiv";
-}
-
-function participantChipAriaLabel(
-  name: string,
-  { isSelf, isSn, isSwapped }: { isSelf: boolean; isSn: boolean; isSwapped: boolean },
-): string {
-  if (isSn && isSelf) return `${name}, du, kurzfristig abgesagt, Platz bleibt belegt`;
-  if (isSn) return `${name}, kurzfristig abgesagt, Platz bleibt belegt`;
-  if (isSwapped) return `${name}, getauscht`;
-  if (isSelf) return `${name}, du`;
-  return `${name}, regulär eingetragen`;
-}
-
-function waitlistChipAriaLabel(name: string, isSelf: boolean): string {
-  return isSelf ? `${name}, du auf der Warteliste` : `${name}, auf der Warteliste`;
-}
-
-function formatAbsenceAnnouncement(
-  courseName: string,
-  termIso: string,
-  outcome: "saving" | AbsenceToggleOutcome | "error",
-): string {
-  const term = formatCourseIsoDateDe(termIso);
-  switch (outcome) {
-    case "saving":
-      return "Speichere Absage …";
-    case "cancelled":
-      return `Termin abgesagt für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
-    case "shortNoticeCancelled":
-      return `Kurzfristige Absage gespeichert für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
-    case "undo":
-      return `Absage zurückgenommen für ${courseName}, ${term}. Du nimmst wieder am Termin teil.`;
-    case "error":
-      return "Fehler beim Speichern der Absage.";
-  }
-}
 
 export default function CourseCard({
   course,
@@ -109,27 +61,7 @@ export default function CourseCard({
     initialSelectedDate,
     includePastTermsInSelect,
   });
-  const {
-    selectedDate,
-    setSelectedDate,
-    selectedDateKey,
-    participants,
-    swapped,
-    shortNotice,
-    waitlist,
-    userName,
-    userNameLower,
-    hasNoUpcomingDates,
-    showLastTermInSelect,
-    lastOccurrenceDate,
-    showAutoInactiveStatusBadge,
-    showPastGraceMarker,
-    showCutoffMarker,
-    showExcludedTermMarker,
-    excludedTermNotice,
-    inactiveNotice,
-    termSelectDisabled,
-  } = termState;
+  const { selectedDate, setSelectedDate, selectedDateKey, userName, hasNoUpcomingDates } = termState;
 
   const [showSwapModal, setShowSwapModal] = useState(false);
   const [absenceSaving, setAbsenceSaving] = useState(false);
@@ -137,24 +69,12 @@ export default function CourseCard({
   const absenceButtonRef = useRef<HTMLButtonElement>(null);
   const restoreAbsenceFocusRef = useRef(false);
 
-  const overbookLimit = resolveOverbookLimit(course);
-  const maxCapacity = resolveMaxCapacity(course);
-  const regularFreeSpots = Math.max(0, course.capacity - participants.length);
-  const overbookFreeSpots = Math.max(0, maxCapacity - Math.max(participants.length, course.capacity));
-  const visibleFreeSpots = showOverbookingDetails
-    ? regularFreeSpots + overbookFreeSpots
-    : regularFreeSpots;
-
   const notEnrolledInTermHint = (
     <div className="muted">Nicht in diesem Termin eingetragen</div>
   );
 
   const titleId = useId();
   const scheduleDescId = useId();
-  const termSelectId = useId();
-  const termSelectDisabledHintId = useId();
-  const participantsLabelId = useId();
-  const waitlistLabelId = useId();
 
   const handleToggleAbsence = useCallback(
     async (outcome: AbsenceToggleOutcome) => {
@@ -198,6 +118,14 @@ export default function CourseCard({
     setShowSwapModal(false);
   }, []);
 
+  const handleSelectedDateChange = useCallback(
+    (isoValue: string, date: Date) => {
+      setSelectedDate(isoValue);
+      onDateChange?.(date);
+    },
+    [onDateChange, setSelectedDate],
+  );
+
   return (
     <article
       className={`course-card${participantActionsLocked ? " course-card--inactive-participant" : ""}`}
@@ -212,235 +140,18 @@ export default function CourseCard({
       >
         {absenceAnnouncement}
       </span>
-      <div className="course-head">
-        <div className="course-head-primary">
-          <div className="course-head-title">
-            <h3 id={titleId}>
-              <span className="visually-hidden">Kurs: </span>
-              {course.name}
-            </h3>
-          </div>
-          <div
-            className="course-head-schedule muted"
-            id={scheduleDescId}
-            aria-label={`${weekdayLabelDe(course.weekday)} · ${course.time}`}
-          >
-            <span aria-hidden="true">
-              {course.weekday} · {course.time}
-            </span>
-          </div>
-        </div>
-        <div className="course-head-meta">
-          {(showPastGraceMarker || showCutoffMarker || showExcludedTermMarker) && (
-            <div className="course-term-visual-markers" role="status">
-              {showExcludedTermMarker && (
-                <span
-                  className="course-term-visual-marker course-term-visual-marker--excluded"
-                  role="img"
-                  aria-label={TERM_MARKER_EXCLUDED_LABEL}
-                  title={TERM_MARKER_EXCLUDED_LABEL}
-                >
-                  <CalendarX size={12} aria-hidden="true" />
-                </span>
-              )}
-              {showPastGraceMarker && (
-                <span
-                  className="course-term-visual-marker course-term-visual-marker--past"
-                  role="img"
-                  aria-label={TERM_MARKER_PAST_LABEL}
-                  title={TERM_MARKER_PAST_LABEL}
-                >
-                  <History size={12} aria-hidden="true" />
-                </span>
-              )}
-              {showCutoffMarker && (
-                <span
-                  className="course-term-visual-marker course-term-visual-marker--cutoff"
-                  role="img"
-                  aria-label={TERM_MARKER_CUTOFF_LABEL}
-                  title={TERM_MARKER_CUTOFF_LABEL}
-                >
-                  <Clock3 size={12} aria-hidden="true" />
-                </span>
-              )}
-            </div>
-          )}
-          {participantActionsLocked && (
-            <span
-              className={`course-status-badge ${
-                showAutoInactiveStatusBadge
-                  ? "course-status-badge--auto"
-                  : "course-status-badge--inactive"
-              }`}
-              aria-label={courseStatusBadgeLabel(showAutoInactiveStatusBadge)}
-            >
-              {showAutoInactiveStatusBadge ? "Automatisch inaktiv" : "Inaktiv"}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="course-row">
-        <div className="muted">Kapazität</div>
-        <div>
-          {showExcludedTermMarker ? (
-            <span className="muted" aria-label="Kapazität entfällt">
-              entfällt
-            </span>
-          ) : (
-            <>
-              {participants.length}/{course.capacity}
-              {showOverbookingDetails && overbookLimit > 0 && ` (+${overbookLimit})`}
-            </>
-          )}
-        </div>
-      </div>
-
-      <div className="course-row">
-        {termSelectDisabled && (
-          <span id={termSelectDisabledHintId} className="visually-hidden">
-            {(course.dates ?? []).length === 0
-              ? `Kein Termin im Kurszeitraum für ${course.name}.`
-              : `Keine anstehenden Termine für ${course.name}.`}
-          </span>
-        )}
-        <label
-          htmlFor={termSelectId}
-          className="muted course-row-label"
-          aria-label={`Termin für ${course.name}`}
-        >
-          Termine
-        </label>
-        <select
-          id={termSelectId}
-          value={termSelectDisabled ? "" : selectedDate}
-          onChange={(e) => {
-            const next = new Date(e.target.value);
-            setSelectedDate(e.target.value);
-            onDateChange?.(next);
-          }}
-          disabled={termSelectDisabled}
-          aria-describedby={termSelectDisabled ? termSelectDisabledHintId : undefined}
-        >
-          {showLastTermInSelect && lastOccurrenceDate ? (
-            <option value={lastOccurrenceDate.toISOString()}>
-              {lastOccurrenceDate.toLocaleDateString()} (letzter Termin)
-            </option>
-          ) : hasNoUpcomingDates ? (
-            <option value="">—</option>
-          ) : (
-            (includePastTermsInSelect ? dates : dates.filter((d) => d >= new Date())).map(
-              (date, index) => {
-                const dateIso = toDateKey(date);
-                const excludedLabel = isExcludedCourseDate(course, dateIso) ? " (entfällt)" : "";
-                return (
-                  <option key={index} value={date.toISOString()}>
-                    {date.toLocaleDateString()}
-                    {excludedLabel}
-                  </option>
-                );
-              },
-            )
-          )}
-        </select>
-      </div>
-
-      <div className="course-row list-row">
-        <div id={participantsLabelId} className="label muted">
-          Teilnehmer
-        </div>
-        <ul className="chips" aria-labelledby={participantsLabelId}>
-          {showExcludedTermMarker ? (
-            <li className="chip muted small" aria-label="Keine Teilnehmer, Termin entfällt">
-              —
-            </li>
-          ) : (
-            <>
-              {participants.length === 0 && (
-                <li className="chip" aria-label="Keine Teilnehmer eingetragen">
-                  —
-                </li>
-              )}
-              {participants.map((name) => {
-                const isSelf = name.toLowerCase() === userNameLower;
-                const isSn = shortNotice.some((n) => n.toLowerCase() === name.toLowerCase());
-                const isSwapped = swapped.includes(name);
-                const chipLabel = participantChipAriaLabel(name, { isSelf, isSn, isSwapped });
-                return (
-                  <li
-                    className={`chip${isSelf ? " chip-self" : ""}${
-                      isSn ? " short-notice" : isSwapped ? " swapped" : ""
-                    }`}
-                    key={name}
-                    aria-label={chipLabel}
-                  >
-                    {name}
-                  </li>
-                );
-              })}
-              {visibleFreeSpots > 0 &&
-                Array.from({ length: regularFreeSpots }).map((_, idx) => (
-                  <li className="chip free" key={`free-${idx}`} aria-label="Freier Platz">
-                    frei
-                  </li>
-                ))}
-              {showOverbookingDetails &&
-                overbookFreeSpots > 0 &&
-                Array.from({ length: overbookFreeSpots }).map((_, idx) => (
-                  <li
-                    className="chip overbook-free"
-                    key={`overbook-free-${idx}`}
-                    aria-label="Freier Überplanungsplatz"
-                  >
-                    +frei
-                  </li>
-                ))}
-            </>
-          )}
-        </ul>
-      </div>
-
-      {/* Warteliste anzeigen */}
-      <div className="course-row list-row">
-        <div id={waitlistLabelId} className="label muted">
-          Warteliste
-        </div>
-        <ul className="chips" aria-labelledby={waitlistLabelId}>
-          {showExcludedTermMarker ? (
-            <li className="chip muted small" aria-label="Keine Warteliste, Termin entfällt">
-              —
-            </li>
-          ) : waitlist.length === 0 ? (
-            <li className="chip muted small">Keine Anfragen</li>
-          ) : (
-            waitlist.map((name) => {
-              const isSelf = name.toLowerCase() === userNameLower;
-              return (
-                <li
-                  className={`chip wait${isSelf ? " chip-self" : ""}`}
-                  key={name}
-                  aria-label={waitlistChipAriaLabel(name, isSelf)}
-                >
-                  {name}
-                </li>
-              );
-            })
-          )}
-        </ul>
-      </div>
-
-      {inactiveNotice && (
-        <div className="course-row course-inactive-notice" role="status">
-          <span className="muted small">{inactiveNotice}</span>
-        </div>
-      )}
-
-      {excludedTermNotice && (
-        <div className="course-row course-excluded-term-notice" role="status">
-          <span className="muted small">{excludedTermNotice}</span>
-        </div>
-      )}
-
+      <CourseCardDetails
+        course={course}
+        dates={dates}
+        showOverbookingDetails={showOverbookingDetails}
+        includePastTermsInSelect={includePastTermsInSelect}
+        participantActionsLocked={participantActionsLocked}
+        termState={termState}
+        selectedDate={selectedDate}
+        onSelectedDateChange={handleSelectedDateChange}
+        titleId={titleId}
+        scheduleDescId={scheduleDescId}
+      />
       <CourseTermActions
         course={course}
         allCourses={allCourses}

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,36 +1,23 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
-import {
-  buildCourseOccurrenceLocal,
-  formatCourseIsoDateDe,
-  lastScheduledOccurrenceIso,
-  getInactiveGraceLastDayIso,
-  isCourseInInactiveGracePeriod,
-  isWithinPostCourseEndGrace,
-  looksLikeAutomaticallyInactive,
-} from "shared/courseStatus";
-import { resolveSwapWindow } from "shared/tenantSettings";
+import { formatCourseIsoDateDe } from "shared/courseStatus";
 import {
   canCancelSwap,
-  canCreateSwapFromOrigin,
-  hasEffectiveCancellation,
   isShortNoticeCancelled,
   isWithinCancellationSwapCutoff,
-  resolveCancellationSwapCutoffMinutes,
 } from "shared/cancellationSwapCutoff";
 import { resolveMaxCapacity, resolveOverbookLimit } from "shared/courseCapacity";
-import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
-import {
-  canRequestSwapFromPastCancelledOrigin,
-  isOccurrenceInPast,
-} from "../lib/courseTermActions";
+import { toDateKey } from "../lib/dates";
 import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
 import { weekdayLabelDe } from "../lib/weekdayLabels";
-import type { SwapSettings } from "../types";
 import CourseSwapModal from "./CourseSwapModal";
 import { formatSwapStatusLine, swapTermIsoForCourse } from "../lib/courseTermActionLabels";
 import CourseTermActionButton from "./CourseTermActionButton";
+import {
+  useCourseCardTermState,
+  type AbsenceToggleOutcome,
+} from "./useCourseCardTermState";
 
 type Props = {
   course: Course;
@@ -55,16 +42,6 @@ type Props = {
   includePastTermsInSelect?: boolean;
 };
 
-
-function sameDayUTC(a: Date, b: Date) {
-  return (
-    a.getUTCFullYear() === b.getUTCFullYear() &&
-    a.getUTCMonth() === b.getUTCMonth() &&
-    a.getUTCDate() === b.getUTCDate()
-  );
-}
-
-type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
 
 const TERM_MARKER_EXCLUDED_LABEL = "Termin entfällt (vom Studio abgesagt)";
 const TERM_MARKER_PAST_LABEL = "Vergangener Termin im Nachlauf";
@@ -127,36 +104,68 @@ export default function CourseCard({
   onDateChange,
   includePastTermsInSelect = false,
 }: Props) {
-  const swapWindow: SwapSettings = useMemo(
-    () => resolveSwapWindow(tenantSettings),
-    [tenantSettings],
-  );
+  const {
+    swapWindow,
+    selectedDate,
+    setSelectedDate,
+    selectedDateKey,
+    participants,
+    swapped,
+    shortNotice,
+    waitlist,
+    userName,
+    userNameLower,
+    hasCancelled,
+    cutoffMinutes,
+    canSwapFromOrigin,
+    pendingCount,
+    hasPendingRequestsFromOrigin,
+    availableSwapDates,
+    waitlistDates,
+    swapForThisTerm,
+    hasNoUpcomingDates,
+    showLastTermInSelect,
+    lastOccurrenceDate,
+    showAutoInactiveStatusBadge,
+    cancellableUserSwapsOnCourse,
+    isPastOccurrence,
+    isSelectedTermExcluded,
+    showPastGraceMarker,
+    showCutoffMarker,
+    showExcludedTermMarker,
+    canUseFullTermActions,
+    canSwapFromPastCancelled,
+    swapForThisTermCancellable,
+    showPastTermSwapActions,
+    excludedTermNotice,
+    inactiveNotice,
+    termSelectDisabled,
+    swapStatusLines,
+    showCutoffHint,
+    termActionExtras,
+    swapPendingAbsenceAction,
+    primaryAbsenceAction,
+    swapModalTitle,
+    swapForWaitlist,
+  } = useCourseCardTermState({
+    course,
+    allCourses,
+    currentUser,
+    dates,
+    overrides,
+    swaps,
+    participantActionsLocked,
+    tenantSettings,
+    initialSelectedDate,
+    includePastTermsInSelect,
+  });
 
-  const [selectedDate, setSelectedDate] = useState<string>(
-    () => (initialSelectedDate ?? dates[0])?.toISOString() || "",
-  );
   const [showSwapModal, setShowSwapModal] = useState(false);
   const [absenceSaving, setAbsenceSaving] = useState(false);
   const [absenceAnnouncement, setAbsenceAnnouncement] = useState("");
   const absenceButtonRef = useRef<HTMLButtonElement>(null);
   const restoreAbsenceFocusRef = useRef(false);
 
-  const userName = currentUser.nickname;
-  const selectedDateKey = toDateKey(new Date(selectedDate));
-
-  // Memoized Berechnungen für reaktive Aktualisierung
-  const override = useMemo(
-    () =>
-      overrides.find((o) =>
-        o.courseId === course.id && sameDayUTC(new Date(o.date), new Date(selectedDate))
-      ),
-    [overrides, course.id, selectedDate]
-  );
-
-  const hasNoUpcomingDates = dates.length === 0;
-  const participants = hasNoUpcomingDates ? course.participants : (override ? override.participants : course.participants);
-  const swapped = hasNoUpcomingDates ? [] : (override?.swapped ?? []);
-  const shortNotice = hasNoUpcomingDates ? [] : (override?.shortNoticeCancellations ?? []);
   const overbookLimit = resolveOverbookLimit(course);
   const maxCapacity = resolveMaxCapacity(course);
   const regularFreeSpots = Math.max(0, course.capacity - participants.length);
@@ -164,229 +173,10 @@ export default function CourseCard({
   const visibleFreeSpots = showOverbookingDetails
     ? regularFreeSpots + overbookFreeSpots
     : regularFreeSpots;
-  const waitlist = hasNoUpcomingDates ? [] : (override?.waitlist ?? []);
 
-  const userNameLower = userName.toLowerCase();
-  const isParticipant = participants.some((p) => p.toLowerCase() === userNameLower);
-  const originallyParticipant = course.participants.some((p) => p.toLowerCase() === userNameLower);
-  const isShortNotice = isShortNoticeCancelled(override, userName);
-  const hasCancelled = hasEffectiveCancellation(
-    originallyParticipant,
-    override,
-    participants,
-    userName,
-  );
-  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
-  const originInCutoff = isWithinCancellationSwapCutoff(
-    selectedDateKey,
-    course.time,
-    cutoffMinutes,
-  );
-  const canSwapFromOrigin =
-    (originallyParticipant || hasCancelled) &&
-    canCreateSwapFromOrigin({
-      isoDate: selectedDateKey,
-      courseTime: course.time,
-      tenantSettings,
-      override,
-      userName,
-      participants,
-      originallyParticipant,
-    });
-  const hasActiveOriginSwapInPast = swaps.some(
-    (s) =>
-      s.user === userName &&
-      s.status === "active" &&
-      s.fromCourseId === course.id &&
-      s.fromDate === selectedDateKey &&
-      new Date(s.toDate) < new Date(),
-  );
-  /** RC: Rücknahme = wieder in participants (auch im Cutoff), außer historischem aktivem Swap. */
-  const canUndoRegularAbsence =
-    hasCancelled && !isShortNotice && !isParticipant && !hasActiveOriginSwapInPast;
-
-  const pendingSwapsFromOrigin = useMemo(
-    () =>
-      swaps.filter(
-        (s) =>
-          s.user === userName &&
-          s.fromCourseId === course.id &&
-          s.fromDate === selectedDateKey &&
-          s.status === "pending"
-      ),
-    [swaps, userName, course.id, selectedDateKey]
-  );
-
-  const existingPendingTargetCourseIds = useMemo(
-    () => new Set(pendingSwapsFromOrigin.map((swap) => swap.toCourseId)),
-    [pendingSwapsFromOrigin]
-  );
-
-  const availableSwapDates = useMemo(
-    () =>
-      getAvailableDates(
-        allCourses,
-        overrides,
-        currentUser,
-        swapWindow,
-        new Date(selectedDate),
-        undefined,
-        tenantSettings,
-      )
-        .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
-        .sort((a, b) => a.date.getTime() - b.date.getTime()),
-    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow, tenantSettings]
-  );
-
-  const waitlistDates = useMemo(
-    () =>
-      getWaitlistDates(
-        allCourses,
-        overrides,
-        currentUser,
-        swapWindow,
-        new Date(selectedDate),
-        undefined,
-        tenantSettings,
-      )
-        .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
-        .sort((a, b) => a.date.getTime() - b.date.getTime()),
-    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow, tenantSettings]
-  );
-
-  const swapForThisTerm = useMemo(
-    () =>
-      swaps.find(
-        (s) =>
-          s.user === userName &&
-          ((s.fromCourseId === course.id && s.fromDate === selectedDateKey) ||
-           (s.toCourseId === course.id && s.toDate === selectedDateKey))
-      ),
-    [swaps, userName, course.id, selectedDateKey]
-  );
-
-  const allSwapsForThisTerm = useMemo(
-    () =>
-      swaps.filter(
-        (s) =>
-          (s.fromCourseId === course.id && s.fromDate === selectedDateKey && s.user === userName) ||
-          (s.toCourseId === course.id && s.toDate === selectedDateKey && s.user === userName)
-      ),
-    [swaps, userName, course.id, selectedDateKey]
-  );
-
-  const swapForWaitlist = useMemo(
-    () =>
-      swaps.find(
-        (s) =>
-          s.user === userName &&
-          s.toCourseId === course.id &&
-          s.toDate === selectedDateKey &&
-          s.status === "pending"
-      ),
-    [swaps, userName, course.id, selectedDateKey]
-  );
-
-  const pendingCount = pendingSwapsFromOrigin.length;
-  const hasPendingRequestsFromOrigin = pendingCount > 0;
-
-  const hasUpcomingDates = dates.length > 0;
-  const courseStatus = course.status ?? "active";
-  const isInactiveCourse = courseStatus === "inactive";
-  const inPostEndGrace = isWithinPostCourseEndGrace(course, tenantSettings);
-  const inInactiveGrace =
-    isInactiveCourse && isCourseInInactiveGracePeriod(course, tenantSettings);
-  const graceLastIso =
-    inPostEndGrace || inInactiveGrace
-      ? getInactiveGraceLastDayIso(course, tenantSettings)
-      : undefined;
-  const lastActualOccurrenceIso = useMemo(
-    () => lastScheduledOccurrenceIso({ dates: course.dates }),
-    [course.dates],
-  );
-  const lastOccurrenceDate =
-    lastActualOccurrenceIso != null
-      ? buildCourseOccurrenceLocal(lastActualOccurrenceIso, course.time)
-      : null;
-  const showLastTermInSelect =
-    hasNoUpcomingDates && lastOccurrenceDate != null && inPostEndGrace;
-  const showAutoInactiveBadge =
-    participantActionsLocked && looksLikeAutomaticallyInactive(course, hasUpcomingDates);
-  const userSwapsOnCourse = useMemo(
-    () =>
-      swaps.filter(
-        (s) =>
-          s.user === userName &&
-          (s.fromCourseId === course.id || s.toCourseId === course.id),
-      ),
-    [swaps, userName, course.id],
-  );
-  const cancellableUserSwapsOnCourse = useMemo(
-    () => userSwapsOnCourse.filter((swap) => canCancelSwap(swap, allCourses)),
-    [userSwapsOnCourse, allCourses],
-  );
-  const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
-  const isSelectedTermExcluded = isExcludedCourseDate(course, selectedDateKey);
-  const showPastGraceMarker =
-    includePastTermsInSelect && isPastOccurrence && !isSelectedTermExcluded;
-  const showCutoffMarker =
-    includePastTermsInSelect &&
-    !isPastOccurrence &&
-    !isSelectedTermExcluded &&
-    originInCutoff;
-  const showExcludedTermMarker = includePastTermsInSelect && isSelectedTermExcluded;
-  const canUseFullTermActions =
-    !participantActionsLocked &&
-    hasUpcomingDates &&
-    (isParticipant || originallyParticipant) &&
-    !isPastOccurrence &&
-    !isSelectedTermExcluded;
-  const canSwapFromPastCancelled = canRequestSwapFromPastCancelledOrigin({
-    isoDate: selectedDateKey,
-    courseTime: course.time,
-    tenantSettings,
-    override,
-    userName,
-    participants,
-    originallyParticipant,
-  });
-  const swapForThisTermCancellable =
-    swapForThisTerm != null && canCancelSwap(swapForThisTerm, allCourses);
-  const showPastTermSwapActions =
-    !participantActionsLocked &&
-    !isSelectedTermExcluded &&
-    isPastOccurrence &&
-    (isParticipant || originallyParticipant || hasCancelled) &&
-    (swapForThisTermCancellable || canSwapFromPastCancelled);
-  const excludedTermNotice = showExcludedTermMarker
-    ? "Dieser Termin entfällt — vom Studio abgesagt."
-    : null;
-
-  const inactiveNotice = participantActionsLocked
-    ? showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
-      ? graceLastIso
-        ? `Dieser Kurs wurde automatisch beendet (keine weiteren Termine). Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
-        : "Dieser Kurs wurde automatisch beendet. Du kannst nur noch bestehende Tausche verwalten."
-      : graceLastIso
-        ? `Dieser Kurs ist inaktiv. Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
-        : "Dieser Kurs ist inaktiv. Du kannst nur noch bestehende Tausche verwalten."
-    : null;
   const notEnrolledInTermHint = (
     <div className="muted">Nicht in diesem Termin eingetragen</div>
   );
-
-  useEffect(() => {
-    if (includePastTermsInSelect) return;
-    if (showLastTermInSelect && lastOccurrenceDate) {
-      setSelectedDate(lastOccurrenceDate.toISOString());
-    }
-  }, [includePastTermsInSelect, showLastTermInSelect, lastActualOccurrenceIso, course.time, lastOccurrenceDate]);
-
-  const initialSelectedTime = initialSelectedDate?.getTime();
-  useEffect(() => {
-    if (initialSelectedTime == null) return;
-    setSelectedDate(new Date(initialSelectedTime).toISOString());
-  }, [initialSelectedTime]);
 
   const titleId = useId();
   const scheduleDescId = useId();
@@ -394,62 +184,6 @@ export default function CourseCard({
   const termSelectDisabledHintId = useId();
   const participantsLabelId = useId();
   const waitlistLabelId = useId();
-  const termSelectDisabled = hasNoUpcomingDates && !showLastTermInSelect;
-
-  const swapStatusLines = useMemo(
-    () =>
-      hasNoUpcomingDates
-        ? []
-        : allSwapsForThisTerm.map((swap) => formatSwapStatusLine(swap, course.id, allCourses)),
-    [hasNoUpcomingDates, allSwapsForThisTerm, course.id, allCourses],
-  );
-
-  const showCutoffHint =
-    canUseFullTermActions &&
-    !swapForThisTerm &&
-    originInCutoff &&
-    (originallyParticipant || hasCancelled) &&
-    !canSwapFromOrigin;
-
-  const cutoffStatusLabel = showCutoffHint
-    ? `Weniger als ${cutoffMinutes} Minuten vor Termin, kein Tausch mehr möglich`
-    : undefined;
-
-  const swapStatusExtras = swapStatusLines.length > 0 ? swapStatusLines : undefined;
-  const cutoffExtras = cutoffStatusLabel ? [cutoffStatusLabel] : undefined;
-  const termActionExtras = [...(swapStatusExtras ?? []), ...(cutoffExtras ?? [])];
-
-  const swapPendingAbsenceAction = useMemo((): {
-    action: string;
-    outcome: AbsenceToggleOutcome;
-  } | null => {
-    if (swapForThisTerm?.status === "pending" && originallyParticipant) {
-      return {
-        action: hasCancelled ? "Absage zurücknehmen" : "Termin absagen",
-        outcome: hasCancelled ? "undo" : "cancelled",
-      };
-    }
-    return null;
-  }, [swapForThisTerm, originallyParticipant, hasCancelled]);
-
-  const primaryAbsenceAction = useMemo((): {
-    action: string;
-    outcome: AbsenceToggleOutcome;
-  } | null => {
-    if (isShortNotice) {
-      return { action: "Absage zurücknehmen", outcome: "undo" };
-    }
-    if (isParticipant) {
-      return {
-        action: "Termin absagen",
-        outcome: originInCutoff ? "shortNoticeCancelled" : "cancelled",
-      };
-    }
-    if (canUndoRegularAbsence) {
-      return { action: "Absage zurücknehmen", outcome: "undo" };
-    }
-    return null;
-  }, [isShortNotice, isParticipant, canUndoRegularAbsence, originInCutoff]);
 
   const handleToggleAbsence = useCallback(
     async (outcome: AbsenceToggleOutcome) => {
@@ -492,10 +226,6 @@ export default function CourseCard({
   const closeSwapModal = useCallback(() => {
     setShowSwapModal(false);
   }, []);
-
-  const swapModalTitle = hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten";
-  const showAutoInactiveStatusBadge =
-    showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace);
 
   return (
     <article
@@ -846,7 +576,7 @@ export default function CourseCard({
 
       ) : showPastTermSwapActions ? (
         <div className="actions">
-          {swapForThisTermCancellable ? (
+          {swapForThisTerm && swapForThisTermCancellable ? (
             <CourseTermActionButton
               action={
                 swapForThisTerm.status === "pending"
@@ -884,7 +614,7 @@ export default function CourseCard({
           ) : null}
         </div>
       ) : isSelectedTermExcluded && includePastTermsInSelect ? (
-        swapForThisTermCancellable ? (
+        swapForThisTerm && swapForThisTermCancellable ? (
           <div className="actions">
             <CourseTermActionButton
               action={

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -2,18 +2,11 @@ import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import { formatCourseIsoDateDe } from "shared/courseStatus";
-import {
-  canCancelSwap,
-  isShortNoticeCancelled,
-  isWithinCancellationSwapCutoff,
-} from "shared/cancellationSwapCutoff";
 import { resolveMaxCapacity, resolveOverbookLimit } from "shared/courseCapacity";
 import { toDateKey } from "../lib/dates";
 import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
 import { weekdayLabelDe } from "../lib/weekdayLabels";
-import CourseSwapModal from "./CourseSwapModal";
-import { formatSwapStatusLine, swapTermIsoForCourse } from "../lib/courseTermActionLabels";
-import CourseTermActionButton from "./CourseTermActionButton";
+import CourseTermActions from "./CourseTermActions";
 import {
   useCourseCardTermState,
   type AbsenceToggleOutcome,
@@ -104,50 +97,7 @@ export default function CourseCard({
   onDateChange,
   includePastTermsInSelect = false,
 }: Props) {
-  const {
-    swapWindow,
-    selectedDate,
-    setSelectedDate,
-    selectedDateKey,
-    participants,
-    swapped,
-    shortNotice,
-    waitlist,
-    userName,
-    userNameLower,
-    hasCancelled,
-    cutoffMinutes,
-    canSwapFromOrigin,
-    pendingCount,
-    hasPendingRequestsFromOrigin,
-    availableSwapDates,
-    waitlistDates,
-    swapForThisTerm,
-    hasNoUpcomingDates,
-    showLastTermInSelect,
-    lastOccurrenceDate,
-    showAutoInactiveStatusBadge,
-    cancellableUserSwapsOnCourse,
-    isPastOccurrence,
-    isSelectedTermExcluded,
-    showPastGraceMarker,
-    showCutoffMarker,
-    showExcludedTermMarker,
-    canUseFullTermActions,
-    canSwapFromPastCancelled,
-    swapForThisTermCancellable,
-    showPastTermSwapActions,
-    excludedTermNotice,
-    inactiveNotice,
-    termSelectDisabled,
-    swapStatusLines,
-    showCutoffHint,
-    termActionExtras,
-    swapPendingAbsenceAction,
-    primaryAbsenceAction,
-    swapModalTitle,
-    swapForWaitlist,
-  } = useCourseCardTermState({
+  const termState = useCourseCardTermState({
     course,
     allCourses,
     currentUser,
@@ -159,6 +109,27 @@ export default function CourseCard({
     initialSelectedDate,
     includePastTermsInSelect,
   });
+  const {
+    selectedDate,
+    setSelectedDate,
+    selectedDateKey,
+    participants,
+    swapped,
+    shortNotice,
+    waitlist,
+    userName,
+    userNameLower,
+    hasNoUpcomingDates,
+    showLastTermInSelect,
+    lastOccurrenceDate,
+    showAutoInactiveStatusBadge,
+    showPastGraceMarker,
+    showCutoffMarker,
+    showExcludedTermMarker,
+    excludedTermNotice,
+    inactiveNotice,
+    termSelectDisabled,
+  } = termState;
 
   const [showSwapModal, setShowSwapModal] = useState(false);
   const [absenceSaving, setAbsenceSaving] = useState(false);
@@ -470,231 +441,31 @@ export default function CourseCard({
         </div>
       )}
 
-      {canUseFullTermActions ? (
-        <div className="actions">
-          {swapForThisTerm ? (
-            <>
-              {/* Falls User den Ursprungstermin noch nicht abgesagt hat → Absage-Button trotzdem anzeigen */}
-              {swapPendingAbsenceAction && (
-                  <CourseTermActionButton
-                    ref={absenceButtonRef}
-                    action={swapPendingAbsenceAction.action}
-                    courseName={course.name}
-                    termIso={selectedDateKey}
-                    labelExtras={termActionExtras}
-                    className="danger"
-                    busy={absenceSaving}
-                    inactive={absenceSaving}
-                    onClick={() => handleToggleAbsence(swapPendingAbsenceAction.outcome)}
-                  />
-                )}
-
-              {swapForThisTermCancellable &&
-                (() => {
-                  const cancelSwapAction =
-                    swapForThisTerm.status === "pending"
-                      ? "Tauschanfragen abbrechen"
-                      : swapForThisTerm.status === "active" &&
-                          swapForThisTerm.toCourseId === course.id &&
-                          isWithinCancellationSwapCutoff(
-                            swapForThisTerm.toDate,
-                            allCourses.find((c) => c.id === swapForThisTerm.toCourseId)?.time ?? "",
-                            cutoffMinutes,
-                          )
-                        ? isShortNoticeCancelled(
-                            overrides.find(
-                              (o) =>
-                                o.courseId === swapForThisTerm.toCourseId &&
-                                o.date === swapForThisTerm.toDate,
-                            ),
-                            userName,
-                          )
-                          ? "Tauschabsage zurücknehmen"
-                          : "Am Zieltermin kurzfristig absagen"
-                        : "Tausch abbrechen";
-                  return (
-                    <CourseTermActionButton
-                      action={cancelSwapAction}
-                      courseName={course.name}
-                      termIso={selectedDateKey}
-                      labelExtras={termActionExtras}
-                      className="secondary danger"
-                      onClick={() => cancelSwap(swapForThisTerm, course.id)}
-                    />
-                  );
-                })()}
-            </>
-          ) : (
-            <>
-              {primaryAbsenceAction ? (
-                <CourseTermActionButton
-                  ref={absenceButtonRef}
-                  action={primaryAbsenceAction.action}
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  className="danger"
-                  busy={absenceSaving}
-                  inactive={absenceSaving}
-                  onClick={() => handleToggleAbsence(primaryAbsenceAction.outcome)}
-                />
-              ) : hasCancelled ? null : (
-                notEnrolledInTermHint
-              )}
-
-              {canSwapFromOrigin && (
-                <CourseTermActionButton
-                  action={hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen"}
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  className="secondary"
-                  onClick={openSwapModal}
-                />
-              )}
-              {showCutoffHint && (
-                <p className="muted small" role="status" aria-hidden="true">
-                  Weniger als {cutoffMinutes} Minuten vor Termin — kein Tausch mehr möglich.
-                </p>
-              )}
-
-            </>
-          )}
-          {/* 🆕 Wenn schon pending-Requests existieren: zusätzlicher Button */}
-              {hasPendingRequestsFromOrigin && canSwapFromOrigin && (
-                <CourseTermActionButton
-                  action="Weitere Tauschanfrage"
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  className="secondary"
-                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                  onClick={openSwapModal}
-                />
-              )}
-        </div>
-
-      ) : showPastTermSwapActions ? (
-        <div className="actions">
-          {swapForThisTerm && swapForThisTermCancellable ? (
-            <CourseTermActionButton
-              action={
-                swapForThisTerm.status === "pending"
-                  ? "Tauschanfragen abbrechen"
-                  : "Tausch abbrechen"
-              }
-              courseName={course.name}
-              termIso={selectedDateKey}
-              labelExtras={termActionExtras}
-              className="secondary danger"
-              onClick={() => cancelSwap(swapForThisTerm, course.id)}
-            />
-          ) : canSwapFromPastCancelled ? (
-            <>
-              <CourseTermActionButton
-                action="Anderen Termin wählen"
-                courseName={course.name}
-                termIso={selectedDateKey}
-                labelExtras={termActionExtras}
-                className="secondary"
-                onClick={openSwapModal}
-              />
-              {hasPendingRequestsFromOrigin && (
-                <CourseTermActionButton
-                  action="Weitere Tauschanfrage"
-                  courseName={course.name}
-                  termIso={selectedDateKey}
-                  labelExtras={termActionExtras}
-                  className="secondary"
-                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
-                  onClick={openSwapModal}
-                />
-              )}
-            </>
-          ) : null}
-        </div>
-      ) : isSelectedTermExcluded && includePastTermsInSelect ? (
-        swapForThisTerm && swapForThisTermCancellable ? (
-          <div className="actions">
-            <CourseTermActionButton
-              action={
-                swapForThisTerm.status === "pending"
-                  ? "Tauschanfrage abbrechen"
-                  : "Tausch abbrechen"
-              }
-              courseName={course.name}
-              termIso={selectedDateKey}
-              labelExtras={termActionExtras}
-              className="secondary danger"
-              onClick={() => cancelSwap(swapForThisTerm, course.id)}
-            />
-          </div>
-        ) : null
-      ) : isPastOccurrence && !participantActionsLocked ? (
-        <p className="muted small course-past-term-note" role="status">
-          Vergangener Termin — keine Änderungen mehr möglich.
-        </p>
-      ) : !participantActionsLocked && !hasNoUpcomingDates ? (
-        <>
-          {swapForWaitlist && canCancelSwap(swapForWaitlist, allCourses) ? (
-            <div className="actions">
-              <CourseTermActionButton
-                action="Tauschanfrage abbrechen"
-                courseName={course.name}
-                termIso={selectedDateKey}
-                labelExtras={termActionExtras}
-                className="secondary danger"
-                onClick={() => cancelSwap(swapForWaitlist, course.id)}
-              />
-            </div>
-          ) : (
-            notEnrolledInTermHint
-          )}
-        </>
-      ) : null}
-
-      {participantActionsLocked && cancellableUserSwapsOnCourse.length > 0 && (
-        <div className="actions course-inactive-swap-actions">
-          {cancellableUserSwapsOnCourse.map((swap) => (
-            <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
-              <CourseTermActionButton
-                action={swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}
-                courseName={course.name}
-                termIso={swapTermIsoForCourse(swap, course.id)}
-                labelExtras={[formatSwapStatusLine(swap, course.id, allCourses)]}
-                className="secondary danger"
-                onClick={() => cancelSwap(swap, course.id)}
-              />
-            </div>
-          ))}
-        </div>
-      )}
-
-      {swapStatusLines.length > 0 && (
-        <div className="muted small status-text" role="status" aria-hidden="true">
-          {swapStatusLines.map((line) => (
-            <div key={line}>{line}</div>
-          ))}
-        </div>
-      )}
-      {(canUseFullTermActions || canSwapFromPastCancelled) && showSwapModal && (
-        <CourseSwapModal
-          title={swapModalTitle}
-          courseName={course.name}
-          originTermIso={selectedDateKey}
-          originTermDisplay={new Date(selectedDate).toLocaleDateString()}
-          swapWindow={swapWindow}
-          availableSwapDates={availableSwapDates}
-          waitlistDates={waitlistDates}
-          onClose={closeSwapModal}
-          onConfirmFree={(targetCourseId, targetDateIso) =>
-            confirmSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
-          }
-          onConfirmWaitlist={(targetCourseId, targetDateIso) =>
-            requestSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
-          }
-        />
-      )}
+      <CourseTermActions
+        course={course}
+        allCourses={allCourses}
+        overrides={overrides}
+        userName={userName}
+        selectedDate={selectedDate}
+        includePastTermsInSelect={includePastTermsInSelect}
+        participantActionsLocked={participantActionsLocked}
+        hasNoUpcomingDates={hasNoUpcomingDates}
+        termState={termState}
+        absenceSaving={absenceSaving}
+        absenceButtonRef={absenceButtonRef}
+        showSwapModal={showSwapModal}
+        notEnrolledInTermHint={notEnrolledInTermHint}
+        onToggleAbsence={handleToggleAbsence}
+        onOpenSwapModal={openSwapModal}
+        onCloseSwapModal={closeSwapModal}
+        onCancelSwap={cancelSwap}
+        onConfirmSwap={(targetCourseId, targetDateIso) =>
+          confirmSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
+        }
+        onRequestSwap={(targetCourseId, targetDateIso) =>
+          requestSwap(course, selectedDateKey, targetCourseId, targetDateIso, userName)
+        }
+      />
     </article>
   );
 }

--- a/app/src/components/CourseCard.tsx
+++ b/app/src/components/CourseCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { CalendarX, Clock3, History } from "lucide-react";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -29,6 +29,8 @@ import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
 import { weekdayLabelDe } from "../lib/weekdayLabels";
 import type { SwapSettings } from "../types";
 import CourseSwapModal from "./CourseSwapModal";
+import { formatSwapStatusLine, swapTermIsoForCourse } from "../lib/courseTermActionLabels";
+import CourseTermActionButton from "./CourseTermActionButton";
 
 type Props = {
   course: Course;
@@ -61,80 +63,6 @@ function sameDayUTC(a: Date, b: Date) {
     a.getUTCDate() === b.getUTCDate()
   );
 }
-
-function courseTermActionLabel(
-  courseName: string,
-  action: string,
-  termIso: string,
-  extras: string[] = [],
-): string {
-  return [action, courseName, formatCourseIsoDateDe(termIso), ...extras].join(", ");
-}
-
-function formatSwapStatusLine(swap: Swap, courseId: number, allCourses: Course[]): string {
-  const courseName = (id: number) => allCourses.find((c) => c.id === id)?.name ?? "Kurs";
-  if (swap.status === "pending" && swap.fromCourseId === courseId) {
-    return `Tauschanfrage für ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
-  }
-  if (swap.status === "pending" && swap.toCourseId === courseId) {
-    return `Tauschanfrage zu ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
-  }
-  if (swap.fromCourseId === courseId) {
-    return `Getauscht mit ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
-  }
-  return `Getauscht von ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
-}
-
-function swapTermIsoForCourse(swap: Swap, courseId: number): string {
-  return swap.fromCourseId === courseId ? swap.fromDate : swap.toDate;
-}
-
-type CourseTermActionButtonProps = {
-  action: string;
-  courseName: string;
-  termIso: string;
-  labelExtras?: string[];
-  className?: string;
-  title?: string;
-  inactive?: boolean;
-  busy?: boolean;
-  onClick: () => void;
-};
-
-const CourseTermActionButton = forwardRef<HTMLButtonElement, CourseTermActionButtonProps>(
-  function CourseTermActionButton(
-    {
-      action,
-      courseName,
-      termIso,
-      labelExtras = [],
-      className,
-      title,
-      inactive,
-      busy,
-      onClick,
-    },
-    ref,
-  ) {
-    return (
-      <button
-        ref={ref}
-        type="button"
-        className={className}
-        aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
-        aria-busy={busy || undefined}
-        aria-disabled={inactive || undefined}
-        title={title}
-        onClick={() => {
-          if (inactive) return;
-          onClick();
-        }}
-      >
-        {action}
-      </button>
-    );
-  },
-);
 
 type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
 

--- a/app/src/components/CourseCardDetails.tsx
+++ b/app/src/components/CourseCardDetails.tsx
@@ -1,0 +1,310 @@
+import { useId } from "react";
+import { CalendarX, Clock3, History } from "lucide-react";
+import type { Course } from "shared/types";
+import { resolveMaxCapacity, resolveOverbookLimit } from "shared/courseCapacity";
+import { toDateKey } from "../lib/dates";
+import {
+  courseStatusBadgeLabel,
+  courseStatusBadgeText,
+  excludedTermOptionSuffix,
+  lastTermOptionSuffix,
+  participantChipAriaLabel,
+  TERM_MARKER_CUTOFF_LABEL,
+  TERM_MARKER_EXCLUDED_LABEL,
+  TERM_MARKER_PAST_LABEL,
+  termSelectAriaLabel,
+  termSelectDisabledHint,
+  waitlistChipAriaLabel,
+} from "../lib/courseCardLabels";
+import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
+import { weekdayLabelDe } from "../lib/weekdayLabels";
+import type { CourseCardTermState } from "./useCourseCardTermState";
+
+type CourseCardDetailsProps = {
+  course: Course;
+  dates: Date[];
+  showOverbookingDetails: boolean;
+  includePastTermsInSelect: boolean;
+  participantActionsLocked: boolean;
+  termState: CourseCardTermState;
+  selectedDate: string;
+  onSelectedDateChange: (isoValue: string, date: Date) => void;
+  titleId: string;
+  scheduleDescId: string;
+};
+
+export default function CourseCardDetails({
+  course,
+  dates,
+  showOverbookingDetails,
+  includePastTermsInSelect,
+  participantActionsLocked,
+  termState,
+  selectedDate,
+  onSelectedDateChange,
+  titleId,
+  scheduleDescId,
+}: CourseCardDetailsProps) {
+  const termSelectId = useId();
+  const termSelectDisabledHintId = useId();
+  const participantsLabelId = useId();
+  const waitlistLabelId = useId();
+
+  const {
+    participants,
+    swapped,
+    shortNotice,
+    waitlist,
+    userNameLower,
+    hasNoUpcomingDates,
+    showLastTermInSelect,
+    lastOccurrenceDate,
+    showAutoInactiveStatusBadge,
+    showPastGraceMarker,
+    showCutoffMarker,
+    showExcludedTermMarker,
+    excludedTermNotice,
+    inactiveNotice,
+    termSelectDisabled,
+  } = termState;
+
+  const overbookLimit = resolveOverbookLimit(course);
+  const maxCapacity = resolveMaxCapacity(course);
+  const regularFreeSpots = Math.max(0, course.capacity - participants.length);
+  const overbookFreeSpots = Math.max(0, maxCapacity - Math.max(participants.length, course.capacity));
+  const visibleFreeSpots = showOverbookingDetails
+    ? regularFreeSpots + overbookFreeSpots
+    : regularFreeSpots;
+
+  return (
+    <>
+      <div className="course-head">
+        <div className="course-head-primary">
+          <div className="course-head-title">
+            <h3 id={titleId}>
+              <span className="visually-hidden">Kurs: </span>
+              {course.name}
+            </h3>
+          </div>
+          <div
+            className="course-head-schedule muted"
+            id={scheduleDescId}
+            aria-label={`${weekdayLabelDe(course.weekday)} · ${course.time}`}
+          >
+            <span aria-hidden="true">
+              {course.weekday} · {course.time}
+            </span>
+          </div>
+        </div>
+        <div className="course-head-meta">
+          {(showPastGraceMarker || showCutoffMarker || showExcludedTermMarker) && (
+            <div className="course-term-visual-markers" role="status">
+              {showExcludedTermMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--excluded"
+                  role="img"
+                  aria-label={TERM_MARKER_EXCLUDED_LABEL}
+                  title={TERM_MARKER_EXCLUDED_LABEL}
+                >
+                  <CalendarX size={12} aria-hidden="true" />
+                </span>
+              )}
+              {showPastGraceMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--past"
+                  role="img"
+                  aria-label={TERM_MARKER_PAST_LABEL}
+                  title={TERM_MARKER_PAST_LABEL}
+                >
+                  <History size={12} aria-hidden="true" />
+                </span>
+              )}
+              {showCutoffMarker && (
+                <span
+                  className="course-term-visual-marker course-term-visual-marker--cutoff"
+                  role="img"
+                  aria-label={TERM_MARKER_CUTOFF_LABEL}
+                  title={TERM_MARKER_CUTOFF_LABEL}
+                >
+                  <Clock3 size={12} aria-hidden="true" />
+                </span>
+              )}
+            </div>
+          )}
+          {participantActionsLocked && (
+            <span
+              className={`course-status-badge ${
+                showAutoInactiveStatusBadge
+                  ? "course-status-badge--auto"
+                  : "course-status-badge--inactive"
+              }`}
+              aria-label={courseStatusBadgeLabel(showAutoInactiveStatusBadge)}
+            >
+              {courseStatusBadgeText(showAutoInactiveStatusBadge)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="course-row">
+        <div className="muted">Kapazität</div>
+        <div>
+          {showExcludedTermMarker ? (
+            <span className="muted" aria-label="Kapazität entfällt">
+              entfällt
+            </span>
+          ) : (
+            <>
+              {participants.length}/{course.capacity}
+              {showOverbookingDetails && overbookLimit > 0 && ` (+${overbookLimit})`}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="course-row">
+        {termSelectDisabled && (
+          <span id={termSelectDisabledHintId} className="visually-hidden">
+            {termSelectDisabledHint(course.name, (course.dates ?? []).length > 0)}
+          </span>
+        )}
+        <label
+          htmlFor={termSelectId}
+          className="muted course-row-label"
+          aria-label={termSelectAriaLabel(course.name)}
+        >
+          Termine
+        </label>
+        <select
+          id={termSelectId}
+          value={termSelectDisabled ? "" : selectedDate}
+          onChange={(e) => {
+            const next = new Date(e.target.value);
+            onSelectedDateChange(e.target.value, next);
+          }}
+          disabled={termSelectDisabled}
+          aria-describedby={termSelectDisabled ? termSelectDisabledHintId : undefined}
+        >
+          {showLastTermInSelect && lastOccurrenceDate ? (
+            <option value={lastOccurrenceDate.toISOString()}>
+              {lastOccurrenceDate.toLocaleDateString()}
+              {lastTermOptionSuffix()}
+            </option>
+          ) : hasNoUpcomingDates ? (
+            <option value="">—</option>
+          ) : (
+            (includePastTermsInSelect ? dates : dates.filter((d) => d >= new Date())).map(
+              (date, index) => {
+                const dateIso = toDateKey(date);
+                const excludedLabel = isExcludedCourseDate(course, dateIso)
+                  ? excludedTermOptionSuffix()
+                  : "";
+                return (
+                  <option key={index} value={date.toISOString()}>
+                    {date.toLocaleDateString()}
+                    {excludedLabel}
+                  </option>
+                );
+              },
+            )
+          )}
+        </select>
+      </div>
+
+      <div className="course-row list-row">
+        <div id={participantsLabelId} className="label muted">
+          Teilnehmer
+        </div>
+        <ul className="chips" aria-labelledby={participantsLabelId}>
+          {showExcludedTermMarker ? (
+            <li className="chip muted small" aria-label="Keine Teilnehmer, Termin entfällt">
+              —
+            </li>
+          ) : (
+            <>
+              {participants.length === 0 && (
+                <li className="chip" aria-label="Keine Teilnehmer eingetragen">
+                  —
+                </li>
+              )}
+              {participants.map((name) => {
+                const isSelf = name.toLowerCase() === userNameLower;
+                const isSn = shortNotice.some((n) => n.toLowerCase() === name.toLowerCase());
+                const isSwapped = swapped.includes(name);
+                const chipLabel = participantChipAriaLabel(name, { isSelf, isSn, isSwapped });
+                return (
+                  <li
+                    className={`chip${isSelf ? " chip-self" : ""}${
+                      isSn ? " short-notice" : isSwapped ? " swapped" : ""
+                    }`}
+                    key={name}
+                    aria-label={chipLabel}
+                  >
+                    {name}
+                  </li>
+                );
+              })}
+              {visibleFreeSpots > 0 &&
+                Array.from({ length: regularFreeSpots }).map((_, idx) => (
+                  <li className="chip free" key={`free-${idx}`} aria-label="Freier Platz">
+                    frei
+                  </li>
+                ))}
+              {showOverbookingDetails &&
+                overbookFreeSpots > 0 &&
+                Array.from({ length: overbookFreeSpots }).map((_, idx) => (
+                  <li
+                    className="chip overbook-free"
+                    key={`overbook-free-${idx}`}
+                    aria-label="Freier Überplanungsplatz"
+                  >
+                    +frei
+                  </li>
+                ))}
+            </>
+          )}
+        </ul>
+      </div>
+
+      <div className="course-row list-row">
+        <div id={waitlistLabelId} className="label muted">
+          Warteliste
+        </div>
+        <ul className="chips" aria-labelledby={waitlistLabelId}>
+          {showExcludedTermMarker ? (
+            <li className="chip muted small" aria-label="Keine Warteliste, Termin entfällt">
+              —
+            </li>
+          ) : waitlist.length === 0 ? (
+            <li className="chip muted small">Keine Anfragen</li>
+          ) : (
+            waitlist.map((name) => {
+              const isSelf = name.toLowerCase() === userNameLower;
+              return (
+                <li
+                  className={`chip wait${isSelf ? " chip-self" : ""}`}
+                  key={name}
+                  aria-label={waitlistChipAriaLabel(name, isSelf)}
+                >
+                  {name}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      </div>
+
+      {inactiveNotice && (
+        <div className="course-row course-inactive-notice" role="status">
+          <span className="muted small">{inactiveNotice}</span>
+        </div>
+      )}
+
+      {excludedTermNotice && (
+        <div className="course-row course-excluded-term-notice" role="status">
+          <span className="muted small">{excludedTermNotice}</span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/src/components/CourseTermActionButton.test.tsx
+++ b/app/src/components/CourseTermActionButton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import CourseTermActionButton from "./CourseTermActionButton";
+
+describe("CourseTermActionButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("setzt aria-label aus Aktion, Kurs und Termin", () => {
+    render(
+      <CourseTermActionButton
+        action="Termin absagen"
+        courseName="Yoga Basic"
+        termIso="2099-06-16"
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Termin absagen, Yoga Basic, 16.06.2099" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ruft onClick nicht auf, wenn inactive gesetzt ist", () => {
+    const onClick = vi.fn();
+    render(
+      <CourseTermActionButton
+        action="Termin absagen"
+        courseName="Yoga Basic"
+        termIso="2099-06-16"
+        inactive
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Termin absagen/i }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/CourseTermActionButton.tsx
+++ b/app/src/components/CourseTermActionButton.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from "react";
+import { courseTermActionLabel } from "../lib/courseTermActionLabels";
+
+type CourseTermActionButtonProps = {
+  action: string;
+  courseName: string;
+  termIso: string;
+  labelExtras?: string[];
+  className?: string;
+  title?: string;
+  inactive?: boolean;
+  busy?: boolean;
+  onClick: () => void;
+};
+
+const CourseTermActionButton = forwardRef<HTMLButtonElement, CourseTermActionButtonProps>(
+  function CourseTermActionButton(
+    {
+      action,
+      courseName,
+      termIso,
+      labelExtras = [],
+      className,
+      title,
+      inactive,
+      busy,
+      onClick,
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={className}
+        aria-label={courseTermActionLabel(courseName, action, termIso, labelExtras)}
+        aria-busy={busy || undefined}
+        aria-disabled={inactive || undefined}
+        title={title}
+        onClick={() => {
+          if (inactive) return;
+          onClick();
+        }}
+      >
+        {action}
+      </button>
+    );
+  },
+);
+
+export default CourseTermActionButton;

--- a/app/src/components/CourseTermActions.test.tsx
+++ b/app/src/components/CourseTermActions.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, screen, renderHook } from "@testing-library/react";
+import React from "react";
+import type { Course, CourseDateOverride, User } from "shared/types";
+import CourseTermActions from "./CourseTermActions";
+import { useCourseCardTermState } from "./useCourseCardTermState";
+
+const baseUser: User = {
+  nickname: "alice",
+  email: "",
+  role: "participant",
+};
+
+const baseCourse: Course = {
+  tenantId: "default-tenant",
+  id: 1,
+  name: "Yoga Basic",
+  weekday: "Monday",
+  time: "10:00",
+  capacity: 10,
+  participants: ["alice"],
+  dates: ["2099-06-16"],
+};
+
+const baseOverride: CourseDateOverride = {
+  courseId: 1,
+  date: "2099-06-16",
+  participants: ["alice"],
+  swapped: [],
+  waitlist: [],
+};
+
+const futureDate = new Date("2099-06-16T10:00:00Z");
+
+function renderCourseTermActions(
+  overrides: {
+    termStateOverrides?: Partial<Parameters<typeof useCourseCardTermState>[0]>;
+    props?: Partial<React.ComponentProps<typeof CourseTermActions>>;
+  } = {},
+) {
+  const { result } = renderHook(() =>
+    useCourseCardTermState({
+      course: baseCourse,
+      allCourses: [baseCourse],
+      currentUser: baseUser,
+      dates: [futureDate],
+      overrides: [baseOverride],
+      swaps: [],
+      ...overrides.termStateOverrides,
+    }),
+  );
+
+  const props: React.ComponentProps<typeof CourseTermActions> = {
+    course: baseCourse,
+    allCourses: [baseCourse],
+    overrides: [baseOverride],
+    userName: baseUser.nickname,
+    selectedDate: futureDate.toISOString(),
+    includePastTermsInSelect: false,
+    participantActionsLocked: false,
+    hasNoUpcomingDates: false,
+    termState: result.current,
+    absenceSaving: false,
+    absenceButtonRef: { current: null },
+    showSwapModal: false,
+    notEnrolledInTermHint: <div className="muted">Nicht in diesem Termin eingetragen</div>,
+    onToggleAbsence: vi.fn(),
+    onOpenSwapModal: vi.fn(),
+    onCloseSwapModal: vi.fn(),
+    onCancelSwap: vi.fn(),
+    onConfirmSwap: vi.fn(),
+    onRequestSwap: vi.fn(),
+    ...overrides.props,
+  };
+
+  return render(<CourseTermActions {...props} />);
+}
+
+describe("CourseTermActions", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("zeigt Kernaktionen für eingetragene Teilnehmer", () => {
+    vi.setSystemTime(new Date("2099-06-10T10:00:00Z"));
+    renderCourseTermActions();
+
+    expect(
+      screen.getByRole("button", { name: /Termin absagen, Yoga Basic, 16\.06\.2099/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Tauschen anfragen, Yoga Basic, 16\.06\.2099/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("zeigt Hinweis für vergangene Termine ohne Aktionen", () => {
+    vi.setSystemTime(new Date("2099-06-20T10:00:00Z"));
+    renderCourseTermActions({
+      termStateOverrides: { includePastTermsInSelect: true },
+    });
+
+    expect(
+      screen.getByText(/Vergangener Termin — keine Änderungen mehr möglich/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/src/components/CourseTermActions.tsx
+++ b/app/src/components/CourseTermActions.tsx
@@ -1,0 +1,318 @@
+import type { ReactNode, RefObject } from "react";
+import type { Course, CourseDateOverride, Swap } from "shared/types";
+import {
+  canCancelSwap,
+  isShortNoticeCancelled,
+  isWithinCancellationSwapCutoff,
+} from "shared/cancellationSwapCutoff";
+import { formatSwapStatusLine, swapTermIsoForCourse } from "../lib/courseTermActionLabels";
+import CourseSwapModal from "./CourseSwapModal";
+import CourseTermActionButton from "./CourseTermActionButton";
+import type { AbsenceToggleOutcome, CourseCardTermState } from "./useCourseCardTermState";
+
+function resolveActiveSwapCancelLabel(
+  swap: Swap,
+  course: Course,
+  allCourses: Course[],
+  overrides: CourseDateOverride[],
+  userName: string,
+  cutoffMinutes: number,
+): string {
+  if (swap.status === "pending") {
+    return "Tauschanfragen abbrechen";
+  }
+  if (
+    swap.status === "active" &&
+    swap.toCourseId === course.id &&
+    isWithinCancellationSwapCutoff(
+      swap.toDate,
+      allCourses.find((c) => c.id === swap.toCourseId)?.time ?? "",
+      cutoffMinutes,
+    )
+  ) {
+    return isShortNoticeCancelled(
+      overrides.find((o) => o.courseId === swap.toCourseId && o.date === swap.toDate),
+      userName,
+    )
+      ? "Tauschabsage zurücknehmen"
+      : "Am Zieltermin kurzfristig absagen";
+  }
+  return "Tausch abbrechen";
+}
+
+function resolvePendingSwapCancelLabel(swap: Swap): string {
+  return swap.status === "pending" ? "Tauschanfragen abbrechen" : "Tausch abbrechen";
+}
+
+type CourseTermActionsProps = {
+  course: Course;
+  allCourses: Course[];
+  overrides: CourseDateOverride[];
+  userName: string;
+  selectedDate: string;
+  includePastTermsInSelect: boolean;
+  participantActionsLocked: boolean;
+  hasNoUpcomingDates: boolean;
+  termState: CourseCardTermState;
+  absenceSaving: boolean;
+  absenceButtonRef: RefObject<HTMLButtonElement | null>;
+  showSwapModal: boolean;
+  notEnrolledInTermHint: ReactNode;
+  onToggleAbsence: (outcome: AbsenceToggleOutcome) => void;
+  onOpenSwapModal: () => void;
+  onCloseSwapModal: () => void;
+  onCancelSwap: (swap: Swap, clickedCourseId: number) => void;
+  onConfirmSwap: (targetCourseId: number, targetDateIso: string) => void;
+  onRequestSwap: (targetCourseId: number, targetDateIso: string) => void;
+};
+
+export default function CourseTermActions({
+  course,
+  allCourses,
+  overrides,
+  userName,
+  selectedDate,
+  includePastTermsInSelect,
+  participantActionsLocked,
+  hasNoUpcomingDates,
+  termState,
+  absenceSaving,
+  absenceButtonRef,
+  showSwapModal,
+  notEnrolledInTermHint,
+  onToggleAbsence,
+  onOpenSwapModal,
+  onCloseSwapModal,
+  onCancelSwap,
+  onConfirmSwap,
+  onRequestSwap,
+}: CourseTermActionsProps) {
+  const {
+    selectedDateKey,
+    hasCancelled,
+    cutoffMinutes,
+    canSwapFromOrigin,
+    pendingCount,
+    hasPendingRequestsFromOrigin,
+    availableSwapDates,
+    waitlistDates,
+    swapWindow,
+    swapForThisTerm,
+    isPastOccurrence,
+    isSelectedTermExcluded,
+    canUseFullTermActions,
+    canSwapFromPastCancelled,
+    swapForThisTermCancellable,
+    showPastTermSwapActions,
+    swapStatusLines,
+    showCutoffHint,
+    termActionExtras,
+    swapPendingAbsenceAction,
+    primaryAbsenceAction,
+    swapModalTitle,
+    swapForWaitlist,
+    cancellableUserSwapsOnCourse,
+  } = termState;
+
+  return (
+    <>
+      {canUseFullTermActions ? (
+        <div className="actions">
+          {swapForThisTerm ? (
+            <>
+              {swapPendingAbsenceAction && (
+                <CourseTermActionButton
+                  ref={absenceButtonRef}
+                  action={swapPendingAbsenceAction.action}
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="danger"
+                  busy={absenceSaving}
+                  inactive={absenceSaving}
+                  onClick={() => onToggleAbsence(swapPendingAbsenceAction.outcome)}
+                />
+              )}
+
+              {swapForThisTerm && swapForThisTermCancellable && (
+                <CourseTermActionButton
+                  action={resolveActiveSwapCancelLabel(
+                    swapForThisTerm,
+                    course,
+                    allCourses,
+                    overrides,
+                    userName,
+                    cutoffMinutes,
+                  )}
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="secondary danger"
+                  onClick={() => onCancelSwap(swapForThisTerm, course.id)}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {primaryAbsenceAction ? (
+                <CourseTermActionButton
+                  ref={absenceButtonRef}
+                  action={primaryAbsenceAction.action}
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="danger"
+                  busy={absenceSaving}
+                  inactive={absenceSaving}
+                  onClick={() => onToggleAbsence(primaryAbsenceAction.outcome)}
+                />
+              ) : hasCancelled ? null : (
+                notEnrolledInTermHint
+              )}
+
+              {canSwapFromOrigin && (
+                <CourseTermActionButton
+                  action={hasCancelled ? "Anderen Termin wählen" : "Tauschen anfragen"}
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="secondary"
+                  onClick={onOpenSwapModal}
+                />
+              )}
+              {showCutoffHint && (
+                <p className="muted small" role="status" aria-hidden="true">
+                  Weniger als {cutoffMinutes} Minuten vor Termin — kein Tausch mehr möglich.
+                </p>
+              )}
+            </>
+          )}
+          {hasPendingRequestsFromOrigin && canSwapFromOrigin && (
+            <CourseTermActionButton
+              action="Weitere Tauschanfrage"
+              courseName={course.name}
+              termIso={selectedDateKey}
+              labelExtras={termActionExtras}
+              className="secondary"
+              title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
+              onClick={onOpenSwapModal}
+            />
+          )}
+        </div>
+      ) : showPastTermSwapActions ? (
+        <div className="actions">
+          {swapForThisTerm && swapForThisTermCancellable ? (
+            <CourseTermActionButton
+              action={resolvePendingSwapCancelLabel(swapForThisTerm)}
+              courseName={course.name}
+              termIso={selectedDateKey}
+              labelExtras={termActionExtras}
+              className="secondary danger"
+              onClick={() => onCancelSwap(swapForThisTerm, course.id)}
+            />
+          ) : canSwapFromPastCancelled ? (
+            <>
+              <CourseTermActionButton
+                action="Anderen Termin wählen"
+                courseName={course.name}
+                termIso={selectedDateKey}
+                labelExtras={termActionExtras}
+                className="secondary"
+                onClick={onOpenSwapModal}
+              />
+              {hasPendingRequestsFromOrigin && (
+                <CourseTermActionButton
+                  action="Weitere Tauschanfrage"
+                  courseName={course.name}
+                  termIso={selectedDateKey}
+                  labelExtras={termActionExtras}
+                  className="secondary"
+                  title={`Du hast bereits ${pendingCount} offene Anfragen für diesen Termin — hier kannst du noch eine weitere anlegen.`}
+                  onClick={onOpenSwapModal}
+                />
+              )}
+            </>
+          ) : null}
+        </div>
+      ) : isSelectedTermExcluded && includePastTermsInSelect ? (
+        swapForThisTerm && swapForThisTermCancellable ? (
+          <div className="actions">
+            <CourseTermActionButton
+              action={
+                swapForThisTerm.status === "pending"
+                  ? "Tauschanfrage abbrechen"
+                  : "Tausch abbrechen"
+              }
+              courseName={course.name}
+              termIso={selectedDateKey}
+              labelExtras={termActionExtras}
+              className="secondary danger"
+              onClick={() => onCancelSwap(swapForThisTerm, course.id)}
+            />
+          </div>
+        ) : null
+      ) : isPastOccurrence && !participantActionsLocked ? (
+        <p className="muted small course-past-term-note" role="status">
+          Vergangener Termin — keine Änderungen mehr möglich.
+        </p>
+      ) : !participantActionsLocked && !hasNoUpcomingDates ? (
+        <>
+          {swapForWaitlist && canCancelSwap(swapForWaitlist, allCourses) ? (
+            <div className="actions">
+              <CourseTermActionButton
+                action="Tauschanfrage abbrechen"
+                courseName={course.name}
+                termIso={selectedDateKey}
+                labelExtras={termActionExtras}
+                className="secondary danger"
+                onClick={() => onCancelSwap(swapForWaitlist, course.id)}
+              />
+            </div>
+          ) : (
+            notEnrolledInTermHint
+          )}
+        </>
+      ) : null}
+
+      {participantActionsLocked && cancellableUserSwapsOnCourse.length > 0 && (
+        <div className="actions course-inactive-swap-actions">
+          {cancellableUserSwapsOnCourse.map((swap) => (
+            <div key={`${swap.fromCourseId}-${swap.fromDate}-${swap.toCourseId}-${swap.toDate}-${swap.status}`}>
+              <CourseTermActionButton
+                action={swap.status === "pending" ? "Tauschanfrage abbrechen" : "Tausch abbrechen"}
+                courseName={course.name}
+                termIso={swapTermIsoForCourse(swap, course.id)}
+                labelExtras={[formatSwapStatusLine(swap, course.id, allCourses)]}
+                className="secondary danger"
+                onClick={() => onCancelSwap(swap, course.id)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {swapStatusLines.length > 0 && (
+        <div className="muted small status-text" role="status" aria-hidden="true">
+          {swapStatusLines.map((line) => (
+            <div key={line}>{line}</div>
+          ))}
+        </div>
+      )}
+
+      {(canUseFullTermActions || canSwapFromPastCancelled) && showSwapModal && (
+        <CourseSwapModal
+          title={swapModalTitle}
+          courseName={course.name}
+          originTermIso={selectedDateKey}
+          originTermDisplay={new Date(selectedDate).toLocaleDateString()}
+          swapWindow={swapWindow}
+          availableSwapDates={availableSwapDates}
+          waitlistDates={waitlistDates}
+          onClose={onCloseSwapModal}
+          onConfirmFree={onConfirmSwap}
+          onConfirmWaitlist={onRequestSwap}
+        />
+      )}
+    </>
+  );
+}

--- a/app/src/components/useCourseCardTermState.test.ts
+++ b/app/src/components/useCourseCardTermState.test.ts
@@ -107,6 +107,49 @@ describe("useCourseCardTermState", () => {
     expect(cancelled.current.swapModalTitle).toBe("Anderen Termin wählen");
   });
 
+  it("verbirgt Nachlauf-Tauschstart bei bestehendem Swap am Ursprungstermin", () => {
+    const pastOrigin = "2099-06-10";
+    const pastTarget = "2099-06-12";
+    const cancelledOverride: CourseDateOverride = {
+      ...baseOverride,
+      date: pastOrigin,
+      participants: [],
+    };
+    const activeSwap: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: pastOrigin,
+      toCourseId: 2,
+      toDate: pastTarget,
+      status: "active",
+    };
+    const targetCourse: Course = {
+      ...baseCourse,
+      id: 2,
+      name: "Yoga Advanced",
+      dates: [pastTarget],
+      participants: ["alice"],
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2099-06-14T10:00:00Z"));
+
+    const { result } = renderTermState({
+      course: { ...baseCourse, dates: [pastOrigin] },
+      allCourses: [baseCourse, targetCourse],
+      dates: [new Date(`${pastOrigin}T10:00:00Z`)],
+      overrides: [cancelledOverride],
+      swaps: [activeSwap],
+      includePastTermsInSelect: true,
+    });
+
+    expect(result.current.canSwapFromPastCancelled).toBe(false);
+    expect(result.current.swapForThisTermCancellable).toBe(false);
+    expect(result.current.showPastTermSwapActions).toBe(false);
+
+    vi.useRealTimers();
+  });
+
   it("findet pending Swap für den gewählten Termin", () => {
     const pendingSwap: Swap = {
       user: "alice",

--- a/app/src/components/useCourseCardTermState.test.ts
+++ b/app/src/components/useCourseCardTermState.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Course, CourseDateOverride, Swap, User } from "shared/types";
+import { useCourseCardTermState } from "./useCourseCardTermState";
+
+const baseUser: User = {
+  nickname: "alice",
+  email: "",
+  role: "participant",
+};
+
+const baseCourse: Course = {
+  tenantId: "default-tenant",
+  id: 1,
+  name: "Yoga Basic",
+  weekday: "Monday",
+  time: "10:00",
+  capacity: 10,
+  participants: ["alice"],
+  dates: ["2099-06-16"],
+};
+
+const baseOverride: CourseDateOverride = {
+  courseId: 1,
+  date: "2099-06-16",
+  participants: ["alice"],
+  swapped: [],
+  waitlist: [],
+};
+
+const futureDate = new Date("2099-06-16T10:00:00Z");
+
+function renderTermState(
+  overrides: Partial<Parameters<typeof useCourseCardTermState>[0]> = {},
+) {
+  return renderHook(() =>
+    useCourseCardTermState({
+      course: baseCourse,
+      allCourses: [baseCourse],
+      currentUser: baseUser,
+      dates: [futureDate],
+      overrides: [baseOverride],
+      swaps: [],
+      ...overrides,
+    }),
+  );
+}
+
+describe("useCourseCardTermState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leitet selectedDateKey und Teilnehmerstatus für den gewählten Termin ab", () => {
+    const { result } = renderTermState();
+
+    expect(result.current.selectedDateKey).toBe("2099-06-16");
+    expect(result.current.isParticipant).toBe(true);
+    expect(result.current.canUseFullTermActions).toBe(true);
+    expect(result.current.primaryAbsenceAction).toEqual({
+      action: "Termin absagen",
+      outcome: "cancelled",
+    });
+  });
+
+  it("erlaubt Tausch und Absage-Rücknahme nach regulärer Absage", () => {
+    const cancelledOverride: CourseDateOverride = {
+      ...baseOverride,
+      participants: [],
+    };
+
+    const { result } = renderTermState({ overrides: [cancelledOverride] });
+
+    expect(result.current.isParticipant).toBe(false);
+    expect(result.current.hasCancelled).toBe(true);
+    expect(result.current.canSwapFromOrigin).toBe(true);
+    expect(result.current.primaryAbsenceAction).toEqual({
+      action: "Absage zurücknehmen",
+      outcome: "undo",
+    });
+  });
+
+  it("setzt canUseFullTermActions auf false für vergangene Termine in der Wochenansicht", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2099-06-20T10:00:00Z"));
+
+    const { result } = renderTermState({
+      includePastTermsInSelect: true,
+      dates: [new Date("2099-06-16T10:00:00Z")],
+    });
+
+    expect(result.current.isPastOccurrence).toBe(true);
+    expect(result.current.canUseFullTermActions).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("liefert Tausch-Modal-Titel abhängig vom Absagestatus", () => {
+    const { result: enrolled } = renderTermState();
+    expect(enrolled.current.swapModalTitle).toBe("Tauschanfrage starten");
+
+    const cancelledOverride: CourseDateOverride = {
+      ...baseOverride,
+      participants: [],
+    };
+    const { result: cancelled } = renderTermState({ overrides: [cancelledOverride] });
+    expect(cancelled.current.swapModalTitle).toBe("Anderen Termin wählen");
+  });
+
+  it("findet pending Swap für den gewählten Termin", () => {
+    const pendingSwap: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: "2099-06-16",
+      toCourseId: 2,
+      toDate: "2099-06-17",
+      status: "pending",
+    };
+
+    const { result } = renderTermState({
+      swaps: [pendingSwap],
+      allCourses: [baseCourse, { ...baseCourse, id: 2, name: "Yoga Advanced" }],
+    });
+
+    expect(result.current.swapForThisTerm).toEqual(pendingSwap);
+    expect(result.current.swapPendingAbsenceAction).toEqual({
+      action: "Termin absagen",
+      outcome: "cancelled",
+    });
+  });
+});

--- a/app/src/components/useCourseCardTermState.ts
+++ b/app/src/components/useCourseCardTermState.ts
@@ -1,0 +1,427 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Course, CourseDateOverride, Swap, TenantSettings, User } from "shared/types";
+import {
+  buildCourseOccurrenceLocal,
+  formatCourseIsoDateDe,
+  getInactiveGraceLastDayIso,
+  isCourseInInactiveGracePeriod,
+  isWithinPostCourseEndGrace,
+  lastScheduledOccurrenceIso,
+  looksLikeAutomaticallyInactive,
+} from "shared/courseStatus";
+import { resolveSwapWindow } from "shared/tenantSettings";
+import {
+  canCancelSwap,
+  canCreateSwapFromOrigin,
+  hasEffectiveCancellation,
+  isShortNoticeCancelled,
+  isWithinCancellationSwapCutoff,
+  resolveCancellationSwapCutoffMinutes,
+} from "shared/cancellationSwapCutoff";
+import { getAvailableDates, getWaitlistDates, toDateKey } from "../lib/dates";
+import {
+  canRequestSwapFromPastCancelledOrigin,
+  isOccurrenceInPast,
+} from "../lib/courseTermActions";
+import { formatSwapStatusLine } from "../lib/courseTermActionLabels";
+import { isExcludedCourseDate } from "../lib/courseWeekOccurrences";
+import type { SwapSettings } from "../types";
+
+export type AbsenceToggleOutcome = "cancelled" | "shortNoticeCancelled" | "undo";
+
+function sameDayUTC(a: Date, b: Date) {
+  return (
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
+  );
+}
+
+export type UseCourseCardTermStateParams = {
+  course: Course;
+  allCourses: Course[];
+  currentUser: User;
+  dates: Date[];
+  overrides: CourseDateOverride[];
+  swaps: Swap[];
+  participantActionsLocked?: boolean;
+  tenantSettings?: TenantSettings;
+  initialSelectedDate?: Date;
+  includePastTermsInSelect?: boolean;
+};
+
+export function useCourseCardTermState({
+  course,
+  allCourses,
+  currentUser,
+  dates,
+  overrides,
+  swaps,
+  participantActionsLocked = false,
+  tenantSettings,
+  initialSelectedDate,
+  includePastTermsInSelect = false,
+}: UseCourseCardTermStateParams) {
+  const swapWindow: SwapSettings = useMemo(
+    () => resolveSwapWindow(tenantSettings),
+    [tenantSettings],
+  );
+
+  const [selectedDate, setSelectedDate] = useState<string>(
+    () => (initialSelectedDate ?? dates[0])?.toISOString() || "",
+  );
+
+  const userName = currentUser.nickname;
+  const selectedDateKey = toDateKey(new Date(selectedDate));
+
+  const override = useMemo(
+    () =>
+      overrides.find((o) =>
+        o.courseId === course.id && sameDayUTC(new Date(o.date), new Date(selectedDate)),
+      ),
+    [overrides, course.id, selectedDate],
+  );
+
+  const hasNoUpcomingDates = dates.length === 0;
+  const participants = hasNoUpcomingDates ? course.participants : (override ? override.participants : course.participants);
+  const swapped = hasNoUpcomingDates ? [] : (override?.swapped ?? []);
+  const shortNotice = hasNoUpcomingDates ? [] : (override?.shortNoticeCancellations ?? []);
+  const waitlist = hasNoUpcomingDates ? [] : (override?.waitlist ?? []);
+
+  const userNameLower = userName.toLowerCase();
+  const isParticipant = participants.some((p) => p.toLowerCase() === userNameLower);
+  const originallyParticipant = course.participants.some((p) => p.toLowerCase() === userNameLower);
+  const isShortNotice = isShortNoticeCancelled(override, userName);
+  const hasCancelled = hasEffectiveCancellation(
+    originallyParticipant,
+    override,
+    participants,
+    userName,
+  );
+  const cutoffMinutes = resolveCancellationSwapCutoffMinutes(tenantSettings);
+  const originInCutoff = isWithinCancellationSwapCutoff(
+    selectedDateKey,
+    course.time,
+    cutoffMinutes,
+  );
+  const canSwapFromOrigin =
+    (originallyParticipant || hasCancelled) &&
+    canCreateSwapFromOrigin({
+      isoDate: selectedDateKey,
+      courseTime: course.time,
+      tenantSettings,
+      override,
+      userName,
+      participants,
+      originallyParticipant,
+    });
+  const hasActiveOriginSwapInPast = swaps.some(
+    (s) =>
+      s.user === userName &&
+      s.status === "active" &&
+      s.fromCourseId === course.id &&
+      s.fromDate === selectedDateKey &&
+      new Date(s.toDate) < new Date(),
+  );
+  const canUndoRegularAbsence =
+    hasCancelled && !isShortNotice && !isParticipant && !hasActiveOriginSwapInPast;
+
+  const pendingSwapsFromOrigin = useMemo(
+    () =>
+      swaps.filter(
+        (s) =>
+          s.user === userName &&
+          s.fromCourseId === course.id &&
+          s.fromDate === selectedDateKey &&
+          s.status === "pending",
+      ),
+    [swaps, userName, course.id, selectedDateKey],
+  );
+
+  const existingPendingTargetCourseIds = useMemo(
+    () => new Set(pendingSwapsFromOrigin.map((swap) => swap.toCourseId)),
+    [pendingSwapsFromOrigin],
+  );
+
+  const availableSwapDates = useMemo(
+    () =>
+      getAvailableDates(
+        allCourses,
+        overrides,
+        currentUser,
+        swapWindow,
+        new Date(selectedDate),
+        undefined,
+        tenantSettings,
+      )
+        .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
+        .sort((a, b) => a.date.getTime() - b.date.getTime()),
+    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow, tenantSettings],
+  );
+
+  const waitlistDates = useMemo(
+    () =>
+      getWaitlistDates(
+        allCourses,
+        overrides,
+        currentUser,
+        swapWindow,
+        new Date(selectedDate),
+        undefined,
+        tenantSettings,
+      )
+        .filter((option) => !existingPendingTargetCourseIds.has(option.course.id))
+        .sort((a, b) => a.date.getTime() - b.date.getTime()),
+    [allCourses, overrides, currentUser, selectedDate, existingPendingTargetCourseIds, swapWindow, tenantSettings],
+  );
+
+  const swapForThisTerm = useMemo(
+    () =>
+      swaps.find(
+        (s) =>
+          s.user === userName &&
+          ((s.fromCourseId === course.id && s.fromDate === selectedDateKey) ||
+            (s.toCourseId === course.id && s.toDate === selectedDateKey)),
+      ),
+    [swaps, userName, course.id, selectedDateKey],
+  );
+
+  const allSwapsForThisTerm = useMemo(
+    () =>
+      swaps.filter(
+        (s) =>
+          (s.fromCourseId === course.id && s.fromDate === selectedDateKey && s.user === userName) ||
+          (s.toCourseId === course.id && s.toDate === selectedDateKey && s.user === userName),
+      ),
+    [swaps, userName, course.id, selectedDateKey],
+  );
+
+  const swapForWaitlist = useMemo(
+    () =>
+      swaps.find(
+        (s) =>
+          s.user === userName &&
+          s.toCourseId === course.id &&
+          s.toDate === selectedDateKey &&
+          s.status === "pending",
+      ),
+    [swaps, userName, course.id, selectedDateKey],
+  );
+
+  const pendingCount = pendingSwapsFromOrigin.length;
+  const hasPendingRequestsFromOrigin = pendingCount > 0;
+
+  const hasUpcomingDates = dates.length > 0;
+  const courseStatus = course.status ?? "active";
+  const isInactiveCourse = courseStatus === "inactive";
+  const inPostEndGrace = isWithinPostCourseEndGrace(course, tenantSettings);
+  const inInactiveGrace =
+    isInactiveCourse && isCourseInInactiveGracePeriod(course, tenantSettings);
+  const graceLastIso =
+    inPostEndGrace || inInactiveGrace
+      ? getInactiveGraceLastDayIso(course, tenantSettings)
+      : undefined;
+  const lastActualOccurrenceIso = useMemo(
+    () => lastScheduledOccurrenceIso({ dates: course.dates }),
+    [course.dates],
+  );
+  const lastOccurrenceDate =
+    lastActualOccurrenceIso != null
+      ? buildCourseOccurrenceLocal(lastActualOccurrenceIso, course.time)
+      : null;
+  const showLastTermInSelect =
+    hasNoUpcomingDates && lastOccurrenceDate != null && inPostEndGrace;
+  const showAutoInactiveBadge =
+    participantActionsLocked && looksLikeAutomaticallyInactive(course, hasUpcomingDates);
+  const userSwapsOnCourse = useMemo(
+    () =>
+      swaps.filter(
+        (s) =>
+          s.user === userName &&
+          (s.fromCourseId === course.id || s.toCourseId === course.id),
+      ),
+    [swaps, userName, course.id],
+  );
+  const cancellableUserSwapsOnCourse = useMemo(
+    () => userSwapsOnCourse.filter((swap) => canCancelSwap(swap, allCourses)),
+    [userSwapsOnCourse, allCourses],
+  );
+  const isPastOccurrence = isOccurrenceInPast(selectedDateKey, course.time);
+  const isSelectedTermExcluded = isExcludedCourseDate(course, selectedDateKey);
+  const showPastGraceMarker =
+    includePastTermsInSelect && isPastOccurrence && !isSelectedTermExcluded;
+  const showCutoffMarker =
+    includePastTermsInSelect &&
+    !isPastOccurrence &&
+    !isSelectedTermExcluded &&
+    originInCutoff;
+  const showExcludedTermMarker = includePastTermsInSelect && isSelectedTermExcluded;
+  const canUseFullTermActions =
+    !participantActionsLocked &&
+    hasUpcomingDates &&
+    (isParticipant || originallyParticipant) &&
+    !isPastOccurrence &&
+    !isSelectedTermExcluded;
+  const canSwapFromPastCancelled = canRequestSwapFromPastCancelledOrigin({
+    isoDate: selectedDateKey,
+    courseTime: course.time,
+    tenantSettings,
+    override,
+    userName,
+    participants,
+    originallyParticipant,
+  });
+  const swapForThisTermCancellable =
+    swapForThisTerm != null && canCancelSwap(swapForThisTerm, allCourses);
+  const showPastTermSwapActions =
+    !participantActionsLocked &&
+    !isSelectedTermExcluded &&
+    isPastOccurrence &&
+    (isParticipant || originallyParticipant || hasCancelled) &&
+    (swapForThisTermCancellable || canSwapFromPastCancelled);
+  const excludedTermNotice = showExcludedTermMarker
+    ? "Dieser Termin entfällt — vom Studio abgesagt."
+    : null;
+
+  const inactiveNotice = participantActionsLocked
+    ? showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace)
+      ? graceLastIso
+        ? `Dieser Kurs wurde automatisch beendet (keine weiteren Termine). Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
+        : "Dieser Kurs wurde automatisch beendet. Du kannst nur noch bestehende Tausche verwalten."
+      : graceLastIso
+        ? `Dieser Kurs ist inaktiv. Offene Tausche kannst du noch bis ${formatCourseIsoDateDe(graceLastIso)} verwalten.`
+        : "Dieser Kurs ist inaktiv. Du kannst nur noch bestehende Tausche verwalten."
+    : null;
+
+  useEffect(() => {
+    if (includePastTermsInSelect) return;
+    if (showLastTermInSelect && lastOccurrenceDate) {
+      setSelectedDate(lastOccurrenceDate.toISOString());
+    }
+  }, [includePastTermsInSelect, showLastTermInSelect, lastActualOccurrenceIso, course.time, lastOccurrenceDate]);
+
+  const initialSelectedTime = initialSelectedDate?.getTime();
+  useEffect(() => {
+    if (initialSelectedTime == null) return;
+    setSelectedDate(new Date(initialSelectedTime).toISOString());
+  }, [initialSelectedTime]);
+
+  const termSelectDisabled = hasNoUpcomingDates && !showLastTermInSelect;
+
+  const swapStatusLines = useMemo(
+    () =>
+      hasNoUpcomingDates
+        ? []
+        : allSwapsForThisTerm.map((swap) => formatSwapStatusLine(swap, course.id, allCourses)),
+    [hasNoUpcomingDates, allSwapsForThisTerm, course.id, allCourses],
+  );
+
+  const showCutoffHint =
+    canUseFullTermActions &&
+    !swapForThisTerm &&
+    originInCutoff &&
+    (originallyParticipant || hasCancelled) &&
+    !canSwapFromOrigin;
+
+  const cutoffStatusLabel = showCutoffHint
+    ? `Weniger als ${cutoffMinutes} Minuten vor Termin, kein Tausch mehr möglich`
+    : undefined;
+
+  const swapStatusExtras = swapStatusLines.length > 0 ? swapStatusLines : undefined;
+  const cutoffExtras = cutoffStatusLabel ? [cutoffStatusLabel] : undefined;
+  const termActionExtras = [...(swapStatusExtras ?? []), ...(cutoffExtras ?? [])];
+
+  const swapPendingAbsenceAction = useMemo((): {
+    action: string;
+    outcome: AbsenceToggleOutcome;
+  } | null => {
+    if (swapForThisTerm?.status === "pending" && originallyParticipant) {
+      return {
+        action: hasCancelled ? "Absage zurücknehmen" : "Termin absagen",
+        outcome: hasCancelled ? "undo" : "cancelled",
+      };
+    }
+    return null;
+  }, [swapForThisTerm, originallyParticipant, hasCancelled]);
+
+  const primaryAbsenceAction = useMemo((): {
+    action: string;
+    outcome: AbsenceToggleOutcome;
+  } | null => {
+    if (isShortNotice) {
+      return { action: "Absage zurücknehmen", outcome: "undo" };
+    }
+    if (isParticipant) {
+      return {
+        action: "Termin absagen",
+        outcome: originInCutoff ? "shortNoticeCancelled" : "cancelled",
+      };
+    }
+    if (canUndoRegularAbsence) {
+      return { action: "Absage zurücknehmen", outcome: "undo" };
+    }
+    return null;
+  }, [isShortNotice, isParticipant, canUndoRegularAbsence, originInCutoff]);
+
+  const swapModalTitle = hasCancelled ? "Anderen Termin wählen" : "Tauschanfrage starten";
+  const showAutoInactiveStatusBadge =
+    showAutoInactiveBadge || (!isInactiveCourse && inPostEndGrace);
+
+  return {
+    swapWindow,
+    selectedDate,
+    setSelectedDate,
+    selectedDateKey,
+    override,
+    participants,
+    swapped,
+    shortNotice,
+    waitlist,
+    userName,
+    userNameLower,
+    isParticipant,
+    originallyParticipant,
+    isShortNotice,
+    hasCancelled,
+    cutoffMinutes,
+    originInCutoff,
+    canSwapFromOrigin,
+    canUndoRegularAbsence,
+    pendingSwapsFromOrigin,
+    pendingCount,
+    hasPendingRequestsFromOrigin,
+    availableSwapDates,
+    waitlistDates,
+    swapForThisTerm,
+    allSwapsForThisTerm,
+    swapForWaitlist,
+    hasNoUpcomingDates,
+    hasUpcomingDates,
+    showLastTermInSelect,
+    lastOccurrenceDate,
+    showAutoInactiveBadge,
+    showAutoInactiveStatusBadge,
+    graceLastIso,
+    userSwapsOnCourse,
+    cancellableUserSwapsOnCourse,
+    isPastOccurrence,
+    isSelectedTermExcluded,
+    showPastGraceMarker,
+    showCutoffMarker,
+    showExcludedTermMarker,
+    canUseFullTermActions,
+    canSwapFromPastCancelled,
+    swapForThisTermCancellable,
+    showPastTermSwapActions,
+    excludedTermNotice,
+    inactiveNotice,
+    termSelectDisabled,
+    swapStatusLines,
+    showCutoffHint,
+    cutoffStatusLabel,
+    termActionExtras,
+    swapPendingAbsenceAction,
+    primaryAbsenceAction,
+    swapModalTitle,
+  };
+}

--- a/app/src/components/useCourseCardTermState.ts
+++ b/app/src/components/useCourseCardTermState.ts
@@ -425,3 +425,5 @@ export function useCourseCardTermState({
     swapModalTitle,
   };
 }
+
+export type CourseCardTermState = ReturnType<typeof useCourseCardTermState>;

--- a/app/src/components/useCourseCardTermState.ts
+++ b/app/src/components/useCourseCardTermState.ts
@@ -262,15 +262,17 @@ export function useCourseCardTermState({
     (isParticipant || originallyParticipant) &&
     !isPastOccurrence &&
     !isSelectedTermExcluded;
-  const canSwapFromPastCancelled = canRequestSwapFromPastCancelledOrigin({
-    isoDate: selectedDateKey,
-    courseTime: course.time,
-    tenantSettings,
-    override,
-    userName,
-    participants,
-    originallyParticipant,
-  });
+  const canSwapFromPastCancelled =
+    swapForThisTerm == null &&
+    canRequestSwapFromPastCancelledOrigin({
+      isoDate: selectedDateKey,
+      courseTime: course.time,
+      tenantSettings,
+      override,
+      userName,
+      participants,
+      originallyParticipant,
+    });
   const swapForThisTermCancellable =
     swapForThisTerm != null && canCancelSwap(swapForThisTerm, allCourses);
   const showPastTermSwapActions =

--- a/app/src/lib/courseCardLabels.test.ts
+++ b/app/src/lib/courseCardLabels.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatAbsenceAnnouncement,
+  participantChipAriaLabel,
+  waitlistChipAriaLabel,
+} from "./courseCardLabels";
+
+describe("courseCardLabels", () => {
+  it("formatiert Chip-Labels für Teilnehmerstatus", () => {
+    expect(participantChipAriaLabel("bob", { isSelf: false, isSn: false, isSwapped: false })).toBe(
+      "bob, regulär eingetragen",
+    );
+    expect(participantChipAriaLabel("alice", { isSelf: true, isSn: false, isSwapped: false })).toBe(
+      "alice, du",
+    );
+  });
+
+  it("formatiert Wartelisten-Chip-Labels", () => {
+    expect(waitlistChipAriaLabel("bob", false)).toBe("bob, auf der Warteliste");
+    expect(waitlistChipAriaLabel("alice", true)).toBe("alice, du auf der Warteliste");
+  });
+
+  it("formatiert Absage-Live-Ansagen", () => {
+    expect(formatAbsenceAnnouncement("Yoga Basic", "2099-06-16", "cancelled")).toBe(
+      "Termin abgesagt für Yoga Basic, 16.06.2099. Absage kann zurückgenommen werden.",
+    );
+  });
+});

--- a/app/src/lib/courseCardLabels.ts
+++ b/app/src/lib/courseCardLabels.ts
@@ -1,0 +1,74 @@
+import { formatCourseIsoDateDe } from "shared/courseStatus";
+
+/** Zentraler Textkatalog für CourseCard — später i18n-fähig machen. */
+export const TERM_MARKER_EXCLUDED_LABEL = "Termin entfällt (vom Studio abgesagt)";
+export const TERM_MARKER_PAST_LABEL = "Vergangener Termin im Nachlauf";
+export const TERM_MARKER_CUTOFF_LABEL = "Kurz vor Termin (Cutoff)";
+
+export type AbsenceAnnouncementOutcome =
+  | "saving"
+  | "cancelled"
+  | "shortNoticeCancelled"
+  | "undo"
+  | "error";
+
+export function courseStatusBadgeLabel(autoInactive: boolean): string {
+  return autoInactive ? "Kursstatus: Automatisch inaktiv" : "Kursstatus: Inaktiv";
+}
+
+export function courseStatusBadgeText(autoInactive: boolean): string {
+  return autoInactive ? "Automatisch inaktiv" : "Inaktiv";
+}
+
+export function participantChipAriaLabel(
+  name: string,
+  { isSelf, isSn, isSwapped }: { isSelf: boolean; isSn: boolean; isSwapped: boolean },
+): string {
+  if (isSn && isSelf) return `${name}, du, kurzfristig abgesagt, Platz bleibt belegt`;
+  if (isSn) return `${name}, kurzfristig abgesagt, Platz bleibt belegt`;
+  if (isSwapped) return `${name}, getauscht`;
+  if (isSelf) return `${name}, du`;
+  return `${name}, regulär eingetragen`;
+}
+
+export function waitlistChipAriaLabel(name: string, isSelf: boolean): string {
+  return isSelf ? `${name}, du auf der Warteliste` : `${name}, auf der Warteliste`;
+}
+
+export function formatAbsenceAnnouncement(
+  courseName: string,
+  termIso: string,
+  outcome: AbsenceAnnouncementOutcome,
+): string {
+  const term = formatCourseIsoDateDe(termIso);
+  switch (outcome) {
+    case "saving":
+      return "Speichere Absage …";
+    case "cancelled":
+      return `Termin abgesagt für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
+    case "shortNoticeCancelled":
+      return `Kurzfristige Absage gespeichert für ${courseName}, ${term}. Absage kann zurückgenommen werden.`;
+    case "undo":
+      return `Absage zurückgenommen für ${courseName}, ${term}. Du nimmst wieder am Termin teil.`;
+    case "error":
+      return "Fehler beim Speichern der Absage.";
+  }
+}
+
+export function termSelectDisabledHint(courseName: string, hasCourseDates: boolean): string {
+  return hasCourseDates
+    ? `Keine anstehenden Termine für ${courseName}.`
+    : `Kein Termin im Kurszeitraum für ${courseName}.`;
+}
+
+export function termSelectAriaLabel(courseName: string): string {
+  return `Termin für ${courseName}`;
+}
+
+export function excludedTermOptionSuffix(): string {
+  return " (entfällt)";
+}
+
+export function lastTermOptionSuffix(): string {
+  return " (letzter Termin)";
+}

--- a/app/src/lib/courseTermActionLabels.test.ts
+++ b/app/src/lib/courseTermActionLabels.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import type { Course, Swap } from "shared/types";
+import {
+  courseTermActionLabel,
+  formatSwapStatusLine,
+  swapTermIsoForCourse,
+} from "./courseTermActionLabels";
+
+const baseCourse: Course = {
+  tenantId: "default-tenant",
+  id: 1,
+  name: "Yoga Basic",
+  weekday: "Monday",
+  time: "10:00",
+  capacity: 10,
+  participants: ["alice"],
+  dates: ["2099-06-16"],
+};
+
+const targetCourse: Course = {
+  ...baseCourse,
+  id: 2,
+  name: "Yoga Advanced",
+  dates: ["2099-06-17"],
+};
+
+const pendingSwap: Swap = {
+  user: "alice",
+  fromCourseId: 1,
+  fromDate: "2099-06-16",
+  toCourseId: 2,
+  toDate: "2099-06-17",
+  status: "pending",
+};
+
+describe("courseTermActionLabel", () => {
+  it("verknüpft Aktion, Kursname und formatiertes Datum", () => {
+    expect(courseTermActionLabel("Yoga Basic", "Termin absagen", "2099-06-16")).toBe(
+      "Termin absagen, Yoga Basic, 16.06.2099",
+    );
+  });
+
+  it("hängt optionale Zusatzteile an", () => {
+    expect(
+      courseTermActionLabel("Yoga Basic", "Tauschanfragen abbrechen", "2099-06-16", [
+        "Tauschanfrage für 17.06.2099 · Yoga Advanced",
+      ]),
+    ).toBe(
+      "Tauschanfragen abbrechen, Yoga Basic, 16.06.2099, Tauschanfrage für 17.06.2099 · Yoga Advanced",
+    );
+  });
+});
+
+describe("formatSwapStatusLine", () => {
+  it("beschreibt ausgehende pending Tauschanfrage", () => {
+    expect(formatSwapStatusLine(pendingSwap, 1, [baseCourse, targetCourse])).toBe(
+      "Tauschanfrage für 17.06.2099 · Yoga Advanced",
+    );
+  });
+
+  it("beschreibt eingehende pending Tauschanfrage", () => {
+    expect(formatSwapStatusLine(pendingSwap, 2, [baseCourse, targetCourse])).toBe(
+      "Tauschanfrage zu 16.06.2099 · Yoga Basic",
+    );
+  });
+});
+
+describe("swapTermIsoForCourse", () => {
+  it("nutzt fromDate für Ursprungskurs und toDate für Zielkurs", () => {
+    expect(swapTermIsoForCourse(pendingSwap, 1)).toBe("2099-06-16");
+    expect(swapTermIsoForCourse(pendingSwap, 2)).toBe("2099-06-17");
+  });
+});

--- a/app/src/lib/courseTermActionLabels.ts
+++ b/app/src/lib/courseTermActionLabels.ts
@@ -1,0 +1,29 @@
+import { formatCourseIsoDateDe } from "shared/courseStatus";
+import type { Course, Swap } from "shared/types";
+
+export function courseTermActionLabel(
+  courseName: string,
+  action: string,
+  termIso: string,
+  extras: string[] = [],
+): string {
+  return [action, courseName, formatCourseIsoDateDe(termIso), ...extras].join(", ");
+}
+
+export function formatSwapStatusLine(swap: Swap, courseId: number, allCourses: Course[]): string {
+  const courseName = (id: number) => allCourses.find((c) => c.id === id)?.name ?? "Kurs";
+  if (swap.status === "pending" && swap.fromCourseId === courseId) {
+    return `Tauschanfrage für ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
+  }
+  if (swap.status === "pending" && swap.toCourseId === courseId) {
+    return `Tauschanfrage zu ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
+  }
+  if (swap.fromCourseId === courseId) {
+    return `Getauscht mit ${formatCourseIsoDateDe(swap.toDate)} · ${courseName(swap.toCourseId)}`;
+  }
+  return `Getauscht von ${formatCourseIsoDateDe(swap.fromDate)} · ${courseName(swap.fromCourseId)}`;
+}
+
+export function swapTermIsoForCourse(swap: Swap, courseId: number): string {
+  return swap.fromCourseId === courseId ? swap.fromDate : swap.toDate;
+}

--- a/docs/a11y-main-view-qa.md
+++ b/docs/a11y-main-view-qa.md
@@ -4,7 +4,7 @@ Kurzer, wiederholbarer manueller Test für die **Hauptansicht nach Login** — T
 
 - **Parent:** [#171 — Barrierefreiheit: Hauptansicht](https://github.com/CurlyKarin/yogaswap/issues/171)
 - **Ticket:** [#198](https://github.com/CurlyKarin/yogaswap/issues/198)
-- **Stand:** nach #171.1–#171.6 (App-Shell, Wochennavigation, Kurskarten-Semantik, Terminaktionen, Swap-Modal, Chips/Badges)
+- **Stand:** nach #171.1–#171.8 (#192–#199: App-Shell, Wochennavigation, Kurskarten-Semantik, Terminaktionen, Swap-Modal, Chips/Badges, QA-Checkliste, AdminPanel)
 
 ---
 
@@ -168,4 +168,4 @@ Issue anlegen oder an [#171](https://github.com/CurlyKarin/yogaswap/issues/171) 
 ## Siehe auch
 
 - [#199 — AdminPanel A11y (optional)](https://github.com/CurlyKarin/yogaswap/issues/199) — Landmark, Tabellen-Semantik, Formular-Labels
-- Implementierte Teil-Tickets: #200 (Shell), #201 (Wochennavigation), #202 (Kurskarten), #196/#205 (Terminaktionen), #206 (Swap-Modal), #197/#209 (Chips/Badges)
+- Implementierte Teil-Tickets: #192/#200 (Shell), #193/#201 (Wochennavigation), #194/#202 (Kurskarten), #196/#205 (Terminaktionen), #195/#206 (Swap-Modal), #197/#209 (Chips/Badges), #198/#210 (QA-Checkliste), #199/#211 (AdminPanel)


### PR DESCRIPTION
## Summary
- Split `CourseCard` into focused pieces: `CourseTermActionButton` + `courseTermActionLabels`, `useCourseCardTermState`, `CourseTermActions`, and `CourseCardDetails`
- `CourseCard.tsx` is now a ~180-line orchestrator (was ~1000 lines); no intentional behavior changes
- Centralize UI strings in `courseCardLabels.ts` as a step toward future i18n
- Fix Nachlauf bug (related to #203): hide „Anderen Termin wählen“ when the term already has an active/pending swap and cancel is blocked
- Update a11y QA doc stand for completed #171 epic

Closes #207

## Test plan
- [x] `cd app && npm test -- --run src/components/CourseCard.test.tsx src/components/CourseTermActionButton.test.tsx src/components/useCourseCardTermState.test.ts src/components/CourseTermActions.test.tsx src/lib/courseTermActionLabels.test.ts src/lib/courseCardLabels.test.ts`
- [x] `npm run lint` in `app/`
- [x] Manual smoke: Kurskarte, Absage, Tausch-Modal, Nachlauf-Termin mit bestehendem Swap


Made with [Cursor](https://cursor.com)