### PR TITLE
Fix waitlist swap targets (#218)

### DIFF
--- a/app/src/components/CourseCard.test.tsx
+++ b/app/src/components/CourseCard.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach } from "vitest";
 import CourseCard from "./CourseCard";
 import type { Course, CourseDateOverride, Swap, User } from "shared/types";
+import { swapOptionKey } from "../lib/dates";
 
 const baseCourse: Course = {
   tenantId: "default-tenant",
@@ -582,8 +583,8 @@ describe("CourseCard", () => {
 
     expect(screen.getByRole("dialog", { name: /Tauschanfrage starten, Yoga Basic, 16\.06\.2099/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Tauschanfrage starten/i })).toBeInTheDocument();
-    expect(document.querySelector('option[value^="2099-06-21T"]')).toBeInTheDocument();
-    expect(document.querySelector('option[value^="2099-06-20T"]')).not.toBeInTheDocument();
+    expect(document.querySelector(`option[value="${swapOptionKey(3, new Date(2099, 5, 21, 10, 0, 0))}"]`)).toBeInTheDocument();
+    expect(document.querySelector(`option[value="${swapOptionKey(2, new Date(2099, 5, 20, 10, 0, 0))}"]`)).not.toBeInTheDocument();
   });
 });
 

--- a/app/src/components/CourseSwapModal.test.tsx
+++ b/app/src/components/CourseSwapModal.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import CourseSwapModal from "./CourseSwapModal";
 import type { Course } from "shared/types";
