### PR TITLE
Lazy-load AdminPanel with skeleton and split vendor chunks

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1122,6 +1122,11 @@ a:focus-visible {
   border-top: 1px solid #e8e8e8;
   font-size: 14px;
   color: #666;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem 1.25rem;
 }
 .app-footer a {
   color: #555;
@@ -1132,7 +1137,10 @@ a:focus-visible {
   text-decoration: underline;
 }
 .app-footer-nav {
-  display: inline;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
 }
 
 .app-footer .sep {
@@ -1225,6 +1233,66 @@ a:focus-visible {
   background: #fff;
   box-sizing: border-box;
   width: 100%;
+}
+
+.admin-panel-fallback {
+  min-height: 28rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-panel-fallback-line {
+  height: 0.875rem;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #e5e7eb 0%, #f3f4f6 50%, #e5e7eb 100%);
+  background-size: 200% 100%;
+  animation: admin-panel-fallback-shimmer 1.4s ease-in-out infinite;
+}
+
+.admin-panel-fallback-line-title {
+  width: 40%;
+  height: 1.125rem;
+}
+
+.admin-panel-fallback-line-toolbar {
+  width: 55%;
+}
+
+.admin-panel-fallback-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+  margin-top: 0.75rem;
+}
+
+.admin-panel-fallback-participants {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.admin-panel-fallback-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.legal-page-fallback {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+@keyframes admin-panel-fallback-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 .studio-settings-section {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,17 +1,14 @@
 // app/src/App.tsx
-import { useEffect, useMemo, useState } from "react";
-import { Routes, Route, useNavigate } from "react-router-dom";
+import { lazy, Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Link, Routes, Route, useNavigate } from "react-router-dom";
 import "./App.css";
 import Login from "./components/Login";
 import CoursesShell from "./components/CoursesShell";
-import AdminPanel from "./components/AdminPanel";
+import AdminPanelFallback from "./components/AdminPanelFallback";
+import LegalPageFallback from "./components/LegalPageFallback";
 import Invite from "./components/Invite";
 import ForgotPassword from "./components/ForgotPassword";
-import Impressum from "./components/Impressum";
-import Datenschutz from "./components/Datenschutz";
-import OpenSourceLicenses from "./components/OpenSourceLicenses";
 import DelegationPickerDialog from "./components/DelegationPickerDialog";
-import { Link } from "react-router-dom";
 import { loadCurrentUser, saveCurrentUser, clearCurrentUser } from "shared/lib/storage";
 import { User, UserRole, Tenant, UserTenantMembership } from "shared/types";
 import { useAppAuth } from "./auth/useAppAuth";
@@ -21,6 +18,15 @@ import { canInviteParticipants, canManageParticipants } from "shared/permissions
 import { getParticipants, type ParticipantWithStatus } from "./api/participants";
 import { setActingForUserId, setActorUserId } from "./api/delegation";
 import { filterParticipantsBySearch } from "./lib/participants";
+
+const AdminPanel = lazy(() => import("./components/AdminPanel"));
+const Impressum = lazy(() => import("./components/Impressum"));
+const Datenschutz = lazy(() => import("./components/Datenschutz"));
+const OpenSourceLicenses = lazy(() => import("./components/OpenSourceLicenses"));
+
+function LegalPage({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<LegalPageFallback />}>{children}</Suspense>;
+}
 
 // Checkmark Haupt-App als Komponente
 function MainApp() {
@@ -318,11 +324,13 @@ function MainApp() {
             <h2 id="admin-heading" className="visually-hidden">
               Verwaltung
             </h2>
-            <AdminPanel
-              canEditRoles={(membership?.role ?? currentUser.role) === "admin"}
-              tenant={tenant}
-              onTenantUpdated={(updated) => setTenant(updated)}
-            />
+            <Suspense fallback={<AdminPanelFallback />}>
+              <AdminPanel
+                canEditRoles={(membership?.role ?? currentUser.role) === "admin"}
+                tenant={tenant}
+                onTenantUpdated={(updated) => setTenant(updated)}
+              />
+            </Suspense>
           </section>
         )}
       </main>
@@ -396,9 +404,36 @@ export default function App() {
       <Route path="/invite" element={<InviteWithRedirect />} />
       <Route path="/forgot-password" element={<ForgotPassword />} />
       <Route path="/login" element={<Login onLogin={() => {}} />} />
-      <Route path="/impressum" element={<div className="app-container"><Impressum /></div>} />
-      <Route path="/datenschutz" element={<div className="app-container"><Datenschutz /></div>} />
-      <Route path="/open-source-lizenzen" element={<div className="app-container"><OpenSourceLicenses /></div>} />
+      <Route
+        path="/impressum"
+        element={
+          <LegalPage>
+            <div className="app-container">
+              <Impressum />
+            </div>
+          </LegalPage>
+        }
+      />
+      <Route
+        path="/datenschutz"
+        element={
+          <LegalPage>
+            <div className="app-container">
+              <Datenschutz />
+            </div>
+          </LegalPage>
+        }
+      />
+      <Route
+        path="/open-source-lizenzen"
+        element={
+          <LegalPage>
+            <div className="app-container">
+              <OpenSourceLicenses />
+            </div>
+          </LegalPage>
+        }
+      />
       <Route path="*" element={<MainApp />} />
     </Routes>
   );

--- a/app/src/components/AdminPanelFallback.test.tsx
+++ b/app/src/components/AdminPanelFallback.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AdminPanelFallback from "./AdminPanelFallback";
+
+describe("AdminPanelFallback", () => {
+  it("exposes loading status for screen readers", () => {
+    render(<AdminPanelFallback />);
+
+    const status = screen.getByRole("status", { name: /verwaltung wird geladen/i });
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveClass("admin-panel-fallback");
+  });
+});

--- a/app/src/components/AdminPanelFallback.tsx
+++ b/app/src/components/AdminPanelFallback.tsx
@@ -1,0 +1,30 @@
+export default function AdminPanelFallback() {
+  return (
+    <div
+      className="admin-panel admin-panel-fallback"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Verwaltung wird geladen"
+    >
+      <span className="visually-hidden">Verwaltung wird geladen</span>
+      <div className="admin-panel-fallback-studio" aria-hidden="true">
+        <div className="admin-panel-fallback-line admin-panel-fallback-line-title" />
+        <div className="admin-panel-fallback-grid">
+          <div className="admin-panel-fallback-line" />
+          <div className="admin-panel-fallback-line" />
+          <div className="admin-panel-fallback-line" />
+        </div>
+      </div>
+      <div className="admin-panel-fallback-participants" aria-hidden="true">
+        <div className="admin-panel-fallback-line admin-panel-fallback-line-toolbar" />
+        <div className="admin-panel-fallback-table">
+          <div className="admin-panel-fallback-line" />
+          <div className="admin-panel-fallback-line" />
+          <div className="admin-panel-fallback-line" />
+          <div className="admin-panel-fallback-line" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/LegalPageFallback.tsx
+++ b/app/src/components/LegalPageFallback.tsx
@@ -1,0 +1,7 @@
+export default function LegalPageFallback() {
+  return (
+    <div className="app-container legal-page-fallback" role="status" aria-live="polite">
+      Seite wird geladen…
+    </div>
+  );
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -10,6 +10,31 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          if (id.includes('aws-amplify') || id.includes('@aws-amplify')) {
+            return 'amplify';
+          }
+          if (id.includes('react-router') || id.includes('react-router-dom')) {
+            return 'react-router';
+          }
+          if (id.includes('react-dom')) {
+            return 'react-dom';
+          }
+          if (id.includes('/react/')) {
+            return 'react';
+          }
+          if (id.includes('lucide-react')) {
+            return 'lucide';
+          }
+          if (id.includes('axios')) {
+            return 'axios';
+          }
+        },
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Lazy-load `AdminPanel` and legal pages (`Impressum`, `Datenschutz`, `OpenSourceLicenses`) via `Suspense`
- Add accessible loading placeholders: admin skeleton with stable height, simple text fallback for legal routes
- Split vendor bundles in Vite (`manualChunks`) so no chunk exceeds 500 kB — build warning gone
- Fix footer spacing between copyright and nav links

Closes #144

## Test plan
- [x] `npm test -- --run src/App.test.tsx src/components/AdminPanelFallback.test.tsx`
- [x] `npm run lint` in `app/`
- [x] `npm run build` — no chunk size warning; `AdminPanel` in separate chunk
- [x] Manual: Admin reload — courses first, admin skeleton briefly, then panel; no layout jump
- [x] Manual: Participant login — no admin area, no skeleton
- [x] Manual: Impressum/Datenschutz — brief loading text, then content
- [x] Manual: Vertretung active — admin hidden, no regression in week view


Made with [Cursor](https://cursor.com)