### PR TITLE
Persist weekAnchor in sessionStorage for week navigation

### DIFF
--- a/app/src/components/CoursesShell.test.tsx
+++ b/app/src/components/CoursesShell.test.tsx
@@ -3,6 +3,17 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CoursesShell from "./CoursesShell";
 import { User, Tenant, UserTenantMembership } from "shared/types";
+import { formatWeekNavLabel, startOfWeekMonday, addWeeks } from "../lib/courseWeek";
+import {
+  buildWeekAnchorStorageKey,
+  readStoredWeekAnchor,
+  writeStoredWeekAnchor,
+} from "../lib/weekNavPersistence";
+import { getActorUserId } from "../api/delegation";
+
+vi.mock("../api/delegation", () => ({
+  getActorUserId: vi.fn(() => "maya"),
+}));
 
 const { mockUseCoursesData, createCoursesDataMock } = vi.hoisted(() => {
   type MockCoursesData = {
@@ -92,11 +103,14 @@ const adminMembership: UserTenantMembership = {
 describe("CoursesShell", () => {
   beforeEach(() => {
     cleanup();
+    sessionStorage.clear();
+    vi.mocked(getActorUserId).mockReturnValue("maya");
     mockUseCoursesData.mockReturnValue(createCoursesDataMock());
   });
 
   afterEach(() => {
     cleanup();
+    sessionStorage.clear();
   });
 
   it("shows week view by default for participants without view toggle", () => {
@@ -239,13 +253,95 @@ describe("CoursesShell", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("Netzwerkfehler");
   });
-});
 
-function startOfWeekMonday(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  d.setDate(d.getDate() + diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
+  it("restores weekAnchor from sessionStorage on mount", () => {
+    const storedWeek = startOfWeekMonday(new Date(2099, 5, 14));
+    writeStoredWeekAnchor(buildWeekAnchorStorageKey("default-tenant", "maya"), storedWeek);
+
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    expect(screen.getByText(formatWeekNavLabel(storedWeek))).toBeInTheDocument();
+  });
+
+  it("persists week navigation in sessionStorage", async () => {
+    const user = userEvent.setup();
+    const storageKey = buildWeekAnchorStorageKey("default-tenant", "maya");
+    const initialWeek = startOfWeekMonday(new Date());
+    const expectedWeek = addWeeks(initialWeek, 1);
+
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
+    await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
+
+    expect(within(nav).getByText(formatWeekNavLabel(expectedWeek))).toBeInTheDocument();
+    expect(readStoredWeekAnchor(storageKey)?.getTime()).toBe(expectedWeek.getTime());
+  });
+
+  it("keeps weekAnchor when switching into delegation view", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getActorUserId).mockReturnValue("admin");
+
+    const { rerender } = render(
+      <CoursesShell
+        currentUser={{ ...baseUser, nickname: "admin", role: "admin" }}
+        tenant={baseTenant}
+        membership={adminMembership}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
+    await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
+    const labelAfterNav = within(nav).getByText(/^KW \d+ · /).textContent;
+
+    rerender(
+      <CoursesShell
+        currentUser={{ ...baseUser, nickname: "maya", role: "participant" }}
+        tenant={baseTenant}
+        membership={adminMembership}
+        forceParticipantView
+      />,
+    );
+
+    expect(within(screen.getByRole("navigation", { name: /kalenderwoche/i })).getByText(
+      /^KW \d+ · /,
+    ).textContent).toBe(labelAfterNav);
+  });
+
+  it("resets to current week via Heute and updates sessionStorage", async () => {
+    const user = userEvent.setup();
+    const storageKey = buildWeekAnchorStorageKey("default-tenant", "maya");
+    const currentWeek = startOfWeekMonday(new Date());
+    const futureWeek = addWeeks(currentWeek, 2);
+
+    render(
+      <CoursesShell
+        currentUser={baseUser}
+        tenant={baseTenant}
+        membership={participantMembership}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: /kalenderwoche/i });
+    await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
+    await user.click(within(nav).getByRole("button", { name: /nächste woche/i }));
+    expect(within(nav).getByText(formatWeekNavLabel(futureWeek))).toBeInTheDocument();
+
+    await user.click(within(nav).getByRole("button", { name: /zur aktuellen kalenderwoche springen/i }));
+
+    expect(within(nav).getByText(formatWeekNavLabel(currentWeek))).toBeInTheDocument();
+    expect(readStoredWeekAnchor(storageKey)?.getTime()).toBe(currentWeek.getTime());
+  });
+});

--- a/app/src/components/CoursesShell.tsx
+++ b/app/src/components/CoursesShell.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import CourseList from "./CourseList";
 import CourseWeekView from "./CourseWeekView";
 import { User, Tenant, UserTenantMembership, DEFAULT_TENANT_ID } from "shared/types";
 import { addWeeks, formatWeekNavLabel, startOfWeekMonday } from "../lib/courseWeek";
+import {
+  buildWeekAnchorStorageKey,
+  clampWeekAnchor,
+  readStoredWeekAnchor,
+  resolveInitialWeekAnchor,
+  writeStoredWeekAnchor,
+} from "../lib/weekNavPersistence";
+import { getActorUserId } from "../api/delegation";
 import { useCoursesData } from "../hooks/useCoursesData";
 
 export type CourseViewMode = "week" | "courses";
@@ -33,8 +41,18 @@ export default function CoursesShell({
   const resolvedRole = effectiveMembership?.role ?? currentUser.role;
   const canSeeCourseManagement = resolvedRole === "admin" || resolvedRole === "instructor";
 
+  const weekAnchorStorageKey = useMemo(() => {
+    const tenantId = tenant?.tenantId ?? membership?.tenantId ?? DEFAULT_TENANT_ID;
+    const userId = getActorUserId() ?? currentUser.nickname;
+    return buildWeekAnchorStorageKey(tenantId, userId);
+  }, [tenant?.tenantId, membership?.tenantId, currentUser.nickname]);
+
   const [viewMode, setViewMode] = useState<CourseViewMode>("week");
-  const [weekAnchor, setWeekAnchor] = useState(() => startOfWeekMonday(new Date()));
+  const [weekAnchor, setWeekAnchorState] = useState(() => {
+    const stored = readStoredWeekAnchor(weekAnchorStorageKey);
+    return stored ?? startOfWeekMonday(new Date());
+  });
+  const prevWeekAnchorStorageKeyRef = useRef(weekAnchorStorageKey);
 
   const {
     loading,
@@ -56,6 +74,35 @@ export default function CoursesShell({
     forceParticipantView,
     weekAnchor,
   });
+
+  const setWeekAnchor = useCallback(
+    (update: Date | ((prev: Date) => Date)) => {
+      setWeekAnchorState((prev) => {
+        const next = typeof update === "function" ? update(prev) : update;
+        const clamped = clampWeekAnchor(next, earliestWeekAnchor);
+        writeStoredWeekAnchor(weekAnchorStorageKey, clamped);
+        return clamped;
+      });
+    },
+    [earliestWeekAnchor, weekAnchorStorageKey],
+  );
+
+  useEffect(() => {
+    if (prevWeekAnchorStorageKeyRef.current === weekAnchorStorageKey) return;
+    prevWeekAnchorStorageKeyRef.current = weekAnchorStorageKey;
+    const resolved = resolveInitialWeekAnchor(weekAnchorStorageKey, earliestWeekAnchor);
+    setWeekAnchorState(resolved);
+    writeStoredWeekAnchor(weekAnchorStorageKey, resolved);
+  }, [weekAnchorStorageKey, earliestWeekAnchor]);
+
+  useEffect(() => {
+    setWeekAnchorState((prev) => {
+      const clamped = clampWeekAnchor(prev, earliestWeekAnchor);
+      if (clamped.getTime() === prev.getTime()) return prev;
+      writeStoredWeekAnchor(weekAnchorStorageKey, clamped);
+      return clamped;
+    });
+  }, [earliestWeekAnchor, weekAnchorStorageKey]);
 
   useEffect(() => {
     if (!canSeeCourseManagement && viewMode === "courses") {

--- a/app/src/lib/weekNavPersistence.test.ts
+++ b/app/src/lib/weekNavPersistence.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { startOfWeekMonday } from "./courseWeek";
+import {
+  buildWeekAnchorStorageKey,
+  clampWeekAnchor,
+  readStoredWeekAnchor,
+  resolveInitialWeekAnchor,
+  writeStoredWeekAnchor,
+} from "./weekNavPersistence";
+
+describe("weekNavPersistence", () => {
+  const storageKey = buildWeekAnchorStorageKey("default-tenant", "maya");
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("builds a tenant- and user-scoped storage key", () => {
+    expect(buildWeekAnchorStorageKey("studio-a", "luna")).toBe(
+      "yogaswap.weekAnchor:studio-a:luna",
+    );
+  });
+
+  it("round-trips a week anchor through sessionStorage", () => {
+    const anchor = startOfWeekMonday(new Date(2099, 5, 14));
+    writeStoredWeekAnchor(storageKey, anchor);
+    expect(readStoredWeekAnchor(storageKey)?.getTime()).toBe(anchor.getTime());
+  });
+
+  it("returns null for invalid stored values", () => {
+    sessionStorage.setItem(storageKey, "not-a-date");
+    expect(readStoredWeekAnchor(storageKey)).toBeNull();
+  });
+
+  it("clamps stored weeks to earliestWeekAnchor", () => {
+    const earliest = startOfWeekMonday(new Date(2026, 2, 2));
+    const tooEarly = startOfWeekMonday(new Date(2026, 1, 2));
+    writeStoredWeekAnchor(storageKey, tooEarly);
+
+    const resolved = resolveInitialWeekAnchor(storageKey, earliest);
+    expect(resolved.getTime()).toBe(earliest.getTime());
+  });
+
+  it("keeps in-range weeks unchanged", () => {
+    const earliest = startOfWeekMonday(new Date(2026, 0, 5));
+    const stored = startOfWeekMonday(new Date(2099, 5, 14));
+    writeStoredWeekAnchor(storageKey, stored);
+
+    expect(resolveInitialWeekAnchor(storageKey, earliest).getTime()).toBe(stored.getTime());
+    expect(clampWeekAnchor(stored, earliest).getTime()).toBe(stored.getTime());
+  });
+});

--- a/app/src/lib/weekNavPersistence.ts
+++ b/app/src/lib/weekNavPersistence.ts
@@ -1,0 +1,76 @@
+import { startOfWeekMonday } from "./courseWeek";
+
+export const WEEK_ANCHOR_STORAGE_PREFIX = "yogaswap.weekAnchor";
+
+export function buildWeekAnchorStorageKey(tenantId: string, userId: string): string {
+  return `${WEEK_ANCHOR_STORAGE_PREFIX}:${tenantId}:${userId}`;
+}
+
+function toLocalDateIso(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseLocalDateIso(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(year, month - 1, day);
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month - 1 ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  parsed.setHours(0, 0, 0, 0);
+  return parsed;
+}
+
+export function readStoredWeekAnchor(storageKey: string): Date | null {
+  if (typeof sessionStorage === "undefined") return null;
+
+  try {
+    const raw = sessionStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = parseLocalDateIso(raw);
+    if (!parsed) return null;
+    return startOfWeekMonday(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredWeekAnchor(storageKey: string, weekAnchor: Date): void {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.setItem(storageKey, toLocalDateIso(startOfWeekMonday(weekAnchor)));
+  } catch {
+    // Quota or private mode — ignore.
+  }
+}
+
+export function clampWeekAnchor(weekAnchor: Date, earliestWeekAnchor: Date): Date {
+  const normalized = startOfWeekMonday(weekAnchor);
+  const earliest = startOfWeekMonday(earliestWeekAnchor);
+  if (normalized.getTime() < earliest.getTime()) {
+    return earliest;
+  }
+  return normalized;
+}
+
+export function resolveInitialWeekAnchor(
+  storageKey: string,
+  earliestWeekAnchor: Date,
+): Date {
+  const stored = readStoredWeekAnchor(storageKey);
+  const fallback = startOfWeekMonday(new Date());
+  return clampWeekAnchor(stored ?? fallback, earliestWeekAnchor);
+}


### PR DESCRIPTION
## Summary
- Keep the selected calendar week (`weekAnchor`) across reloads in the same browser tab via `sessionStorage`
- Storage key scoped per tenant and logged-in actor (no leak between accounts)
- Clamp restored weeks to `earliestWeekAnchor`; „Heute“ resets to the current week
- Delegation (`forceParticipantView`) keeps the same week anchor in `CoursesShell`

Closes #187

## Test plan
- [x] `npm test -- --run src/lib/weekNavPersistence.test.ts src/components/CoursesShell.test.tsx`
- [x] `npm run lint` in `app/`
- [ ] Manual: navigate to another KW → reload same tab → week stays
- [ ] Manual: new tab or closed tab → current week
- [ ] Manual: start delegation in KW X → week view stays in KW X
- [ ] Manual: „Heute“ → current week and updated session entry


Made with [Cursor](https://cursor.com)