+import { swapOptionKey } from "../lib/dates";
 
 const baseCourse: Course = {
   tenantId: "default-tenant",
@@ -151,11 +152,36 @@ describe("CourseSwapModal", () => {
     const { onConfirmFree, onClose } = renderSwapModal();
 
     fireEvent.change(screen.getByRole("combobox"), {
-      target: { value: freeTargetDate.toISOString() },
+      target: { value: swapOptionKey(2, freeTargetDate) },
     });
     fireEvent.click(screen.getByRole("button", { name: /Bestätigen/i }));
 
     expect(onConfirmFree).toHaveBeenCalledWith(2, "2099-06-20");
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("unterscheidet zwei Kurse am selben Zeitpunkt in der Warteliste", () => {
+    const sharedDate = new Date(2099, 5, 20, 10, 0, 0);
+    const secondCourse: Course = {
+      ...alternativeCourse,
+      id: 3,
+      name: "Yoga Mittag",
+      dates: ["2099-06-20"],
+    };
+    const { onConfirmWaitlist } = renderSwapModal({
+      availableSwapDates: [],
+      waitlistDates: [
+        { course: alternativeCourse, date: sharedDate },
+        { course: secondCourse, date: sharedDate },
+      ],
+    });
+
+    const waitlistSelect = screen.getAllByRole("combobox")[0];
+    fireEvent.change(waitlistSelect, {
+      target: { value: swapOptionKey(3, sharedDate) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Bestätigen/i }));
+
+    expect(onConfirmWaitlist).toHaveBeenCalledWith(3, "2099-06-20");
   });
 });

--- a/app/src/components/CourseSwapModal.tsx
+++ b/app/src/components/CourseSwapModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useId, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import { formatCourseIsoDateDe } from "shared/courseStatus";
 import type { Course } from "shared/types";
-import { toDateKey } from "../lib/dates";
+import { parseSwapOptionKey, swapOptionKey, toDateKey } from "../lib/dates";
 import { focusWithVisibleRing } from "../lib/focusWithVisibleRing";
 import type { SwapSettings } from "../types";
 import CourseModalFrame from "./CourseModalFrame";
@@ -155,14 +155,25 @@ export default function CourseSwapModal({
     [onClose],
   );
 
+  const resolveTarget = (optionKey: string, options: SwapTargetOption[]) => {
+    const parsed = parseSwapOptionKey(optionKey);
+    if (!parsed) return null;
+    return (
+      options.find(
+        (opt) =>
+          opt.course.id === parsed.courseId && swapOptionKey(opt.course.id, opt.date) === optionKey,
+      ) ?? null
+    );
+  };
+
   const handleConfirm = () => {
     if (swapDateIso) {
-      const target = availableSwapDates.find((opt) => opt.date.toISOString() === swapDateIso);
+      const target = resolveTarget(swapDateIso, availableSwapDates);
       if (target) {
         onConfirmFree(target.course.id, toDateKey(target.date));
       }
     } else if (swapDateIsoWaitlist) {
-      const target = waitlistDates.find((opt) => opt.date.toISOString() === swapDateIsoWaitlist);
+      const target = resolveTarget(swapDateIsoWaitlist, waitlistDates);
       if (target) {
         onConfirmWaitlist(target.course.id, toDateKey(target.date));
       }
@@ -214,9 +225,19 @@ export default function CourseSwapModal({
                 <option value="" disabled>
                   Bitte freien Termin auswählen…
                 </option>
-                {availableSwapDates.map((swapDate, idx) => (
-                  <option key={idx} value={swapDate.date.toISOString()}>
+                {availableSwapDates.map((swapDate) => (
+                  <option
+                    key={swapOptionKey(swapDate.course.id, swapDate.date)}
+                    value={swapOptionKey(swapDate.course.id, swapDate.date)}
+                  >
                     {swapOptionLabel(swapDate.date)}
+                    {availableSwapDates.some(
+                      (other) =>
+                        other !== swapDate &&
+                        other.date.getTime() === swapDate.date.getTime(),
+                    )
+                      ? ` · ${swapDate.course.name}`
+                      : ""}
                   </option>
                 ))}
               </select>
@@ -255,9 +276,19 @@ export default function CourseSwapModal({
                 <option value="" disabled>
                   Bitte belegten Termin wählen…
                 </option>
-                {waitlistDates.map((waitlistDate, idx) => (
-                  <option key={idx} value={waitlistDate.date.toISOString()}>
+                {waitlistDates.map((waitlistDate) => (
+                  <option
+                    key={swapOptionKey(waitlistDate.course.id, waitlistDate.date)}
+                    value={swapOptionKey(waitlistDate.course.id, waitlistDate.date)}
+                  >
                     {swapOptionLabel(waitlistDate.date)}
+                    {waitlistDates.some(
+                      (other) =>
+                        other !== waitlistDate &&
+                        other.date.getTime() === waitlistDate.date.getTime(),
+                    )
+                      ? ` · ${waitlistDate.course.name}`
+                      : ""}
                   </option>
                 ))}
               </select>

--- a/app/src/components/useCourseSwaps.test.ts
+++ b/app/src/components/useCourseSwaps.test.ts
@@ -366,6 +366,218 @@ describe("useCourseSwaps", () => {
     expect(processPromotions).toHaveBeenCalledTimes(1);
   });
 
+  it("cancelSwap vom Ursprung bereinigt Wartelisten aller pending Ziele", async () => {
+    const targetCourseA: Course = {
+      ...course,
+      id: 2,
+      name: "Yoga A",
+      dates: ["2099-06-17"],
+      participants: ["bob"],
+    };
+    const targetCourseB: Course = {
+      ...course,
+      id: 3,
+      name: "Yoga B",
+      dates: ["2099-06-17"],
+      participants: ["carol"],
+    };
+    const overrideA: CourseDateOverride = {
+      courseId: 2,
+      date: "2099-06-17",
+      participants: ["bob"],
+      swapped: [],
+      waitlist: ["alice"],
+    };
+    const overrideB: CourseDateOverride = {
+      courseId: 3,
+      date: "2099-06-17",
+      participants: ["carol"],
+      swapped: [],
+      waitlist: ["alice"],
+    };
+    const pendingToA: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: "2099-06-16",
+      toCourseId: 2,
+      toDate: "2099-06-17",
+      status: "pending",
+    };
+    const pendingToB: Swap = {
+      user: "alice",
+      fromCourseId: 1,
+      fromDate: "2099-06-16",
+      toCourseId: 3,
+      toDate: "2099-06-17",
+      status: "pending",
+    };
+
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    let latestOverrides: CourseDateOverride[] = [baseOverride, overrideA, overrideB];
+    const setOverrides = vi.fn((updater: (prev: CourseDateOverride[]) => CourseDateOverride[]) => {
+      latestOverrides = updater(latestOverrides);
+    });
+    const setSwaps = vi.fn();
+
+    (processPromotions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      swaps: [],
+      overrides: [],
+    });
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course, targetCourseA, targetCourseB],
+        latestOverrides,
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [pendingToA, pendingToB],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.cancelSwap(pendingToA, 1);
+    });
+
+    expect(deleteSwap).toHaveBeenCalledTimes(2);
+    expect(updateOverride).toHaveBeenCalledWith(
+      2,
+      "2099-06-17",
+      expect.objectContaining({ waitlist: [] }),
+    );
+    expect(updateOverride).toHaveBeenCalledWith(
+      3,
+      "2099-06-17",
+      expect.objectContaining({ waitlist: [] }),
+    );
+  });
+
+  it("cancelSwap pending sendet nur Wartelisten-Patch bei vollem Termin", async () => {
+    const targetCourse: Course = {
+      ...course,
+      id: 2,
+      capacity: 2,
+      participants: ["bob", "carol"],
+      dates: ["2099-06-17"],
+    };
+    const fullOverride: CourseDateOverride = {
+      courseId: 2,
+      date: "2099-06-17",
+      participants: ["bob", "carol"],
+      swapped: [],
+      waitlist: ["alice"],
+    };
+    const pendingToTarget: Swap = {
+      ...pendingSwap,
+      toCourseId: 2,
+      toDate: "2099-06-17",
+    };
+
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn();
+    const setSwaps = vi.fn();
+
+    (processPromotions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      swaps: [],
+      overrides: [],
+    });
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course, targetCourse],
+        [baseOverride, fullOverride],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [pendingToTarget],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.cancelSwap(pendingToTarget, 1);
+    });
+
+    expect(updateOverride).toHaveBeenCalledWith(2, "2099-06-17", { waitlist: [] });
+    expect(updateOverride).not.toHaveBeenCalledWith(
+      2,
+      "2099-06-17",
+      expect.objectContaining({ participants: expect.anything() }),
+    );
+  });
+
+  it("requestSwap erstellt Swap erneut bei verwaistem Wartelisten-Eintrag", async () => {
+    const targetCourse: Course = {
+      ...course,
+      id: 2,
+      capacity: 2,
+      participants: ["bob", "carol"],
+      dates: ["2099-06-17"],
+    };
+    const orphanedOverride: CourseDateOverride = {
+      courseId: 2,
+      date: "2099-06-17",
+      participants: ["bob", "carol"],
+      swapped: [],
+      waitlist: ["alice"],
+    };
+
+    const fetchData = vi.fn().mockResolvedValue(undefined);
+    const setOverrides = vi.fn();
+    const setSwaps = vi.fn();
+
+    (processPromotions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      swaps: [
+        {
+          ...pendingSwap,
+          toCourseId: 2,
+          toDate: "2099-06-17",
+          status: "pending",
+        },
+      ],
+      overrides: [orphanedOverride],
+    });
+
+    const { result } = renderHook(() =>
+      useCourseSwaps(
+        [course, targetCourse],
+        [baseOverride, orphanedOverride],
+        setOverrides as unknown as (
+          value:
+            | CourseDateOverride[]
+            | ((prev: CourseDateOverride[]) => CourseDateOverride[])
+        ) => void,
+        [],
+        setSwaps as unknown as (
+          value: Swap[] | ((prev: Swap[]) => Swap[])
+        ) => void,
+        baseUser,
+        fetchData,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.requestSwap(course, "2099-06-16", 2, "2099-06-17", baseUser.nickname);
+    });
+
+    expect(updateOverride).not.toHaveBeenCalled();
+    expect(createSwap).toHaveBeenCalledTimes(1);
+    expect(processPromotions).toHaveBeenCalledTimes(1);
+  });
+
   it("cancelSwap blockiert Abbrechen bei vergangenem Ursprung und Ziel", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 0, 1, 12, 0));

--- a/app/src/components/useCourseSwaps.ts
+++ b/app/src/components/useCourseSwaps.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
+import axios from "axios";
 import { getEffectiveWaitlist } from "../lib/waitlist";
+import { findOverrideForCourseDate, sameInstant } from "../lib/dates";
 import { overrideCourseUidFields, swapCourseUidFields } from "../lib/courseUid";
 import { Swap, CourseDateOverride, Course, User, TenantSettings } from "shared/types";
 import {
@@ -16,6 +18,31 @@ import {
 import { hasRegularBookingCapacity, resolveMaxCapacity } from "shared/courseCapacity";
 import { createSwap, deleteSwap, processPromotions } from "../api/swaps";
 import { createOverride, updateOverride } from "../api/overrides";
+
+function overrideMatchesCourseDate(
+  override: CourseDateOverride,
+  courseId: number,
+  dateIso: string,
+): boolean {
+  return override.courseId === courseId && sameInstant(override.date, dateIso);
+}
+
+function buildOverridePatch(
+  before: CourseDateOverride,
+  after: CourseDateOverride,
+): Partial<CourseDateOverride> {
+  const patch: Partial<CourseDateOverride> = {};
+  if (JSON.stringify(before.participants) !== JSON.stringify(after.participants)) {
+    patch.participants = after.participants;
+  }
+  if (JSON.stringify(before.swapped) !== JSON.stringify(after.swapped)) {
+    patch.swapped = after.swapped;
+  }
+  if (JSON.stringify(before.waitlist) !== JSON.stringify(after.waitlist)) {
+    patch.waitlist = after.waitlist;
+  }
+  return patch;
+}
 
 function findOverrideIndex(
   list: CourseDateOverride[],
@@ -555,8 +582,8 @@ export function useCourseSwaps(
 
           setOverrides((prev) =>
             prev.map((override) => {
-              const affectedPending = pendingFromSameOrigin.filter(
-                (swap) => swap.toCourseId === override.courseId && swap.toDate === override.date
+              const affectedPending = pendingFromSameOrigin.filter((swap) =>
+                overrideMatchesCourseDate(override, swap.toCourseId, swap.toDate),
               );
               if (affectedPending.length === 0) return override;
               const usersToRemove = new Set(
@@ -692,64 +719,62 @@ export function useCourseSwaps(
           })
         );
 
-        // 1) Overrides zuerst bereinigen
-        setOverrides((prev) => {
-          return prev.map((o) => {
-            const newO = { ...o };
-            const before = { ...o }; // vorheriger Zustand für Debug
+        // 1) Overrides bereinigen — alle betroffenen Swaps in swapsToDelete berücksichtigen
+        const overridePatches: Array<{
+          courseId: number;
+          date: string;
+          patch: Partial<CourseDateOverride>;
+          next: CourseDateOverride;
+        }> = [];
 
-            // Ursprungstermin
-            if (isOrigin && o.courseId === swap.fromCourseId && o.date === swap.fromDate) {
-              if (swap.status === "active") {
-                newO.swapped = (o.swapped ?? []).filter((u) => u !== swap.user);
-                newO.participants = (o.participants ?? []).filter((p) => p !== swap.user);
-              } else if (swap.status === "pending") {
-                newO.waitlist = (o.waitlist ?? []).filter((u) => u !== swap.user);
-              }
-            }
+        const nextOverrides = filteredOverrides.map((o) => {
+          const newO = { ...o };
+          const before = { ...o };
 
-            // Zieltermin bereinigen, wenn Ursprung absagt
-            if (isOrigin && o.courseId === swap.toCourseId && o.date === swap.toDate) {
-              if (swap.status === "active") {
-                newO.participants = o.participants.filter((p) => p !== swap.user);
-                newO.swapped = (o.swapped ?? []).filter((u) => u !== swap.user);
-              } else if (swap.status === "pending") {
-                newO.waitlist = (o.waitlist ?? []).filter((u) => u !== swap.user);
-              }
-            }
+          for (const s of swapsToDelete) {
+            const userLower = s.user.toLowerCase();
 
-            // Zieltermin bereinigen, wenn Ziel-Button gedrückt wird
-            if (!isOrigin && o.courseId === swap.toCourseId && o.date === swap.toDate) {
-              if (swap.status === "active") {
-                newO.participants = o.participants.filter((p) => p !== swap.user);
-                newO.swapped = (o.swapped ?? []).filter((u) => u !== swap.user);
-              } else if (swap.status === "pending") {
-                newO.waitlist = (o.waitlist ?? []).filter((u) => u !== swap.user);
-              }
-            }
-            
-            // UpdateOverride, falls sich etwas geändert hat
             if (
-              JSON.stringify(before.participants) !== JSON.stringify(newO.participants) ||
-              JSON.stringify(before.swapped) !== JSON.stringify(newO.swapped) ||
-              JSON.stringify(before.waitlist) !== JSON.stringify(newO.waitlist)
+              isOrigin &&
+              overrideMatchesCourseDate(o, s.fromCourseId, s.fromDate) &&
+              s.status === "active"
             ) {
-              console.log("Override updated:", {
-                courseId: o.courseId,
-                date: o.date,
-                before,
-                after: newO,
-              });
-
-              updateOverride(o.courseId, o.date, {
-                participants: newO.participants,
-                swapped: newO.swapped,
-                waitlist: newO.waitlist,
-              });
+              newO.swapped = (newO.swapped ?? []).filter((u) => u.toLowerCase() !== userLower);
+              newO.participants = (newO.participants ?? []).filter((p) => p.toLowerCase() !== userLower);
             }
-            return newO;
-          });
+
+            const cleansTarget =
+              (isOrigin && overrideMatchesCourseDate(o, s.toCourseId, s.toDate)) ||
+              (!isOrigin && overrideMatchesCourseDate(o, swap.toCourseId, swap.toDate));
+
+            if (cleansTarget) {
+              if (s.status === "active") {
+                newO.participants = (newO.participants ?? []).filter((p) => p.toLowerCase() !== userLower);
+                newO.swapped = (newO.swapped ?? []).filter((u) => u.toLowerCase() !== userLower);
+              } else if (s.status === "pending") {
+                newO.waitlist = (newO.waitlist ?? []).filter((u) => u.toLowerCase() !== userLower);
+              }
+            }
+          }
+
+          const patch = buildOverridePatch(before, newO);
+          if (Object.keys(patch).length > 0) {
+            overridePatches.push({
+              courseId: o.courseId,
+              date: o.date,
+              patch,
+              next: newO,
+            });
+          }
+          return newO;
         });
+
+        await Promise.all(
+          overridePatches.map(({ courseId, date, patch }) => updateOverride(courseId, date, patch)),
+        );
+        if (overridePatches.length > 0) {
+          setOverrides(nextOverrides);
+        }
 
         console.log('Calling processPromotions for cancelSwap...');
         const response = await processPromotions();
@@ -793,7 +818,7 @@ export function useCourseSwaps(
             s.fromCourseId === fromCourse.id &&
             s.fromDate === fromDateIso &&
             s.toCourseId === toCourseId &&
-            s.toDate === toDateIso
+            sameInstant(s.toDate, toDateIso),
         );
         if (existing) {
           alert("Du hast diese Anfrage bereits gestellt!");
@@ -808,48 +833,86 @@ export function useCourseSwaps(
         }
         if (!assertSwapTargetNotInCutoff(targetCourse, toDateIso)) return;
 
-        // 3) in Overrides die Warteliste ergänzen
-        setOverrides((prev) => {
-          const updated = [...prev];
-          const targetIdx = updated.findIndex(
-            (o) => o.courseId === toCourseId && o.date === toDateIso
+        const existingTargetOverride = findOverrideForCourseDate(
+          filteredOverrides,
+          toCourseId,
+          toDateIso,
+        );
+        const targetDateKey = existingTargetOverride?.date ?? toDateIso;
+
+        const hasPendingSwapToTarget = swaps.some(
+          (s) =>
+            s.status === "pending" &&
+            s.user.toLowerCase() === userName.toLowerCase() &&
+            s.fromCourseId === fromCourse.id &&
+            s.fromDate === fromDateIso &&
+            s.toCourseId === toCourseId &&
+            sameInstant(s.toDate, targetDateKey),
+        );
+
+        // 3) Warteliste in Overrides ergänzen (API-Aufrufe außerhalb von setState)
+        const userNameLowerForWaitlist = userName.toLowerCase();
+
+        const appendWaitlist = (current: string[] | undefined): string[] => {
+          const base = current ?? [];
+          if (base.some((entry) => entry.toLowerCase() === userNameLowerForWaitlist)) {
+            return base;
+          }
+          return [...base, userName];
+        };
+
+        const persistWaitlistUpdate = async (nextWaitlist: string[]) => {
+          await updateOverride(toCourseId, targetDateKey, { waitlist: nextWaitlist });
+          setOverrides((prev) =>
+            prev.map((o) =>
+              overrideMatchesCourseDate(o, toCourseId, targetDateKey)
+                ? { ...o, waitlist: nextWaitlist }
+                : o,
+            ),
           );
+        };
 
-          let nextOverride: CourseDateOverride;
+        const alreadyOnWaitlist = existingTargetOverride?.waitlist?.some(
+          (entry) => entry.toLowerCase() === userNameLowerForWaitlist,
+        );
 
-          if (targetIdx >= 0) {
-            const cur = updated[targetIdx];
-            // nur hinzufügen, falls User nicht schon drin
-            const userNameLowerForWaitlist = userName.toLowerCase();
-            if (!cur.waitlist?.some((p) => p.toLowerCase() === userNameLowerForWaitlist)) {
-              nextOverride = {
-                ...cur,
-                waitlist: [...(cur.waitlist ?? []), userName],
-              };
-              updated[targetIdx] = nextOverride;
-              // Backend-Aufruf: Override aktualisieren
-              updateOverride(toCourseId, toDateIso, { waitlist: nextOverride.waitlist });
-            } else {
-              return prev; // Keine Änderung, falls schon in Warteliste
-            }
+        if (alreadyOnWaitlist && hasPendingSwapToTarget) {
+          alert("Du hast diese Anfrage bereits gestellt!");
+          return;
+        }
+
+        if (!alreadyOnWaitlist) {
+          if (existingTargetOverride) {
+            await persistWaitlistUpdate(appendWaitlist(existingTargetOverride.waitlist));
           } else {
-            // Override neu anlegen → Basis sind immer die aktuellen Kursdaten
-            const baseParticipants = targetCourse.participants;
-            nextOverride = {
+            const nextOverride: CourseDateOverride = {
               courseId: toCourseId,
-              date: toDateIso,
-              participants: [...baseParticipants],  // alle bisherigen Teilnehmer
+              date: targetDateKey,
+              participants: [...targetCourse.participants],
               swapped: [],
-              waitlist: [userName], // neue Warteliste
+              waitlist: [userName],
               ...overrideCourseUidFields(targetCourse),
             };
-            updated.push(nextOverride);
-            // Backend-Aufruf: Override erstellen
-            createOverride(nextOverride);
+            try {
+              await createOverride(nextOverride);
+              setOverrides((prev) => [...prev, nextOverride]);
+            } catch (err) {
+              if (axios.isAxiosError(err) && err.response?.status === 409) {
+                const existingWaitlist = Array.isArray(err.response.data?.override?.waitlist)
+                  ? (err.response.data.override.waitlist as string[])
+                  : [];
+                const nextWaitlist = appendWaitlist(existingWaitlist);
+                if (
+                  nextWaitlist.some((entry) => entry.toLowerCase() === userNameLowerForWaitlist)
+                ) {
+                  await persistWaitlistUpdate(nextWaitlist);
+                }
+              } else {
+                throw err;
+              }
+            }
           }
-
-          return updated;
-        });
+        }
 
         // 4) Swap mit Status "pending" speichern
         const newSwap: Swap = {
@@ -857,7 +920,7 @@ export function useCourseSwaps(
           fromCourseId: fromCourse.id,
           fromDate: fromDateIso,
           toCourseId,
-          toDate: toDateIso,
+          toDate: targetDateKey,
           status: 'pending',
           ...swapCourseUidFields(fromCourse, targetCourse),
         };

--- a/app/src/lib/dates.test.ts
+++ b/app/src/lib/dates.test.ts
@@ -271,6 +271,63 @@ describe("getAvailableDates / getWaitlistDates", () => {
     expect(noWaitlistAtMax).toHaveLength(0);
   });
 
+  it("includes regularly full courses without overbookLimit as waitlist targets", () => {
+    const referenceDate = new Date("2025-06-15");
+    const fullCourse: Course = {
+      ...course,
+      id: 22,
+      capacity: 2,
+      overbookLimit: 0,
+      participants: ["a", "b"],
+      dates: ["2025-06-16"],
+    };
+
+    const waitlist = getWaitlistDates(
+      [fullCourse],
+      [],
+      currentUser,
+      swapSettings,
+      referenceDate,
+      TEST_NOW,
+    );
+
+    expect(waitlist).toHaveLength(1);
+    expect(waitlist[0]?.course.id).toBe(22);
+  });
+
+  it("includes max-full courses with an existing waitlist when overbookLimit > 0", () => {
+    const referenceDate = new Date("2025-06-15");
+    const overbookCourse: Course = {
+      ...course,
+      id: 23,
+      capacity: 2,
+      overbookLimit: 1,
+      participants: ["a", "b"],
+      dates: ["2025-06-16"],
+    };
+    const fullOverride: CourseDateOverride[] = [
+      {
+        courseId: 23,
+        date: "2025-06-16",
+        participants: ["a", "b", "c"],
+        swapped: [],
+        waitlist: ["luna"],
+      },
+    ];
+
+    const waitlist = getWaitlistDates(
+      [overbookCourse],
+      fullOverride,
+      currentUser,
+      swapSettings,
+      referenceDate,
+      TEST_NOW,
+    );
+
+    expect(waitlist).toHaveLength(1);
+    expect(waitlist[0]?.course.id).toBe(23);
+  });
+
   it("excludes targets inside cutoff from available and waitlist", () => {
     const referenceDate = new Date("2025-06-14");
     const nowInCutoff = new Date(2025, 5, 15, 9, 30);

--- a/app/src/lib/dates.test.ts
+++ b/app/src/lib/dates.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   getCourseDates,
   toDateKey,
+  swapOptionKey,
+  parseSwapOptionKey,
+  findOverrideForCourseDate,
   sameDayUTC,
   sameInstant,
   getAvailableDates,
@@ -28,9 +31,39 @@ describe("toDateKey", () => {
     expect(toDateKey(new Date("2025-06-15T14:30:00Z"))).toBe("2025-06-15");
   });
 
+  it("nutzt lokales Kalenderdatum", () => {
+    expect(toDateKey(new Date(2025, 5, 15, 23, 30, 0))).toBe("2025-06-15");
+  });
+
   it("gibt leeren String für Invalid Date zurück (kein Crash)", () => {
     expect(toDateKey(new Date(""))).toBe("");
     expect(toDateKey(new Date(NaN))).toBe("");
+  });
+});
+
+describe("swapOptionKey", () => {
+  it("kombiniert Kurs-ID und lokales Datum", () => {
+    const date = new Date(2099, 5, 20, 10, 0, 0);
+    expect(swapOptionKey(2, date)).toBe("2:2099-06-20");
+    expect(parseSwapOptionKey("2:2099-06-20")).toEqual({ courseId: 2, dateKey: "2099-06-20" });
+  });
+});
+
+describe("findOverrideForCourseDate", () => {
+  it("findet Override per Kalendertag, nicht nur exaktem String", () => {
+    const overrides = [
+      {
+        courseId: 2,
+        date: "2025-06-16",
+        participants: ["bob"],
+        swapped: [],
+        waitlist: [],
+      },
+    ];
+    expect(findOverrideForCourseDate(overrides, 2, "2025-06-16")).toEqual(overrides[0]);
+    expect(findOverrideForCourseDate(overrides, 2, new Date(2025, 5, 16, 10, 0, 0).toISOString())).toEqual(
+      overrides[0],
+    );
   });
 });
 
@@ -212,7 +245,7 @@ describe("getAvailableDates / getWaitlistDates", () => {
     expect(available.map((entry) => entry.course.id)).toEqual([11]);
   });
 
-  it("excludes overbook-only slots from swap targets; waitlist until maxCapacity", () => {
+  it("excludes overbook-only slots from direct swap; waitlist for all regularly full targets", () => {
     const referenceDate = new Date("2025-06-15");
     const overbookCourse: Course = {
       ...course,
@@ -268,7 +301,40 @@ describe("getAvailableDates / getWaitlistDates", () => {
     expect(atRegularCapacity).toHaveLength(0);
     expect(waitlistWithOverbookHeadroom).toHaveLength(1);
     expect(fullAtMax).toHaveLength(0);
-    expect(noWaitlistAtMax).toHaveLength(0);
+    expect(noWaitlistAtMax).toHaveLength(1);
+  });
+
+  it("includes max-full overbooked courses without existing waitlist", () => {
+    const referenceDate = new Date("2025-06-15");
+    const overbookCourse: Course = {
+      ...course,
+      id: 24,
+      capacity: 2,
+      overbookLimit: 1,
+      participants: ["a", "b"],
+      dates: ["2025-06-16"],
+    };
+    const fullOverride: CourseDateOverride[] = [
+      {
+        courseId: 24,
+        date: "2025-06-16",
+        participants: ["a", "b", "c"],
+        swapped: [],
+        waitlist: [],
+      },
+    ];
+
+    const waitlist = getWaitlistDates(
+      [overbookCourse],
+      fullOverride,
+      currentUser,
+      swapSettings,
+      referenceDate,
+      TEST_NOW,
+    );
+
+    expect(waitlist).toHaveLength(1);
+    expect(waitlist[0]?.course.id).toBe(24);
   });
 
   it("includes regularly full courses without overbookLimit as waitlist targets", () => {

--- a/app/src/lib/dates.ts
+++ b/app/src/lib/dates.ts
@@ -1,6 +1,6 @@
 // lib/dates.ts
 import { CourseDateOverride, Course, User, TenantSettings } from "shared/types";
-import { isAtMaxCapacity, isAtRegularCapacity } from "shared/courseCapacity";
+import { isAtMaxCapacity, isAtRegularCapacity, resolveOverbookLimit } from "shared/courseCapacity";
 import { isSwapTargetInCutoffWindow } from "shared/cancellationSwapCutoff";
 import { buildCourseOccurrenceLocal } from "shared/courseStatus";
 import type { SwapSettings } from "../types";
@@ -117,6 +117,43 @@ function collectCourseDates(
   });
 }
 
+function hasExistingWaitlist(
+  overrides: CourseDateOverride[],
+  courseId: number,
+  date: Date,
+): boolean {
+  const override = overrides.find(
+    (o) => o.courseId === courseId && sameInstant(o.date, date),
+  );
+  return (override?.waitlist?.length ?? 0) > 0;
+}
+
+function isWaitlistSwapTarget(
+  entry: {
+    course: Course;
+    date: Date;
+    regularFull: boolean;
+    maxFull: boolean;
+    userAlreadyInThisCourse: boolean;
+    targetInCutoff: boolean;
+  },
+  overrides: CourseDateOverride[],
+): boolean {
+  if (!entry.regularFull || entry.userAlreadyInThisCourse || entry.targetInCutoff) {
+    return false;
+  }
+
+  if (!entry.maxFull) {
+    return true;
+  }
+
+  if (resolveOverbookLimit(entry.course) === 0) {
+    return true;
+  }
+
+  return hasExistingWaitlist(overrides, entry.course.id, entry.date);
+}
+
 /** freie Termine (nur reguläre Kapazität, keine Überplanungs-Slots) */
 export function getAvailableDates(
   allCourses: Course[],
@@ -140,7 +177,7 @@ export function getAvailableDates(
     .map(({ course, date, time }) => ({ course, date, time }));
 }
 
-/** regulär volle Termine mit Überplanungs-Freiraum → Warteliste; bei maxCapacity ausgeschlossen */
+/** regulär volle Termine als Wartelisten-Ziel (Nachrücken / Ringtausch-Vorbereitung) */
 export function getWaitlistDates(
   allCourses: Course[],
   overrides: CourseDateOverride[],
@@ -159,8 +196,6 @@ export function getWaitlistDates(
     now,
     tenantSettings,
   )
-    .filter(
-      (x) => x.regularFull && !x.maxFull && !x.userAlreadyInThisCourse && !x.targetInCutoff,
-    )
+    .filter((entry) => isWaitlistSwapTarget(entry, overrides))
     .map(({ course, date, time }) => ({ course, date, time }));
 }

--- a/app/src/lib/dates.ts
+++ b/app/src/lib/dates.ts
@@ -1,6 +1,6 @@
 // lib/dates.ts
 import { CourseDateOverride, Course, User, TenantSettings } from "shared/types";
-import { isAtMaxCapacity, isAtRegularCapacity, resolveOverbookLimit } from "shared/courseCapacity";
+import { isAtMaxCapacity, isAtRegularCapacity } from "shared/courseCapacity";
 import { isSwapTargetInCutoffWindow } from "shared/cancellationSwapCutoff";
 import { buildCourseOccurrenceLocal } from "shared/courseStatus";
 import type { SwapSettings } from "../types";
@@ -41,7 +41,36 @@ export function sameInstant(a: Date | string, b: Date | string): boolean {
 
 export function toDateKey(date: Date): string {
   if (isNaN(date.getTime())) return ""; // ungültiges Datum → kein Crash
-  return date.toISOString().slice(0, 10); // "YYYY-MM-DD"
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Eindeutiger Select-Wert für Tauschziele (Kurs + lokales Datum). */
+export function swapOptionKey(courseId: number, date: Date): string {
+  return `${courseId}:${toDateKey(date)}`;
+}
+
+export function parseSwapOptionKey(
+  value: string,
+): { courseId: number; dateKey: string } | null {
+  const separator = value.indexOf(":");
+  if (separator <= 0) return null;
+  const courseId = Number(value.slice(0, separator));
+  const dateKey = value.slice(separator + 1);
+  if (!Number.isFinite(courseId) || !dateKey) return null;
+  return { courseId, dateKey };
+}
+
+export function findOverrideForCourseDate(
+  overrides: CourseDateOverride[],
+  courseId: number,
+  dateIso: string,
+): CourseDateOverride | undefined {
+  return overrides.find(
+    (o) => o.courseId === courseId && sameInstant(o.date, dateIso),
+  );
 }
 
 
@@ -117,41 +146,20 @@ function collectCourseDates(
   });
 }
 
-function hasExistingWaitlist(
-  overrides: CourseDateOverride[],
-  courseId: number,
-  date: Date,
-): boolean {
-  const override = overrides.find(
-    (o) => o.courseId === courseId && sameInstant(o.date, date),
-  );
-  return (override?.waitlist?.length ?? 0) > 0;
-}
-
 function isWaitlistSwapTarget(
   entry: {
-    course: Course;
-    date: Date;
     regularFull: boolean;
-    maxFull: boolean;
     userAlreadyInThisCourse: boolean;
     targetInCutoff: boolean;
   },
-  overrides: CourseDateOverride[],
 ): boolean {
   if (!entry.regularFull || entry.userAlreadyInThisCourse || entry.targetInCutoff) {
     return false;
   }
 
-  if (!entry.maxFull) {
-    return true;
-  }
-
-  if (resolveOverbookLimit(entry.course) === 0) {
-    return true;
-  }
-
-  return hasExistingWaitlist(overrides, entry.course.id, entry.date);
+  // Regulär volle Termine sind Wartelisten-Ziele — auch bei ausgeschöpfter Überplanung.
+  // Nachrücken erfolgt erst unter regulärer capacity (canPromoteFromWaitlist).
+  return true;
 }
 
 /** freie Termine (nur reguläre Kapazität, keine Überplanungs-Slots) */
@@ -196,6 +204,6 @@ export function getWaitlistDates(
     now,
     tenantSettings,
   )
-    .filter((entry) => isWaitlistSwapTarget(entry, overrides))
+    .filter((entry) => isWaitlistSwapTarget(entry))
     .map(({ course, date, time }) => ({ course, date, time }));
 }

--- a/backend/src/lambdas/createOverride/index.test.ts
+++ b/backend/src/lambdas/createOverride/index.test.ts
@@ -20,7 +20,11 @@ beforeEach(() => {
 
 describe('createOverride Lambda', () => {
   it('should create a new override successfully', async () => {
-    dynamoMock.on(GetItemCommand).resolves({ Item: mockCourseItem });
+    dynamoMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: mockCourseItem })
+      .resolvesOnce({ Item: undefined })
+      .resolvesOnce({ Item: mockCourseItem });
     dynamoMock.on(PutItemCommand).resolves({});
 
     const event: Partial<APIGatewayProxyEvent> = {
@@ -38,11 +42,12 @@ describe('createOverride Lambda', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ message: 'Override created' });
 
-    expect(dynamoMock.commandCalls(GetItemCommand)).toHaveLength(2);
+    expect(dynamoMock.commandCalls(GetItemCommand)).toHaveLength(3);
     expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(1);
 
     expect(dynamoMock.commandCalls(PutItemCommand)[0].args[0].input).toMatchObject({
       TableName: 'yogaswap-backend-demo-courseOverrides-table',
+      ConditionExpression: 'attribute_not_exists(courseId_date)',
       Item: {
         tenantId: { S: 'default-tenant' },
         courseId_date: { S: '1_2025-10-01' },
@@ -110,8 +115,83 @@ describe('createOverride Lambda', () => {
     expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(0);
   });
 
+  it('should allow waitlist enrollment when roster matches course participants above capacity', async () => {
+    dynamoMock
+      .on(GetItemCommand)
+      .resolvesOnce({
+        Item: {
+          ...mockCourseItem,
+          capacity: { N: '1' },
+          overbookLimit: { N: '0' },
+          participants: { L: [{ S: 'A' }, { S: 'B' }] },
+        },
+      })
+      .resolvesOnce({ Item: undefined })
+      .resolvesOnce({
+        Item: {
+          ...mockCourseItem,
+          capacity: { N: '1' },
+          overbookLimit: { N: '0' },
+          participants: { L: [{ S: 'A' }, { S: 'B' }] },
+        },
+      });
+    dynamoMock.on(PutItemCommand).resolves({});
+
+    const event: Partial<APIGatewayProxyEvent> = {
+      body: JSON.stringify({
+        courseId: 1,
+        date: '2025-10-01',
+        participants: ['A', 'B'],
+        swapped: [],
+        waitlist: ['Luna'],
+      }),
+    };
+
+    const result = await handler(event as APIGatewayProxyEvent);
+
+    expect(result.statusCode).toBe(200);
+    expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(1);
+  });
+
+  it('should return 409 when override already exists', async () => {
+    dynamoMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: mockCourseItem })
+      .resolvesOnce({
+        Item: {
+          tenantId: { S: 'default-tenant' },
+          courseId_date: { S: '1_2025-10-01' },
+          courseId: { S: '1' },
+          date: { S: '2025-10-01' },
+          participants: { L: [{ S: 'Luna' }] },
+          swapped: { L: [] },
+          waitlist: { L: [{ S: 'Bob' }] },
+        },
+      });
+
+    const event: Partial<APIGatewayProxyEvent> = {
+      body: JSON.stringify({
+        courseId: 1,
+        date: '2025-10-01',
+        participants: ['Luna'],
+        swapped: [],
+        waitlist: ['Alice'],
+      }),
+    };
+
+    const result = await handler(event as APIGatewayProxyEvent);
+
+    expect(result.statusCode).toBe(409);
+    expect(JSON.parse(result.body).error).toBe('Override already exists');
+    expect(dynamoMock.commandCalls(PutItemCommand)).toHaveLength(0);
+  });
+
   it('should handle DynamoDB errors gracefully', async () => {
-    dynamoMock.on(GetItemCommand).resolves({ Item: mockCourseItem });
+    dynamoMock
+      .on(GetItemCommand)
+      .resolvesOnce({ Item: mockCourseItem })
+      .resolvesOnce({ Item: undefined })
+      .resolvesOnce({ Item: mockCourseItem });
     dynamoMock.on(PutItemCommand).rejects(new Error('DynamoDB failure'));
 
     const event: Partial<APIGatewayProxyEvent> = {

--- a/backend/src/lambdas/createOverride/index.ts
+++ b/backend/src/lambdas/createOverride/index.ts
@@ -1,10 +1,22 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import { GetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { getTenantContext } from '../shared/tenantContext';
 import { dynamoClient } from '../shared/dynamoClient';
 import { getDelegationErrorResponse } from '../shared/delegation';
 import { fetchCourseUidByLegacyCourseId } from '../shared/courseUid';
+import { mapOverrideItem, mapStringList } from '../shared/overrideDynamo';
 import { courseCapacityFromDynamoItem, validateParticipantsForCourse } from '../shared/courseCapacityDynamo';
+
+function normalizedRoster(values: string[]): string[] {
+  return values.map((entry) => entry.trim().toLowerCase()).sort();
+}
+
+function sameParticipantRoster(a: string[], b: string[]): boolean {
+  const left = normalizedRoster(a);
+  const right = normalizedRoster(b);
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
 
 const client = dynamoClient;
 
@@ -65,9 +77,34 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       return { statusCode: 404, body: JSON.stringify({ error: 'Course not found' }) };
     }
     const capacityFields = courseCapacityFromDynamoItem(courseResp.Item);
+    const baseParticipants = mapStringList(courseResp.Item.participants);
     const capacityError = validateParticipantsForCourse(participants, capacityFields);
-    if (capacityError) {
+    const waitlistEnrollmentOnly =
+      waitlist.length > 0 &&
+      swapped.length === 0 &&
+      sameParticipantRoster(participants, baseParticipants);
+    if (capacityError && !waitlistEnrollmentOnly) {
       return { statusCode: 400, body: JSON.stringify({ error: capacityError }) };
+    }
+
+    const existingResp = await client.send(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: {
+          tenantId: { S: tenantId },
+          courseId_date: { S: courseId_date },
+        },
+        ConsistentRead: true,
+      }),
+    );
+    if (existingResp.Item) {
+      return {
+        statusCode: 409,
+        body: JSON.stringify({
+          error: 'Override already exists',
+          override: mapOverrideItem(existingResp.Item),
+        }),
+      };
     }
 
     const courseUid = await fetchCourseUidByLegacyCourseId(client, coursesTable, tenantId, legacyCourseId);
@@ -86,7 +123,23 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       ...(courseUid ? { courseUid: { S: courseUid } } : {}),
     };
 
-    await client.send(new PutItemCommand({ TableName: tableName, Item: dynamoItem }));
+    try {
+      await client.send(
+        new PutItemCommand({
+          TableName: tableName,
+          Item: dynamoItem,
+          ConditionExpression: 'attribute_not_exists(courseId_date)',
+        }),
+      );
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        return {
+          statusCode: 409,
+          body: JSON.stringify({ error: 'Override already exists' }),
+        };
+      }
+      throw error;
+    }
     return { statusCode: 200, body: JSON.stringify({ message: 'Override created' }) };
   } catch (error) {
     console.error('Error creating override:', error);


### PR DESCRIPTION
## Summary
- Zeigt regulär volle und überplant ausgeschöpfte Termine als Wartelisten-Ziele im Tauschdialog (`getWaitlistDates`).
- Eindeutige Terminauswahl bei zwei Kursen am selben Tag/Uhrzeit (`swapOptionKey` im Swap-Modal).
- Behebt Wartelisten-Bereinigung beim Abbrechen pending Anfragen (nur geänderte Override-Felder, alle Ziele vom Ursprung).
- Erlaubt erneuten Wartelisten-Tausch nach verwaistem Wartelisten-Eintrag; `createOverride` toleriert volle Kurs-Roster bei Wartelisten-Anmeldung (409 bei bestehendem Override).

Closes #218

## Test plan
- [ ] Tauschdialog: regulär voller Termin ohne `overbookLimit` erscheint unter Warteliste
- [ ] Tauschdialog: überplant voller Termin (`capacity + overbookLimit`) erscheint unter Warteliste
- [ ] Zwei Kurse am selben Tag/Uhrzeit: korrekter Kurs wird bei Wartelisten-Anfrage gewählt
- [ ] Wartelisten-Anfrage stellen → vom Ursprung abbrechen → User ist nirgends mehr auf Warteliste, erneute Anfrage möglich
- [ ] `npm test` in `app/` und `createOverride`-Tests im Backend


Made with [Cursor](https://cursor.com)